### PR TITLE
chore: deploy inicial en Vercel + URL de producción

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ ENABLEBANKING_SECRET_KEY=
 EDENRED_WEBHOOK_SECRET=    # genera con: openssl rand -hex 32
 
 # App
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app


### PR DESCRIPTION
Closes #3

## Summary

- Actualiza `NEXT_PUBLIC_APP_URL` en `.env.example` con la URL de producción de Vercel: `https://fin-app-tawny.vercel.app`
- El deploy en Vercel está activo y accesible

## Pasos realizados fuera del código
- PR #9: `develop` → `main` mergeada (prerrequisito para que Vercel tuviera código real)
- Repo conectado a Vercel apuntando a `main`
- Variables de entorno configuradas en Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)