### PR TITLE
feat(shell): app shell, bottom nav 4 tabs y dark/light mode

### DIFF
--- a/app/(app)/analisis/page.tsx
+++ b/app/(app)/analisis/page.tsx
@@ -1,0 +1,8 @@
+export default function AnalisisPage() {
+  return (
+    <div className="px-6 pt-14">
+      <h1 className="text-lg font-bold text-foreground">Análisis</h1>
+      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
+    </div>
+  )
+}

--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -1,0 +1,8 @@
+export default function CuentasPage() {
+  return (
+    <div className="px-6 pt-14">
+      <h1 className="text-lg font-bold text-foreground">Cuentas</h1>
+      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
+    </div>
+  )
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,12 @@
+import { BottomNav } from '@/components/bottom-nav'
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative mx-auto w-full max-w-[420px] min-h-screen overflow-clip bg-background">
+      <main className="pb-[90px] animate-fade-in">
+        {children}
+      </main>
+      <BottomNav />
+    </div>
+  )
+}

--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -1,0 +1,8 @@
+export default function MovimientosPage() {
+  return (
+    <div className="px-6 pt-14">
+      <h1 className="text-lg font-bold text-foreground">Movimientos</h1>
+      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
+    </div>
+  )
+}

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,0 +1,12 @@
+import { ThemeToggle } from '@/components/theme-toggle'
+
+export default function HomePage() {
+  return (
+    <div className="px-6 pt-14 flex flex-col gap-4">
+      <div className="flex justify-end">
+        <ThemeToggle />
+      </div>
+      <p className="text-muted-foreground text-sm">Dashboard — próximamente</p>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-sans: var(--font-dm-sans);
+  --font-mono: var(--font-dm-sans);
+  --font-heading: var(--font-dm-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -49,72 +49,88 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: #f5f5f7;
+  --foreground: #0f0f14;
+  --card: rgba(0, 0, 0, 0.03);
+  --card-foreground: #0f0f14;
+  --popover: #ffffff;
+  --popover-foreground: #0f0f14;
+  --primary: #6366f1;
+  --primary-foreground: #ffffff;
+  --secondary: #f0f0f5;
+  --secondary-foreground: #0f0f14;
+  --muted: #f0f0f5;
+  --muted-foreground: rgba(15, 15, 20, 0.45);
+  --accent: rgba(99, 102, 241, 0.1);
+  --accent-foreground: #6366f1;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: rgba(0, 0, 0, 0.08);
+  --input: #f0f0f5;
+  --ring: #6366f1;
+  --chart-1: #6366f1;
+  --chart-2: #22c55e;
+  --chart-3: #ef4444;
+  --chart-4: #f59e0b;
+  --chart-5: #3b82f6;
+  --radius: 0.75rem;
+  --app-surface: #ffffff;
+  --app-surface2: #f0f0f5;
+  --app-positive: #22c55e;
+  --app-negative: #ef4444;
+  --app-accent: #6366f1;
+  --app-accent-light: rgba(99, 102, 241, 0.1);
+  --app-nav-bg: rgba(245, 245, 247, 0.92);
+  --sidebar: #f0f0f5;
+  --sidebar-foreground: #0f0f14;
+  --sidebar-primary: #6366f1;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(99, 102, 241, 0.1);
+  --sidebar-accent-foreground: #6366f1;
+  --sidebar-border: rgba(0, 0, 0, 0.08);
+  --sidebar-ring: #6366f1;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #0f0f14;
+  --foreground: #f0f0f5;
+  --card: rgba(255, 255, 255, 0.04);
+  --card-foreground: #f0f0f5;
+  --popover: #1a1a24;
+  --popover-foreground: #f0f0f5;
+  --primary: #6366f1;
+  --primary-foreground: #ffffff;
+  --secondary: #22222f;
+  --secondary-foreground: #f0f0f5;
+  --muted: #22222f;
+  --muted-foreground: rgba(240, 240, 245, 0.45);
+  --accent: rgba(99, 102, 241, 0.15);
+  --accent-foreground: #6366f1;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --border: rgba(255, 255, 255, 0.07);
+  --input: #22222f;
+  --ring: #6366f1;
+  --chart-1: #6366f1;
+  --chart-2: #22c55e;
+  --chart-3: #ef4444;
+  --chart-4: #f59e0b;
+  --chart-5: #3b82f6;
+  --app-surface: #1a1a24;
+  --app-surface2: #22222f;
+  --app-positive: #22c55e;
+  --app-negative: #ef4444;
+  --app-accent: #6366f1;
+  --app-accent-light: rgba(99, 102, 241, 0.15);
+  --app-nav-bg: rgba(15, 15, 20, 0.92);
+  --sidebar: #1a1a24;
+  --sidebar-foreground: #f0f0f5;
+  --sidebar-primary: #6366f1;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(99, 102, 241, 0.15);
+  --sidebar-accent-foreground: #6366f1;
+  --sidebar-border: rgba(255, 255, 255, 0.07);
+  --sidebar-ring: #6366f1;
 }
 
 @layer base {
@@ -123,8 +139,29 @@
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
   }
   html {
     @apply font-sans;
   }
+  ::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.2s ease forwards;
+}
+
+.safe-top {
+  padding-top: env(safe-area-inset-top);
+}
+
+.safe-bottom {
+  padding-bottom: max(env(safe-area-inset-bottom), 1.5rem);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
 @custom-variant dark (&:is(.dark *));
@@ -135,14 +134,16 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: color-mix(in srgb, var(--ring) 50%, transparent);
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--background);
+    color: var(--foreground);
     -webkit-font-smoothing: antialiased;
   }
   html {
-    @apply font-sans;
+    font-family: var(--font-sans);
   }
   ::-webkit-scrollbar {
     display: none;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,33 +1,39 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata, Viewport } from 'next'
+import { DM_Sans } from 'next/font/google'
+import { ThemeProvider } from '@/components/theme-provider'
+import './globals.css'
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  variable: '--font-dm-sans',
+})
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+export const viewport: Viewport = {
+  themeColor: '#6366f1',
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+}
 
 export const metadata: Metadata = {
-  title: "Finanzas",
-  description: "App de gestión financiera personal",
-};
+  title: 'Finanzas',
+  description: 'App de gestión financiera personal',
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
-    >
-      <body className="min-h-full flex flex-col overflow-clip">{children}</body>
+    <html lang="es" className={dmSans.variable} suppressHydrationWarning>
+      <body className="min-h-full overflow-clip antialiased">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
-  );
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main className="flex flex-1 items-center justify-center">
-      <p className="text-muted-foreground">fin-app</p>
-    </main>
-  );
-}

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Home, List, Wallet, BarChart2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const NAV_ITEMS = [
+  { href: '/',            label: 'Inicio',      Icon: Home },
+  { href: '/movimientos', label: 'Movimientos', Icon: List },
+  { href: '/cuentas',     label: 'Cuentas',     Icon: Wallet },
+  { href: '/analisis',    label: 'Análisis',    Icon: BarChart2 },
+] as const
+
+export function BottomNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[420px] z-[100]
+                 border-t border-border safe-bottom"
+      style={{ background: 'var(--app-nav-bg)', backdropFilter: 'blur(20px)' }}
+    >
+      <div className="flex pt-[10px]">
+        {NAV_ITEMS.map(({ href, label, Icon }) => {
+          const active = pathname === href
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'flex flex-1 flex-col items-center gap-[3px] py-[6px] text-[10px] transition-colors duration-200',
+                active ? 'text-primary font-semibold' : 'text-muted-foreground font-normal'
+              )}
+            >
+              <span
+                className={cn(
+                  'flex items-center justify-center rounded-xl px-4 py-1 transition-colors duration-200',
+                  active && 'bg-accent'
+                )}
+              >
+                <Icon className="size-5" strokeWidth={active ? 2 : 1.8} />
+              </span>
+              {label}
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -17,11 +17,11 @@ export function BottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[420px] z-[100]
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-105 z-100
                  border-t border-border safe-bottom"
       style={{ background: 'var(--app-nav-bg)', backdropFilter: 'blur(20px)' }}
     >
-      <div className="flex pt-[10px]">
+      <div className="flex pt-2.5">
         {NAV_ITEMS.map(({ href, label, Icon }) => {
           const active = pathname === href
           return (
@@ -29,7 +29,7 @@ export function BottomNav() {
               key={href}
               href={href}
               className={cn(
-                'flex flex-1 flex-col items-center gap-[3px] py-[6px] text-[10px] transition-colors duration-200',
+                'flex flex-1 flex-col items-center gap-0.75 py-1.5 text-[10px] transition-colors duration-200',
                 active ? 'text-primary font-semibold' : 'text-muted-foreground font-normal'
               )}
             >

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ThemeProviderProps } from 'next-themes'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Sun, Moon } from 'lucide-react'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="flex items-center justify-center w-[38px] h-[38px] rounded-xl cursor-pointer
+                 bg-secondary border border-border text-muted-foreground transition-colors"
+      aria-label="Cambiar tema"
+    >
+      <Sun className="size-4 hidden dark:block" />
+      <Moon className="size-4 block dark:hidden" />
+    </button>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "next": "16.2.4",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
     "shadcn": "^4.6.0",
-    "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -2412,6 +2415,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
@@ -5590,6 +5599,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -3014,9 +3011,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tw-animate-css@1.4.0:
-    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6335,8 +6329,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Resumen

Implementa el issue #5 — infraestructura visual base de la app.

- **Tokens de color**: sustituye la paleta genérica de shadcn/ui (oklch) por el sistema de colores del prototipo (`docs/finanzas-app.jsx`, objeto `t`) — light y dark
- **DM Sans**: cambia la fuente de Geist a DM Sans, fiel al prototipo
- **Viewport**: añade export `viewport` con `viewportFit: 'cover'` para iPhone con notch (§7.2)
- **ThemeProvider**: `next-themes` con clase `.dark` en `<html>`, sin flash de hidratación
- **BottomNav**: navegación fija con 4 tabs (Inicio, Movimientos, Cuentas, Análisis), glassmorphism, safe area, tab activo con pastilla `accentLight`
- **Route group `(app)/`**: shell centrado a 420px con `overflow:clip`, animación `fadeIn` en cada cambio de pantalla
- **Safe areas**: utilities `.safe-top` / `.safe-bottom` con `env(safe-area-inset-*)` para notch e home indicator

## Test plan

- [ ] Navegar a `/` — ver shell centrado (max 420px) con bottom nav visible
- [ ] Pulsar cada tab y verificar navegación a `/`, `/movimientos`, `/cuentas`, `/analisis`
- [ ] Verificar tab activo resaltado (color indigo + pastilla de fondo)
- [ ] Pulsar el toggle sun/moon — la app debe cambiar entre modo claro y oscuro
- [ ] Comprobar colores en ambos modos: fondo `#f5f5f7` / `#0f0f14`, acento `#6366f1`
- [ ] En iPhone (375px): verificar que el nav no tapa contenido y safe areas respetadas
- [ ] `pnpm build` sin errores TypeScript

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)