### PR TITLE
feat(banking): Enable Banking OAuth — flujo completo de conexión de cuenta

### DIFF
--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -1,8 +1,63 @@
-export default function CuentasPage() {
+import { redirect } from 'next/navigation'
+import { Check } from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
+import { AccountCard } from '@/components/accounts/AccountCard'
+import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
+import type { Account } from '@/types'
+
+export default async function CuentasPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ connected?: string; error?: string }>
+}) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: accounts } = await supabase
+    .from('accounts')
+    .select('*')
+    .eq('is_active', true)
+    .order('created_at', { ascending: true })
+
+  const params = await searchParams
+
   return (
-    <div className="px-6 pt-14">
-      <h1 className="text-lg font-bold text-foreground">Cuentas</h1>
-      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
+    <div className="px-5 pt-14 pb-6 flex flex-col gap-4">
+      <h1 className="text-xl font-bold text-foreground mb-2">Cuentas</h1>
+
+      {params.connected === 'true' && (
+        <div
+          className="rounded-2xl px-4 py-3 text-sm font-medium flex items-center gap-2"
+          style={{
+            background: '#22c55e15',
+            border: '1px solid #22c55e30',
+            color: '#22c55e',
+          }}
+        >
+          <Check className="size-4 shrink-0" />
+          Banco conectado correctamente
+        </div>
+      )}
+
+      {params.error && (
+        <div
+          className="rounded-2xl px-4 py-3 text-sm font-medium"
+          style={{
+            background: '#ef444415',
+            border: '1px solid #ef444430',
+            color: '#ef4444',
+          }}
+        >
+          No se pudo conectar el banco. Inténtalo de nuevo.
+        </div>
+      )}
+
+      {(accounts ?? []).map((account: Account) => (
+        <AccountCard key={account.id} account={account} />
+      ))}
+
+      <ConnectBankButton />
     </div>
   )
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,12 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
 import { BottomNav } from '@/components/bottom-nav'
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
   return (
     <div className="relative mx-auto w-full max-w-[420px] min-h-screen overflow-clip bg-background">
       <main className="pb-[90px] animate-fade-in">

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -8,8 +8,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   if (!user) redirect('/login')
 
   return (
-    <div className="relative mx-auto w-full max-w-[420px] min-h-screen overflow-clip bg-background">
-      <main className="pb-[90px] animate-fade-in">
+    <div className="relative mx-auto w-full max-w-105 min-h-screen overflow-clip bg-background">
+      <main className="pb-22.5 animate-fade-in">
         {children}
       </main>
       <BottomNav />

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,21 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
 import { ThemeToggle } from '@/components/theme-toggle'
 
-export default function HomePage() {
+export default async function HomePage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (user) {
+    const { data: config } = await supabase
+      .from('user_config')
+      .select('has_onboarded')
+      .eq('user_id', user.id)
+      .single()
+
+    if (!config?.has_onboarded) redirect('/onboarding')
+  }
+
   return (
     <div className="px-6 pt-14 flex flex-col gap-4">
       <div className="flex justify-end">

--- a/app/api/banking/aspsps/route.ts
+++ b/app/api/banking/aspsps/route.ts
@@ -11,14 +11,19 @@ export async function GET(request: NextRequest) {
       { headers: { Authorization: `Bearer ${jwt}` } }
     )
 
-    if (!res.ok) return NextResponse.json([])
+    if (!res.ok) {
+      const body = await res.text()
+      console.error('[EB aspsps] API error:', res.status, body)
+      return NextResponse.json({ error: `Enable Banking ${res.status}`, detail: body }, { status: 502 })
+    }
 
     const data = await res.json()
     const list = Array.isArray(data) ? data : (data.aspsps ?? [])
     return NextResponse.json(
       list.map((a: { name: string; country: string }) => ({ name: a.name, country: a.country }))
     )
-  } catch {
-    return NextResponse.json([])
+  } catch (err) {
+    console.error('[EB aspsps] exception:', err)
+    return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 }

--- a/app/api/banking/aspsps/route.ts
+++ b/app/api/banking/aspsps/route.ts
@@ -4,14 +4,6 @@ import { signJWT } from '@/lib/enablebanking'
 export async function GET(request: NextRequest) {
   const country = new URL(request.url).searchParams.get('country') ?? 'ES'
 
-  const raw = process.env.ENABLEBANKING_SECRET_KEY ?? ''
-  const keyDiag = {
-    length: raw.length,
-    first30: raw.slice(0, 30),
-    hasLiteralBackslashN: raw.includes('\\n'),
-    hasRealNewline: raw.includes('\n'),
-  }
-
   try {
     const jwt = await signJWT()
     const res = await fetch(
@@ -19,19 +11,14 @@ export async function GET(request: NextRequest) {
       { headers: { Authorization: `Bearer ${jwt}` } }
     )
 
-    if (!res.ok) {
-      const body = await res.text()
-      console.error('[EB aspsps] API error:', res.status, body)
-      return NextResponse.json({ error: `Enable Banking ${res.status}`, detail: body }, { status: 502 })
-    }
+    if (!res.ok) return NextResponse.json([])
 
     const data = await res.json()
     const list = Array.isArray(data) ? data : (data.aspsps ?? [])
     return NextResponse.json(
       list.map((a: { name: string; country: string }) => ({ name: a.name, country: a.country }))
     )
-  } catch (err) {
-    console.error('[EB aspsps] exception:', err)
-    return NextResponse.json({ error: String(err), keyDiag }, { status: 500 })
+  } catch {
+    return NextResponse.json([])
   }
 }

--- a/app/api/banking/aspsps/route.ts
+++ b/app/api/banking/aspsps/route.ts
@@ -4,6 +4,14 @@ import { signJWT } from '@/lib/enablebanking'
 export async function GET(request: NextRequest) {
   const country = new URL(request.url).searchParams.get('country') ?? 'ES'
 
+  const raw = process.env.ENABLEBANKING_SECRET_KEY ?? ''
+  const keyDiag = {
+    length: raw.length,
+    first30: raw.slice(0, 30),
+    hasLiteralBackslashN: raw.includes('\\n'),
+    hasRealNewline: raw.includes('\n'),
+  }
+
   try {
     const jwt = await signJWT()
     const res = await fetch(
@@ -24,6 +32,6 @@ export async function GET(request: NextRequest) {
     )
   } catch (err) {
     console.error('[EB aspsps] exception:', err)
-    return NextResponse.json({ error: String(err) }, { status: 500 })
+    return NextResponse.json({ error: String(err), keyDiag }, { status: 500 })
   }
 }

--- a/app/api/banking/aspsps/route.ts
+++ b/app/api/banking/aspsps/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { signJWT } from '@/lib/enablebanking'
+
+export async function GET(request: NextRequest) {
+  const country = new URL(request.url).searchParams.get('country') ?? 'ES'
+
+  try {
+    const jwt = await signJWT()
+    const res = await fetch(
+      `https://api.enablebanking.com/aspsps?country=${country}`,
+      { headers: { Authorization: `Bearer ${jwt}` } }
+    )
+
+    if (!res.ok) return NextResponse.json([])
+
+    const data = await res.json()
+    const list = Array.isArray(data) ? data : (data.aspsps ?? [])
+    return NextResponse.json(
+      list.map((a: { name: string; country: string }) => ({ name: a.name, country: a.country }))
+    )
+  } catch {
+    return NextResponse.json([])
+  }
+}

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getSession } from '@/lib/enablebanking'
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url)
+  const sessionId = searchParams.get('session_id')
+  const error = searchParams.get('error')
+
+  if (error || !sessionId) {
+    return NextResponse.redirect(`${origin}/cuentas?error=bank_auth_cancelled`)
+  }
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.redirect(`${origin}/login`)
+  }
+
+  let ebSession
+  try {
+    ebSession = await getSession(sessionId)
+  } catch (err) {
+    console.error('[EB callback] getSession error:', err)
+    return NextResponse.redirect(`${origin}/cuentas?error=session_fetch_failed`)
+  }
+
+  if (ebSession.status !== 'AUTHORIZED') {
+    return NextResponse.redirect(`${origin}/cuentas?error=not_authorized`)
+  }
+
+  for (const acc of ebSession.accounts) {
+    const lastFour = acc.iban ? acc.iban.replace(/\s/g, '').slice(-4) : null
+    const balanceEntry = acc.balances?.find(
+      b => b.balance_type === 'INTERIM_AVAILABLE' || b.balance_type === 'BOOKED'
+    )
+    const balance = balanceEntry ? parseFloat(balanceEntry.balance_amount.amount) : null
+
+    await supabase.from('accounts').upsert(
+      {
+        user_id: user.id,
+        name: acc.name ?? acc.product ?? 'Cuenta bancaria',
+        type: 'bank',
+        source: 'enablebanking',
+        balance,
+        number: lastFour ? `•••• ${lastFour}` : null,
+        currency: acc.currency ?? 'EUR',
+        external_id: acc.account_id,
+        session_id: sessionId,
+        consent_expires_at: ebSession.access.valid_until,
+        is_active: true,
+      },
+      { onConflict: 'user_id,external_id' }
+    )
+  }
+
+  await supabase
+    .from('user_config')
+    .upsert({ user_id: user.id, has_onboarded: true }, { onConflict: 'user_id' })
+
+  return NextResponse.redirect(`${origin}/cuentas?connected=true`)
+}

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -3,18 +3,19 @@ import { createClient } from '@/lib/supabase/server'
 import { createSessionFromCode } from '@/lib/enablebanking'
 
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = new URL(request.url)
+  const { searchParams } = new URL(request.url)
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
   const code = searchParams.get('code')
   const error = searchParams.get('error')
 
   if (error || !code) {
-    return NextResponse.redirect(`${origin}/cuentas?error=bank_auth_cancelled`)
+    return NextResponse.redirect(`${appUrl}/cuentas?error=bank_auth_cancelled`)
   }
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) {
-    return NextResponse.redirect(`${origin}/login`)
+    return NextResponse.redirect(`${appUrl}/login`)
   }
 
   let session
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest) {
     session = await createSessionFromCode(code)
   } catch (err) {
     console.error('[EB callback] createSessionFromCode error:', err)
-    return NextResponse.redirect(`${origin}/cuentas?error=session_fetch_failed`)
+    return NextResponse.redirect(`${appUrl}/cuentas?error=session_fetch_failed`)
   }
 
   for (const acc of session.accounts) {
@@ -50,5 +51,5 @@ export async function GET(request: NextRequest) {
     .from('user_config')
     .upsert({ user_id: user.id, has_onboarded: true }, { onConflict: 'user_id' })
 
-  return NextResponse.redirect(`${origin}/cuentas?connected=true`)
+  return NextResponse.redirect(`${appUrl}/cuentas?connected=true`)
 }

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { getSession } from '@/lib/enablebanking'
+import { createSessionFromCode } from '@/lib/enablebanking'
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
-  const sessionId = searchParams.get('session_id')
+  const code = searchParams.get('code')
   const error = searchParams.get('error')
 
-  if (error || !sessionId) {
+  if (error || !code) {
     return NextResponse.redirect(`${origin}/cuentas?error=bank_auth_cancelled`)
   }
 
@@ -17,37 +17,29 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${origin}/login`)
   }
 
-  let ebSession
+  let session
   try {
-    ebSession = await getSession(sessionId)
+    session = await createSessionFromCode(code)
   } catch (err) {
-    console.error('[EB callback] getSession error:', err)
+    console.error('[EB callback] createSessionFromCode error:', err)
     return NextResponse.redirect(`${origin}/cuentas?error=session_fetch_failed`)
   }
 
-  if (ebSession.status !== 'AUTHORIZED') {
-    return NextResponse.redirect(`${origin}/cuentas?error=not_authorized`)
-  }
-
-  for (const acc of ebSession.accounts) {
+  for (const acc of session.accounts) {
     const lastFour = acc.iban ? acc.iban.replace(/\s/g, '').slice(-4) : null
-    const balanceEntry = acc.balances?.find(
-      b => b.balance_type === 'INTERIM_AVAILABLE' || b.balance_type === 'BOOKED'
-    )
-    const balance = balanceEntry ? parseFloat(balanceEntry.balance_amount.amount) : null
 
     await supabase.from('accounts').upsert(
       {
         user_id: user.id,
-        name: acc.name ?? acc.product ?? 'Cuenta bancaria',
+        name: acc.account_holder ?? 'Cuenta bancaria',
         type: 'bank',
         source: 'enablebanking',
-        balance,
+        balance: null,
         number: lastFour ? `•••• ${lastFour}` : null,
         currency: acc.currency ?? 'EUR',
-        external_id: acc.account_id,
-        session_id: sessionId,
-        consent_expires_at: ebSession.access.valid_until,
+        external_id: acc.uid,
+        session_id: session.session_id,
+        consent_expires_at: session.access.valid_until,
         is_active: true,
       },
       { onConflict: 'user_id,external_id' }

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -27,12 +27,13 @@ export async function GET(request: NextRequest) {
   }
 
   for (const acc of session.accounts) {
-    const lastFour = acc.iban ? acc.iban.replace(/\s/g, '').slice(-4) : null
+    const iban = acc.account_id?.iban ?? null
+    const lastFour = iban ? iban.replace(/\s/g, '').slice(-4) : null
 
     await supabase.from('accounts').upsert(
       {
         user_id: user.id,
-        name: acc.account_holder ?? 'Cuenta bancaria',
+        name: acc.name ?? 'Cuenta bancaria',
         type: 'bank',
         source: 'enablebanking',
         balance: null,

--- a/app/api/banking/connect/route.ts
+++ b/app/api/banking/connect/route.ts
@@ -1,19 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createSession } from '@/lib/enablebanking'
+import { initiateAuth } from '@/lib/enablebanking'
 
-export async function POST(_request: NextRequest) {
+export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const { aspspName, aspspCountry } = await request.json()
+  if (!aspspName || !aspspCountry) {
+    return NextResponse.json({ error: 'aspspName y aspspCountry son obligatorios' }, { status: 400 })
+  }
+
   const redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/banking/callback`
 
   try {
-    const session = await createSession(redirectUrl)
-    return NextResponse.json({ url: session.url })
+    const auth = await initiateAuth(redirectUrl, { name: aspspName, country: aspspCountry })
+    return NextResponse.json({ url: auth.url })
   } catch (err) {
     console.error('[EB connect]', err)
     return NextResponse.json(

--- a/app/api/banking/connect/route.ts
+++ b/app/api/banking/connect/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createSession } from '@/lib/enablebanking'
+
+export async function POST(_request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/banking/callback`
+
+  try {
+    const session = await createSession(redirectUrl)
+    return NextResponse.json({ url: session.url })
+  } catch (err) {
+    console.error('[EB connect]', err)
+    return NextResponse.json(
+      { error: 'No se pudo iniciar la conexión bancaria' },
+      { status: 502 }
+    )
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es" className={dmSans.variable} suppressHydrationWarning>
-      <body className="min-h-full overflow-clip antialiased">
+      <body className="min-h-full antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
         </ThemeProvider>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { OnboardingClient } from '@/components/onboarding/OnboardingClient'
+
+export default async function OnboardingPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: config } = await supabase
+    .from('user_config')
+    .select('has_onboarded')
+    .eq('user_id', user.id)
+    .single()
+
+  if (config?.has_onboarded) redirect('/')
+
+  return <OnboardingClient />
+}

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,0 +1,74 @@
+import { Check } from 'lucide-react'
+import { fmt } from '@/lib/formatting'
+import type { Account } from '@/types'
+
+function formatRelativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const hours = Math.floor(diffMs / 3_600_000)
+  if (hours < 1) return 'hace menos de 1 hora'
+  if (hours < 24) return `hace ${hours} hora${hours > 1 ? 's' : ''}`
+  const days = Math.floor(hours / 24)
+  return `hace ${days} día${days > 1 ? 's' : ''}`
+}
+
+export function AccountCard({ account }: { account: Account }) {
+  const color = account.color ?? '#6366f1'
+  const isPsd2 = account.source === 'enablebanking'
+  const isNegative = (account.balance ?? 0) < 0
+
+  return (
+    <div className="bg-card rounded-[20px] p-5 border border-border">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div
+            className="size-11 rounded-[14px] flex items-center justify-center"
+            style={{ background: color + '22' }}
+          >
+            <div className="size-[18px] rounded-[5px]" style={{ background: color }} />
+          </div>
+          <div>
+            <div className="text-[15px] font-bold text-foreground leading-tight">
+              {account.name}
+            </div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              {account.number ?? '—'}
+            </div>
+          </div>
+        </div>
+
+        <span
+          className="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+          style={{
+            background: isPsd2 ? '#6366f122' : '#f59e0b22',
+            color: isPsd2 ? '#6366f1' : '#f59e0b',
+          }}
+        >
+          {isPsd2 ? 'PSD2' : 'Scraper'}
+        </span>
+      </div>
+
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="text-xs text-muted-foreground mb-1">Saldo actual</div>
+          <div
+            className="text-[26px] font-extrabold tracking-tight leading-none"
+            style={{ color: isNegative ? '#ef4444' : undefined }}
+          >
+            {account.balance !== null ? `${fmt(account.balance, 2)} €` : '—'}
+          </div>
+        </div>
+        <div
+          className="text-xs font-semibold px-3 py-1.5 rounded-[10px]"
+          style={{ background: '#6366f115', color: '#6366f1' }}
+        >
+          Ver movimientos
+        </div>
+      </div>
+
+      <div className="mt-3.5 pt-3.5 border-t border-border text-[11px] text-muted-foreground flex items-center gap-1.5">
+        <Check className="size-3 shrink-0" style={{ color: '#22c55e' }} />
+        {account.last_synced ? formatRelativeTime(account.last_synced) : 'Nunca sincronizado'}
+      </div>
+    </div>
+  )
+}

--- a/components/accounts/ConnectBankButton.tsx
+++ b/components/accounts/ConnectBankButton.tsx
@@ -1,34 +1,140 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, X, Search } from 'lucide-react'
+
+interface Aspsp {
+  name: string
+  country: string
+}
+
+type Step = 'idle' | 'selecting' | 'connecting'
 
 export function ConnectBankButton() {
-  const [loading, setLoading] = useState(false)
+  const [step, setStep] = useState<Step>('idle')
+  const [country, setCountry] = useState('ES')
+  const [aspsps, setAspsps] = useState<Aspsp[]>([])
+  const [loadingAspsps, setLoadingAspsps] = useState(false)
+  const [selected, setSelected] = useState<Aspsp | null>(null)
+
+  async function handleOpenSelector() {
+    setStep('selecting')
+    setLoadingAspsps(true)
+    try {
+      const res = await fetch(`/api/banking/aspsps?country=${country}`)
+      if (res.ok) setAspsps(await res.json())
+    } finally {
+      setLoadingAspsps(false)
+    }
+  }
+
+  async function handleCountryChange(newCountry: string) {
+    setCountry(newCountry)
+    setSelected(null)
+    setLoadingAspsps(true)
+    try {
+      const res = await fetch(`/api/banking/aspsps?country=${newCountry}`)
+      if (res.ok) setAspsps(await res.json())
+    } finally {
+      setLoadingAspsps(false)
+    }
+  }
 
   async function handleConnect() {
-    setLoading(true)
+    if (!selected) return
+    setStep('connecting')
     try {
-      const res = await fetch('/api/banking/connect', { method: 'POST' })
+      const res = await fetch('/api/banking/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ aspspName: selected.name, aspspCountry: selected.country }),
+      })
       if (!res.ok) throw new Error('connect failed')
       const { url } = await res.json()
       window.location.href = url
     } catch {
-      setLoading(false)
+      setStep('selecting')
     }
   }
 
+  if (step === 'idle') {
+    return (
+      <button
+        onClick={handleOpenSelector}
+        className="w-full rounded-[20px] border-2 border-dashed p-5 flex items-center justify-center gap-2 transition-opacity"
+        style={{ borderColor: '#6366f140', background: '#6366f108' }}
+      >
+        <Plus className="size-[18px]" style={{ color: '#6366f1' }} />
+        <span className="text-[14px] font-semibold" style={{ color: '#6366f1' }}>
+          Conectar nueva cuenta
+        </span>
+      </button>
+    )
+  }
+
   return (
-    <button
-      onClick={handleConnect}
-      disabled={loading}
-      className="w-full rounded-[20px] border-2 border-dashed p-5 flex items-center justify-center gap-2 transition-opacity disabled:opacity-50"
-      style={{ borderColor: '#6366f140', background: '#6366f108' }}
-    >
-      <Plus className="size-[18px]" style={{ color: '#6366f1' }} />
-      <span className="text-[14px] font-semibold" style={{ color: '#6366f1' }}>
-        {loading ? 'Iniciando…' : 'Conectar nueva cuenta'}
-      </span>
-    </button>
+    <div className="rounded-[20px] border border-border bg-card p-5 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <span className="text-[15px] font-bold text-foreground">Selecciona tu banco</span>
+        <button onClick={() => setStep('idle')} className="text-muted-foreground">
+          <X className="size-4" />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs font-semibold text-muted-foreground">País</label>
+        <select
+          value={country}
+          onChange={e => handleCountryChange(e.target.value)}
+          className="w-full rounded-[10px] border border-border bg-background px-3 py-2.5 text-sm text-foreground"
+        >
+          <option value="ES">España</option>
+          <option value="FI">Finlandia</option>
+          <option value="SE">Suecia</option>
+          <option value="GB">Reino Unido</option>
+          <option value="FR">Francia</option>
+          <option value="DE">Alemania</option>
+          <option value="IT">Italia</option>
+          <option value="PT">Portugal</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-xs font-semibold text-muted-foreground">Banco</label>
+        {loadingAspsps ? (
+          <div className="text-sm text-muted-foreground py-2">Cargando bancos…</div>
+        ) : aspsps.length === 0 ? (
+          <div className="text-sm text-muted-foreground py-2">
+            No hay bancos disponibles para este país.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1 max-h-48 overflow-y-auto rounded-[10px] border border-border">
+            {aspsps.map(aspsp => (
+              <button
+                key={aspsp.name}
+                onClick={() => setSelected(aspsp)}
+                className="px-3 py-2.5 text-sm text-left transition-colors"
+                style={{
+                  background: selected?.name === aspsp.name ? '#6366f115' : undefined,
+                  color: selected?.name === aspsp.name ? '#6366f1' : undefined,
+                  fontWeight: selected?.name === aspsp.name ? 600 : undefined,
+                }}
+              >
+                {aspsp.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <button
+        onClick={handleConnect}
+        disabled={!selected || step === 'connecting'}
+        className="w-full rounded-[14px] py-3.5 text-[14px] font-bold text-white transition-opacity disabled:opacity-40"
+        style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
+      >
+        {step === 'connecting' ? 'Iniciando…' : selected ? `Conectar ${selected.name}` : 'Selecciona un banco'}
+      </button>
+    </div>
   )
 }

--- a/components/accounts/ConnectBankButton.tsx
+++ b/components/accounts/ConnectBankButton.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus } from 'lucide-react'
+
+export function ConnectBankButton() {
+  const [loading, setLoading] = useState(false)
+
+  async function handleConnect() {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/banking/connect', { method: 'POST' })
+      if (!res.ok) throw new Error('connect failed')
+      const { url } = await res.json()
+      window.location.href = url
+    } catch {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={loading}
+      className="w-full rounded-[20px] border-2 border-dashed p-5 flex items-center justify-center gap-2 transition-opacity disabled:opacity-50"
+      style={{ borderColor: '#6366f140', background: '#6366f108' }}
+    >
+      <Plus className="size-[18px]" style={{ color: '#6366f1' }} />
+      <span className="text-[14px] font-semibold" style={{ color: '#6366f1' }}>
+        {loading ? 'Iniciando…' : 'Conectar nueva cuenta'}
+      </span>
+    </button>
+  )
+}

--- a/components/onboarding/OnboardingClient.tsx
+++ b/components/onboarding/OnboardingClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import { BarChart2, Wallet, Home } from 'lucide-react'
+import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
 
 const FEATURES = [
   {
@@ -22,22 +22,8 @@ const FEATURES = [
 ]
 
 export function OnboardingClient() {
-  const [loading, setLoading] = useState(false)
-
-  async function handleConnect() {
-    setLoading(true)
-    try {
-      const res = await fetch('/api/banking/connect', { method: 'POST' })
-      if (!res.ok) throw new Error('connect failed')
-      const { url } = await res.json()
-      window.location.href = url
-    } catch {
-      setLoading(false)
-    }
-  }
-
   return (
-    <div className="min-h-screen bg-background px-6 pt-[60px] pb-10 flex flex-col overflow-clip">
+    <div className="min-h-screen bg-background px-6 pt-[60px] pb-10 flex flex-col">
       <div className="flex-1 flex flex-col justify-center text-center">
         <div
           className="size-24 mx-auto mb-7 rounded-[28px] flex items-center justify-center"
@@ -79,17 +65,7 @@ export function OnboardingClient() {
       </div>
 
       <div className="flex flex-col gap-2.5">
-        <button
-          onClick={handleConnect}
-          disabled={loading}
-          className="w-full rounded-2xl py-4 text-[15px] font-bold text-white transition-opacity disabled:opacity-60"
-          style={{
-            background: 'linear-gradient(135deg, #6366f1, #8b5cf6)',
-            boxShadow: '0 10px 30px rgba(99,102,241,0.35)',
-          }}
-        >
-          {loading ? 'Iniciando…' : 'Conectar mi primer banco'}
-        </button>
+        <ConnectBankButton />
         <button className="py-2.5 text-[13px] font-semibold text-muted-foreground">
           Empezar con datos de ejemplo
         </button>

--- a/components/onboarding/OnboardingClient.tsx
+++ b/components/onboarding/OnboardingClient.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { BarChart2, Wallet, Home } from 'lucide-react'
+
+const FEATURES = [
+  {
+    icon: Wallet,
+    title: 'Conexión bancaria PSD2',
+    desc: 'Vía Open Banking, lectura segura y sin contraseñas',
+  },
+  {
+    icon: BarChart2,
+    title: 'Análisis automático',
+    desc: 'Categorías, tendencias y comparativas mensuales',
+  },
+  {
+    icon: Home,
+    title: 'Todo en un solo sitio',
+    desc: 'Cuentas, tarjetas, Edenred y más',
+  },
+]
+
+export function OnboardingClient() {
+  const [loading, setLoading] = useState(false)
+
+  async function handleConnect() {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/banking/connect', { method: 'POST' })
+      if (!res.ok) throw new Error('connect failed')
+      const { url } = await res.json()
+      window.location.href = url
+    } catch {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background px-6 pt-[60px] pb-10 flex flex-col overflow-clip">
+      <div className="flex-1 flex flex-col justify-center text-center">
+        <div
+          className="size-24 mx-auto mb-7 rounded-[28px] flex items-center justify-center"
+          style={{
+            background: 'linear-gradient(135deg, #6366f1, #8b5cf6, #a78bfa)',
+            boxShadow: '0 20px 60px rgba(99,102,241,0.4)',
+          }}
+        >
+          <BarChart2 className="size-11 text-white" strokeWidth={2.2} />
+        </div>
+
+        <h1 className="text-[28px] font-extrabold text-foreground tracking-tight mb-2.5">
+          Bienvenido a tus finanzas
+        </h1>
+        <p className="text-sm text-muted-foreground mb-10 leading-relaxed px-3">
+          Conecta tus cuentas y empieza a entender en qué se va tu dinero.
+          Privado, seguro y bajo tu control.
+        </p>
+
+        <div className="flex flex-col gap-3 mb-10 text-left">
+          {FEATURES.map(({ icon: Icon, title, desc }) => (
+            <div
+              key={title}
+              className="flex items-center gap-3.5 p-3.5 rounded-2xl bg-card border border-border"
+            >
+              <div
+                className="size-10 rounded-[12px] shrink-0 flex items-center justify-center"
+                style={{ background: '#6366f115' }}
+              >
+                <Icon className="size-[18px]" style={{ color: '#6366f1' }} strokeWidth={2} />
+              </div>
+              <div>
+                <div className="text-sm font-bold text-foreground mb-0.5">{title}</div>
+                <div className="text-xs text-muted-foreground">{desc}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <button
+          onClick={handleConnect}
+          disabled={loading}
+          className="w-full rounded-2xl py-4 text-[15px] font-bold text-white transition-opacity disabled:opacity-60"
+          style={{
+            background: 'linear-gradient(135deg, #6366f1, #8b5cf6)',
+            boxShadow: '0 10px 30px rgba(99,102,241,0.35)',
+          }}
+        >
+          {loading ? 'Iniciando…' : 'Conectar mi primer banco'}
+        </button>
+        <button className="py-2.5 text-[13px] font-semibold text-muted-foreground">
+          Empezar con datos de ejemplo
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/docs/enablebanking-integration-log.md
+++ b/docs/enablebanking-integration-log.md
@@ -1,0 +1,243 @@
+# Enable Banking — Log de integración
+
+> Registro completo de problemas encontrados y soluciones aplicadas durante la integración del flujo OAuth PSD2 con Enable Banking en fin-app (Next.js 16 App Router + TypeScript).
+> Issue: [#14 — \[feature\] Enable Banking: flujo OAuth + conexión de cuenta](https://github.com/MrClit/fin-app/issues/14)
+> Rama: `feature/enable-banking-oauth` — [PR #18](https://github.com/MrClit/fin-app/pull/18)
+
+---
+
+## Estado actual (2026-05-06)
+
+El flujo **llega a hacer llamadas correctas a la API de Enable Banking** pero está bloqueado en la configuración de la redirect URL, que debe ser HTTPS. El entorno local usa HTTP y los túneles probados (localtunnel, ngrok) tienen fricción adicional. **Pendiente: probar en el preview de Vercel del PR.**
+
+---
+
+## Credenciales
+
+- **`ENABLEBANKING_APP_ID`** — UUID de la aplicación registrada en el Developer Portal. Coincide con el nombre del fichero `.pem` descargado.
+- **`ENABLEBANKING_SECRET_KEY`** — Clave privada RSA-4096 en formato PKCS8 (`BEGIN PRIVATE KEY`). **El portal de Enable Banking genera el par de claves y entrega solo la clave privada.** No hay que generar claves ni subir clave pública — el portal ya tiene la pública internamente.
+
+Ambas variables están en `.env.local`. La clave privada es multilínea y debe ir entre comillas dobles:
+```
+ENABLEBANKING_SECRET_KEY="-----BEGIN PRIVATE KEY-----
+MIIEvQ...
+-----END PRIVATE KEY-----"
+```
+Next.js/dotenv lo parsea correctamente con las comillas.
+
+---
+
+## Problemas encontrados y soluciones
+
+### 1. Algoritmo JWT incorrecto: ES256 → RS256
+
+**Error:** `Invalid key type` en `importPKCS8`
+
+**Causa:** La implementación inicial asumía que Enable Banking usa ECDSA P-256 (ES256). La clave descargada del portal es RSA-4096, que requiere RS256.
+
+**Diagnóstico:**
+```bash
+openssl pkey -in docs/3dea7d0f-....pem -text -noout | head -1
+# RSA Private-Key: (4096 bit)
+```
+
+**Solución:** Cambiar `'ES256'` por `'RS256'` en `importPKCS8` y en el header del JWT.
+
+---
+
+### 2. JWT — claim `aud` faltante
+
+**Error:** `401 — {"message": "aud is missing in JWT body"}`
+
+**Causa:** El JWT no incluía el claim `aud` (audience).
+
+**Solución:** Añadir `.setAudience('api.enablebanking.com')`. El valor correcto es `"api.enablebanking.com"` (sin `https://`). Valores incorrectos probados: `"enablebanking"`.
+
+---
+
+### 3. JWT — claim `aud` incorrecto
+
+**Error:** `401 — {"message": "JWT audience is not valid"}`
+
+**Causa:** El valor `"enablebanking"` no era el audience correcto.
+
+**Solución:** El audience correcto es `"api.enablebanking.com"`.
+
+---
+
+### 4. JWT — claim `iss` incorrecto
+
+**Causa:** El `iss` (issuer) se ponía como el `APP_ID`. Enable Banking espera `"enablebanking.com"`.
+
+**Solución:** `.setIssuer('enablebanking.com')`
+
+**Resumen de claims JWT correctos:**
+```json
+Header: { "alg": "RS256", "kid": "<APP_ID>" }
+Body:   { "iss": "enablebanking.com", "aud": "api.enablebanking.com", "iat": ..., "exp": ... }
+```
+
+---
+
+### 5. Endpoint incorrecto: `/application/sessions` → `/auth`
+
+**Error:** `404 — {"detail": "Not Found"}`
+
+**Causa:** La documentación inicial llevó a usar `POST /application/sessions`, que no existe.
+
+**Flujo real de la API:**
+```
+POST /auth       → devuelve { url, authorization_id }
+                   (url = redirect al banco para que el usuario autorice)
+
+[Usuario autoriza en el banco]
+
+Callback recibe: ?code=xxx  (NO session_id)
+
+POST /sessions   → body: { code }
+                 → devuelve { session_id, accounts[], access.valid_until }
+```
+
+**Archivos afectados:**
+- `lib/enablebanking.ts` — renombrar `createSession` → `initiateAuth` (llama a `/auth`) y `getSession` → `createSessionFromCode` (llama a `POST /sessions`)
+- `app/api/banking/callback/route.ts` — leer `?code=` en lugar de `?session_id=`
+
+---
+
+### 6. `/auth` requiere `aspsp` y `state`
+
+**Error:** `422 — {"error":"WRONG_REQUEST_PARAMETERS","detail":[{"loc":["body","aspsp"],"msg":"Field required"}, {"loc":["body","state"],"msg":"Field required"}]}`
+
+**Causa:** El endpoint `POST /auth` requiere obligatoriamente:
+- `aspsp: { name: string, country: string }` — el banco al que conectar
+- `state: string` — string aleatorio anti-CSRF
+
+**Implicación de diseño:** No hay selector de banco en la UI del banco, hay que pre-seleccionarlo. Enable Banking tiene un endpoint `GET /aspsps?country=XX` para listar los bancos disponibles por país.
+
+**Solución implementada:**
+- Nuevo endpoint `GET /api/banking/aspsps?country=XX` que consulta la lista de bancos
+- `ConnectBankButton` expandido con un selector de país + lista de bancos antes de conectar
+- `state` generado con `crypto.randomUUID()` en cada llamada
+
+**Body completo de `POST /auth`:**
+```json
+{
+  "aspsp": { "name": "Banco Santander", "country": "ES" },
+  "access": { "valid_until": "2026-08-03T..." },
+  "state": "uuid-aleatorio",
+  "redirect_url": "https://tu-app.com/api/banking/callback",
+  "psu_type": "personal"
+}
+```
+
+---
+
+### 7. `NEXT_PUBLIC_APP_URL` = `undefined` → redirect_url inválida
+
+**Error:** `422 — {"detail":[{"loc":["body","redirect_url"],"msg":"Input should be a valid URL","input":"undefined/api/banking/callback"}]}`
+
+**Causa:** Un script Python usado anteriormente para escribir `ENABLEBANKING_SECRET_KEY` en `.env.local` usaba `re.DOTALL` en el regex, lo que hacía que el patrón `ENABLEBANKING_SECRET_KEY=.*` consumiera todo el contenido del fichero hasta el final, borrando `NEXT_PUBLIC_APP_URL` y `EDENRED_WEBHOOK_SECRET`.
+
+**Solución:** Restaurar manualmente en `.env.local`:
+```
+EDENRED_WEBHOOK_SECRET=
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+```
+
+---
+
+### 8. HTTPS requerido para la redirect URL
+
+**Error:** `400 — {"error":"REDIRECT_URI_NOT_ALLOWED"}`
+
+**Causa:** Enable Banking **no acepta URLs HTTP** como redirect URI. Solo HTTPS. En desarrollo local (`http://localhost:3000`) no funciona.
+
+**Opciones probadas para desarrollo local:**
+
+| Opción | Resultado |
+|--------|-----------|
+| `http://localhost:3000` | ❌ Rechazado por Enable Banking |
+| `localtunnel` (`npx localtunnel --port 3000`) | ⚠️ Genera URL HTTPS pero requiere registrarla en el portal y a veces pide tunnel password |
+| `ngrok` | ⚠️ Requiere cuenta registrada y authtoken |
+
+**Solución pendiente:** Usar el **preview de Vercel del PR #18** como entorno de prueba:
+1. Esperar a que el preview esté activo
+2. Añadir en Vercel → Environment Variables (Preview): `ENABLEBANKING_APP_ID`, `ENABLEBANKING_SECRET_KEY`, `NEXT_PUBLIC_APP_URL=https://url-del-preview.vercel.app`
+3. Registrar `https://url-del-preview.vercel.app/api/banking/callback` en Enable Banking portal
+4. Hacer redeploy del preview
+
+---
+
+### 9. Scroll bloqueado en `/onboarding`
+
+**Causa:** El `<body>` del root layout (`app/layout.tsx`) tenía la clase `overflow-clip`, que bloquea el scroll en toda la app, incluyendo páginas que legítimamente necesitan scroll (como onboarding cuando se abre el selector de banco).
+
+**Nota:** El layout de `(app)` ya tiene `overflow-clip` en su propio contenedor, así que el `body` no necesitaba esa clase.
+
+**Solución:** Eliminar `overflow-clip` del `body` en `app/layout.tsx`.
+
+---
+
+### 10. Caché de Next.js corrupta
+
+**Síntoma:** Todas las rutas devolvían 404 tras reiniciar el servidor.
+
+**Solución:**
+```bash
+rm -rf .next
+pnpm dev
+```
+
+---
+
+## Estructura de ficheros relevantes
+
+```
+lib/
+└── enablebanking.ts          # signJWT (RS256), initiateAuth (/auth), createSessionFromCode (/sessions)
+
+app/api/banking/
+├── connect/route.ts          # POST → llama initiateAuth, devuelve { url }
+├── callback/route.ts         # GET ?code=xxx → llama createSessionFromCode, guarda accounts
+└── aspsps/route.ts           # GET ?country=XX → lista bancos disponibles
+
+components/accounts/
+├── AccountCard.tsx            # Server Component, muestra cuenta con saldo y badge PSD2/Scraper
+└── ConnectBankButton.tsx      # Client Component, selector país+banco + POST /api/banking/connect
+
+components/onboarding/
+└── OnboardingClient.tsx       # Client Component, reutiliza ConnectBankButton
+
+app/(app)/cuentas/page.tsx     # Server Component, lee accounts de Supabase
+app/onboarding/page.tsx        # Server Component (fuera del grupo (app)), verifica has_onboarded
+```
+
+---
+
+## Variables de entorno necesarias
+
+```bash
+# Supabase (ya configuradas)
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Enable Banking
+ENABLEBANKING_APP_ID=3dea7d0f-87a5-4cf2-9ec7-3e42c44d09db
+ENABLEBANKING_SECRET_KEY="-----BEGIN PRIVATE KEY-----
+...clave RSA-4096 PKCS8...
+-----END PRIVATE KEY-----"
+
+# App (debe ser HTTPS para que Enable Banking acepte la redirect URL)
+NEXT_PUBLIC_APP_URL=https://tu-dominio.com
+```
+
+---
+
+## Pendiente
+
+- [ ] Probar el flujo completo en el preview de Vercel del PR #18
+- [ ] Verificar que `GET /api/banking/aspsps?country=ES` devuelve bancos correctamente
+- [ ] Verificar que el callback procesa bien el `code` y guarda las cuentas en Supabase
+- [ ] Aplicar la migración SQL en Supabase: `supabase/migrations/20260506000000_accounts_unique_external_id.sql`
+- [ ] (Futura issue) Sincronización de saldos y transacciones tras la conexión

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -2,60 +2,60 @@ import { SignJWT, importPKCS8 } from 'jose'
 
 const BASE_URL = 'https://api.enablebanking.com'
 
-async function signJWT(): Promise<string> {
-  const key = await importPKCS8(process.env.ENABLEBANKING_SECRET_KEY!, 'ES256')
+export async function signJWT(): Promise<string> {
+  const key = await importPKCS8(process.env.ENABLEBANKING_SECRET_KEY!, 'RS256')
   return new SignJWT({})
-    .setProtectedHeader({ alg: 'ES256', kid: process.env.ENABLEBANKING_APP_ID! })
-    .setIssuer(process.env.ENABLEBANKING_APP_ID!)
+    .setProtectedHeader({ alg: 'RS256', kid: process.env.ENABLEBANKING_APP_ID! })
+    .setIssuer('enablebanking.com')
+    .setAudience('api.enablebanking.com')
     .setIssuedAt()
     .setExpirationTime('60s')
     .sign(key)
 }
 
-export interface EBSession {
-  session_id: string
+export interface EBAuthResponse {
   url: string
+  authorization_id: string
 }
 
 export interface EBAccount {
-  account_id: string
+  uid: string
   iban: string | null
+  account_holder: string | null
   currency: string
-  product: string | null
-  name: string | null
-  balances?: Array<{
-    balance_amount: { amount: string; currency: string }
-    balance_type: string
-  }>
 }
 
-export interface EBSessionStatus {
+export interface EBSession {
   session_id: string
-  status: 'AUTHORIZED' | 'REJECTED' | 'PENDING' | string
   accounts: EBAccount[]
   access: {
     valid_until: string
   }
 }
 
-export async function createSession(redirectUrl: string): Promise<EBSession> {
-  const jwt = await signJWT()
-  const validUntil = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split('T')[0]
+export interface EBaspsp {
+  name: string
+  country: string
+}
 
-  const res = await fetch(`${BASE_URL}/application/sessions`, {
+export async function initiateAuth(
+  redirectUrl: string,
+  aspsp: EBaspsp
+): Promise<EBAuthResponse> {
+  const jwt = await signJWT()
+  const validUntil = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
+  const state = crypto.randomUUID()
+
+  const res = await fetch(`${BASE_URL}/auth`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${jwt}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      access: {
-        valid_until: validUntil,
-        balances: true,
-        transactions: true,
-      },
+      aspsp,
+      access: { valid_until: validUntil },
+      state,
       redirect_url: redirectUrl,
       psu_type: 'personal',
     }),
@@ -63,21 +63,26 @@ export async function createSession(redirectUrl: string): Promise<EBSession> {
 
   if (!res.ok) {
     const body = await res.text()
-    throw new Error(`Enable Banking createSession failed: ${res.status} — ${body}`)
+    throw new Error(`Enable Banking /auth failed: ${res.status} — ${body}`)
   }
 
   return res.json()
 }
 
-export async function getSession(sessionId: string): Promise<EBSessionStatus> {
+export async function createSessionFromCode(code: string): Promise<EBSession> {
   const jwt = await signJWT()
-  const res = await fetch(`${BASE_URL}/application/sessions/${sessionId}`, {
-    headers: { Authorization: `Bearer ${jwt}` },
+  const res = await fetch(`${BASE_URL}/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code }),
   })
 
   if (!res.ok) {
     const body = await res.text()
-    throw new Error(`Enable Banking getSession failed: ${res.status} — ${body}`)
+    throw new Error(`Enable Banking /sessions failed: ${res.status} — ${body}`)
   }
 
   return res.json()

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -3,7 +3,9 @@ import { SignJWT, importPKCS8 } from 'jose'
 const BASE_URL = 'https://api.enablebanking.com'
 
 export async function signJWT(): Promise<string> {
-  const rawKey = process.env.ENABLEBANKING_SECRET_KEY!.replace(/\\n/g, '\n')
+  const raw = process.env.ENABLEBANKING_SECRET_KEY ?? ''
+  console.log('[EB key] length:', raw.length, '| first30:', JSON.stringify(raw.slice(0, 30)), '| hasLiteralN:', raw.includes('\\n'), '| hasRealN:', raw.includes('\n'))
+  const rawKey = raw.replace(/\\n/g, '\n')
   const key = await importPKCS8(rawKey, 'RS256')
   return new SignJWT({})
     .setProtectedHeader({ alg: 'RS256', kid: process.env.ENABLEBANKING_APP_ID! })

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -3,7 +3,8 @@ import { SignJWT, importPKCS8 } from 'jose'
 const BASE_URL = 'https://api.enablebanking.com'
 
 export async function signJWT(): Promise<string> {
-  const key = await importPKCS8(process.env.ENABLEBANKING_SECRET_KEY!, 'RS256')
+  const rawKey = process.env.ENABLEBANKING_SECRET_KEY!.replace(/\\n/g, '\n')
+  const key = await importPKCS8(rawKey, 'RS256')
   return new SignJWT({})
     .setProtectedHeader({ alg: 'RS256', kid: process.env.ENABLEBANKING_APP_ID! })
     .setIssuer('enablebanking.com')

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -1,0 +1,84 @@
+import { SignJWT, importPKCS8 } from 'jose'
+
+const BASE_URL = 'https://api.enablebanking.com'
+
+async function signJWT(): Promise<string> {
+  const key = await importPKCS8(process.env.ENABLEBANKING_SECRET_KEY!, 'ES256')
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'ES256', kid: process.env.ENABLEBANKING_APP_ID! })
+    .setIssuer(process.env.ENABLEBANKING_APP_ID!)
+    .setIssuedAt()
+    .setExpirationTime('60s')
+    .sign(key)
+}
+
+export interface EBSession {
+  session_id: string
+  url: string
+}
+
+export interface EBAccount {
+  account_id: string
+  iban: string | null
+  currency: string
+  product: string | null
+  name: string | null
+  balances?: Array<{
+    balance_amount: { amount: string; currency: string }
+    balance_type: string
+  }>
+}
+
+export interface EBSessionStatus {
+  session_id: string
+  status: 'AUTHORIZED' | 'REJECTED' | 'PENDING' | string
+  accounts: EBAccount[]
+  access: {
+    valid_until: string
+  }
+}
+
+export async function createSession(redirectUrl: string): Promise<EBSession> {
+  const jwt = await signJWT()
+  const validUntil = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0]
+
+  const res = await fetch(`${BASE_URL}/application/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      access: {
+        valid_until: validUntil,
+        balances: true,
+        transactions: true,
+      },
+      redirect_url: redirectUrl,
+      psu_type: 'personal',
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Enable Banking createSession failed: ${res.status} — ${body}`)
+  }
+
+  return res.json()
+}
+
+export async function getSession(sessionId: string): Promise<EBSessionStatus> {
+  const jwt = await signJWT()
+  const res = await fetch(`${BASE_URL}/application/sessions/${sessionId}`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Enable Banking getSession failed: ${res.status} — ${body}`)
+  }
+
+  return res.json()
+}

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -3,9 +3,7 @@ import { SignJWT, importPKCS8 } from 'jose'
 const BASE_URL = 'https://api.enablebanking.com'
 
 export async function signJWT(): Promise<string> {
-  const raw = process.env.ENABLEBANKING_SECRET_KEY ?? ''
-  console.log('[EB key] length:', raw.length, '| first30:', JSON.stringify(raw.slice(0, 30)), '| hasLiteralN:', raw.includes('\\n'), '| hasRealN:', raw.includes('\n'))
-  const rawKey = raw.replace(/\\n/g, '\n')
+  const rawKey = (process.env.ENABLEBANKING_SECRET_KEY ?? '').replace(/\\n/g, '\n')
   const key = await importPKCS8(rawKey, 'RS256')
   return new SignJWT({})
     .setProtectedHeader({ alg: 'RS256', kid: process.env.ENABLEBANKING_APP_ID! })

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -21,8 +21,8 @@ export interface EBAuthResponse {
 
 export interface EBAccount {
   uid: string
-  iban: string | null
-  account_holder: string | null
+  account_id: { iban: string | null } | null
+  name: string | null
   currency: string
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: ["*.ngrok-free.app", "*.ngrok-free.dev"],
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.105.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jose": "^6.2.3",
     "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.4)

--- a/supabase/migrations/20260506000000_accounts_unique_external_id.sql
+++ b/supabase/migrations/20260506000000_accounts_unique_external_id.sql
@@ -1,5 +1,4 @@
 -- Permite upsert seguro en accounts al reconectar el mismo banco
--- external_id puede ser NULL (cuentas manuales), de ahí el WHERE
-CREATE UNIQUE INDEX idx_accounts_user_external
-  ON accounts(user_id, external_id)
-  WHERE external_id IS NOT NULL;
+-- UNIQUE constraint (no índice parcial) para que ON CONFLICT funcione con el cliente Supabase
+DROP INDEX IF EXISTS idx_accounts_user_external;
+ALTER TABLE accounts ADD CONSTRAINT accounts_user_external_unique UNIQUE (user_id, external_id);

--- a/supabase/migrations/20260506000000_accounts_unique_external_id.sql
+++ b/supabase/migrations/20260506000000_accounts_unique_external_id.sql
@@ -1,0 +1,5 @@
+-- Permite upsert seguro en accounts al reconectar el mismo banco
+-- external_id puede ser NULL (cuentas manuales), de ahí el WHERE
+CREATE UNIQUE INDEX idx_accounts_user_external
+  ON accounts(user_id, external_id)
+  WHERE external_id IS NOT NULL;


### PR DESCRIPTION
Closes #14

## Resumen

- **`lib/enablebanking.ts`** — cliente Enable Banking: firma JWT ES256 con `jose` + `createSession` / `getSession`
- **`POST /api/banking/connect`** — inicia sesión con Enable Banking y devuelve la URL del banco al que redirigir al usuario
- **`GET /api/banking/callback`** — recibe el retorno del banco, guarda las cuentas en Supabase y marca al usuario como onboarded
- **Pantalla `/cuentas`** — `AccountCard` + `ConnectBankButton` + banners de éxito/error tras la conexión
- **Pantalla `/onboarding`** — hero con gradiente + lista de features + CTA "Conectar mi primer banco"
- **`app/(app)/layout.tsx`** — añade verificación de auth (redirect a `/login` si no hay sesión)
- **`app/(app)/page.tsx`** — redirect a `/onboarding` si `!has_onboarded`
- **Migración SQL** — índice único `accounts(user_id, external_id)` para `upsert` seguro al reconectar el mismo banco

## Variables de entorno necesarias

```
ENABLEBANKING_APP_ID=       # UUID de la app en el Developer Portal de Enable Banking
ENABLEBANKING_SECRET_KEY=   # Clave privada PKCS8 descargada del portal (BEGIN PRIVATE KEY)
NEXT_PUBLIC_APP_URL=        # URL base de la app (para construir el redirect URL del callback)
```

## Plan de pruebas

- [ ] Aplicar migración SQL en Supabase (`supabase/migrations/20260506000000_accounts_unique_external_id.sql`)
- [ ] Rellenar `ENABLEBANKING_APP_ID` y `ENABLEBANKING_SECRET_KEY` en `.env.local`
- [ ] Configurar la redirect URL `{APP_URL}/api/banking/callback` en el Developer Portal de Enable Banking
- [ ] `pnpm dev` → navegar a `/` → redirige a `/onboarding`
- [ ] Pulsar "Conectar mi primer banco" → `POST /api/banking/connect` devuelve URL de Enable Banking
- [ ] Completar el flujo en el Sandbox de Enable Banking
- [ ] Verificar que `/api/banking/callback` crea filas en `accounts` con `source='enablebanking'`
- [ ] Verificar que `/cuentas` muestra el banner verde y los `AccountCard` con los datos del banco

🤖 Generated with [Claude Code](https://claude.ai/claude-code)