### PR TITLE
feat(sync): Enable Banking transaction sync + auto-categorization

### DIFF
--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { getAccountTransactions, getAccountBalance } from '@/lib/enablebanking'
+import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorize } from '@/lib/categories'
 
 export async function POST() {
@@ -54,7 +54,12 @@ export async function POST() {
 
     if (ebTransactions.length > 0) {
       const rows = ebTransactions.map(tx => {
-        const description = tx.remittance_information_unstructured?.trim() || 'Sin descripción'
+        const externalId = tx.entry_reference ?? tx.transaction_id
+        const description =
+          tx.remittance_information?.[0]?.trim() ||
+          tx.creditor?.name ||
+          tx.debtor?.name ||
+          'Sin descripción'
         const sign = tx.credit_debit_indicator === 'DBIT' ? -1 : 1
         const amount = parseFloat(tx.transaction_amount.amount) * sign
 
@@ -66,7 +71,7 @@ export async function POST() {
           description,
           category:             categorize(description),
           source:               'enablebanking' as const,
-          external_id:          tx.transaction_id,
+          external_id:          externalId,
           is_computable:        true,
           is_internal_transfer: false,
         }
@@ -83,20 +88,15 @@ export async function POST() {
       }
     }
 
-    // Update balance and last_synced
-    try {
-      const balance = await getAccountBalance(account.external_id, account.session_id)
-      await db
-        .from('accounts')
-        .update({ ...(balance !== null && { balance }), last_synced: new Date().toISOString() })
-        .eq('id', account.id)
-    } catch (err) {
-      console.error(`[sync/eb] getBalance ${account.external_id}:`, err)
-      await db
-        .from('accounts')
-        .update({ last_synced: new Date().toISOString() })
-        .eq('id', account.id)
-    }
+    // Update balance from last transaction's balance_after_transaction
+    const lastTx = ebTransactions.at(-1)
+    const balance = lastTx?.balance_after_transaction
+      ? parseFloat(lastTx.balance_after_transaction.amount)
+      : null
+    await db
+      .from('accounts')
+      .update({ ...(balance !== null && { balance }), last_synced: new Date().toISOString() })
+      .eq('id', account.id)
   }
 
   const { error: transferError } = await db.rpc('mark_internal_transfers', { p_user_id: user.id })

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getAccountTransactions, getAccountBalance } from '@/lib/enablebanking'
+import { categorize } from '@/lib/categories'
+
+export async function POST() {
+  // Auth: verify user via cookie client
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // All DB writes via service client (bypasses RLS)
+  const db = createServiceClient()
+
+  const { data: accounts, error: accError } = await db
+    .from('accounts')
+    .select('id, external_id, session_id, last_synced')
+    .eq('user_id', user.id)
+    .eq('source', 'enablebanking')
+    .eq('is_active', true)
+
+  if (accError) {
+    console.error('[sync/eb] fetch accounts:', accError)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  if (!accounts || accounts.length === 0) {
+    return NextResponse.json({ synced: 0, accounts: 0 })
+  }
+
+  let totalSynced = 0
+
+  for (const account of accounts) {
+    if (!account.external_id || !account.session_id) continue
+
+    const dateFrom = account.last_synced
+      ? (account.last_synced as string).slice(0, 10)
+      : undefined
+
+    let ebTransactions
+    try {
+      ebTransactions = await getAccountTransactions(
+        account.external_id,
+        account.session_id,
+        dateFrom
+      )
+    } catch (err) {
+      console.error(`[sync/eb] getTransactions ${account.external_id}:`, err)
+      continue
+    }
+
+    if (ebTransactions.length > 0) {
+      const rows = ebTransactions.map(tx => {
+        const description = tx.remittance_information_unstructured?.trim() || 'Sin descripción'
+        const sign = tx.credit_debit_indicator === 'DBIT' ? -1 : 1
+        const amount = parseFloat(tx.transaction_amount.amount) * sign
+
+        return {
+          user_id:              user.id,
+          account_id:           account.id,
+          date:                 tx.booking_date,
+          amount,
+          description,
+          category:             categorize(description),
+          source:               'enablebanking' as const,
+          external_id:          tx.transaction_id,
+          is_computable:        true,
+          is_internal_transfer: false,
+        }
+      })
+
+      const { error: upsertError } = await db
+        .from('transactions')
+        .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: true })
+
+      if (upsertError) {
+        console.error(`[sync/eb] upsert ${account.external_id}:`, upsertError)
+      } else {
+        totalSynced += rows.length
+      }
+    }
+
+    // Update balance and last_synced
+    try {
+      const balance = await getAccountBalance(account.external_id, account.session_id)
+      await db
+        .from('accounts')
+        .update({ ...(balance !== null && { balance }), last_synced: new Date().toISOString() })
+        .eq('id', account.id)
+    } catch (err) {
+      console.error(`[sync/eb] getBalance ${account.external_id}:`, err)
+      await db
+        .from('accounts')
+        .update({ last_synced: new Date().toISOString() })
+        .eq('id', account.id)
+    }
+  }
+
+  const { error: transferError } = await db.rpc('mark_internal_transfers', { p_user_id: user.id })
+  if (transferError) console.error('[sync/eb] mark_internal_transfers:', transferError)
+
+  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
+  if (refreshError) console.error('[sync/eb] refresh_monthly_summary:', refreshError)
+
+  return NextResponse.json({ synced: totalSynced, accounts: accounts.length })
+}

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,16 @@
+import type { CategoryId } from '@/types'
+
+export const AUTO_RULES: { pattern: RegExp; category: CategoryId }[] = [
+  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski/i, category: 'groceries' },
+  { pattern: /netflix|spotify|hbo|disney|amazon prime/i,    category: 'leisure'   },
+  { pattern: /repsol|cepsa|bp\b|galp|campsa/i,              category: 'transport' },
+  { pattern: /farmacia|clinica|hospital|sanitas|adeslas/i,  category: 'health'    },
+  { pattern: /nomina|salario|payroll/i,                     category: 'income'    },
+]
+
+export function categorize(description: string): CategoryId | null {
+  for (const rule of AUTO_RULES) {
+    if (rule.pattern.test(description)) return rule.category
+  }
+  return null
+}

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -88,3 +88,72 @@ export async function createSessionFromCode(code: string): Promise<EBSession> {
 
   return res.json()
 }
+
+async function signJWTForSession(sessionId: string): Promise<string> {
+  const rawKey = (process.env.ENABLEBANKING_SECRET_KEY ?? '').replace(/\\n/g, '\n')
+  const key = await importPKCS8(rawKey, 'RS256')
+  return new SignJWT({ session_id: sessionId })
+    .setProtectedHeader({ alg: 'RS256', kid: process.env.ENABLEBANKING_APP_ID! })
+    .setIssuer('enablebanking.com')
+    .setAudience('api.enablebanking.com')
+    .setIssuedAt()
+    .setExpirationTime('60s')
+    .sign(key)
+}
+
+export interface EBTransaction {
+  transaction_id: string
+  booking_date: string
+  transaction_amount: { amount: string; currency: string }
+  credit_debit_indicator: 'CRDT' | 'DBIT'
+  remittance_information_unstructured?: string
+}
+
+export interface EBBalance {
+  balance_type: string
+  balance_amount: { amount: string; currency: string }
+}
+
+export async function getAccountTransactions(
+  accountUid: string,
+  sessionId: string,
+  dateFrom?: string
+): Promise<EBTransaction[]> {
+  const jwt = await signJWTForSession(sessionId)
+  const url = new URL(`${BASE_URL}/accounts/${accountUid}/transactions`)
+  if (dateFrom) url.searchParams.set('date_from', dateFrom)
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`EB getTransactions ${accountUid}: ${res.status} — ${body}`)
+  }
+
+  const data: { transactions?: EBTransaction[] } = await res.json()
+  return data.transactions ?? []
+}
+
+export async function getAccountBalance(
+  accountUid: string,
+  sessionId: string
+): Promise<number | null> {
+  const jwt = await signJWTForSession(sessionId)
+  const res = await fetch(`${BASE_URL}/accounts/${accountUid}/balances`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`EB getBalance ${accountUid}: ${res.status} — ${body}`)
+  }
+
+  const data: { balances?: EBBalance[] } = await res.json()
+  const chosen =
+    data.balances?.find(b => b.balance_type === 'closingBooked') ??
+    data.balances?.[0] ??
+    null
+  return chosen ? parseFloat(chosen.balance_amount.amount) : null
+}

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -102,11 +102,15 @@ async function signJWTForSession(sessionId: string): Promise<string> {
 }
 
 export interface EBTransaction {
-  transaction_id: string
+  entry_reference: string | null
+  transaction_id: string | null
   booking_date: string
   transaction_amount: { amount: string; currency: string }
   credit_debit_indicator: 'CRDT' | 'DBIT'
-  remittance_information_unstructured?: string
+  remittance_information: string[] | null
+  creditor: { name: string | null } | null
+  debtor: { name: string | null } | null
+  balance_after_transaction: { amount: string; currency: string } | null
 }
 
 export interface EBBalance {

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,0 +1,8 @@
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+
+export function createServiceClient() {
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "tunnel": "ngrok http --domain=decidable-rendering-propeller.ngrok-free.dev 3000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/supabase/migrations/20260507000000_sync_helpers.sql
+++ b/supabase/migrations/20260507000000_sync_helpers.sql
@@ -1,0 +1,46 @@
+-- Issue #15: Helper functions for Enable Banking transaction sync
+
+-- ============================================================
+-- FUNCTION: refresh_monthly_summary()
+-- Refreshes the materialized view used for analytics aggregation.
+-- CONCURRENTLY requires the unique index idx_monthly_unique (created in initial schema).
+-- ============================================================
+CREATE OR REPLACE FUNCTION refresh_monthly_summary()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary;
+END;
+$$;
+
+-- ============================================================
+-- FUNCTION: mark_internal_transfers(p_user_id UUID)
+-- Marks same-day opposite-amount enablebanking transaction pairs as internal
+-- transfers so they are excluded from analytics aggregation.
+-- Idempotent: skips already-marked rows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION mark_internal_transfers(p_user_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE transactions t
+  SET    is_internal_transfer = true
+  WHERE  t.user_id            = p_user_id
+    AND  t.source             = 'enablebanking'
+    AND  t.is_internal_transfer = false
+    AND  EXISTS (
+      SELECT 1
+      FROM   transactions t2
+      WHERE  t2.user_id              = p_user_id
+        AND  t2.source               = 'enablebanking'
+        AND  t2.is_internal_transfer = false
+        AND  t2.date                 = t.date
+        AND  t2.amount               = -t.amount
+        AND  t2.id                  <> t.id
+    );
+END;
+$$;


### PR DESCRIPTION
## Summary

- Nuevo endpoint `POST /api/sync/enablebanking` que obtiene transacciones y saldos de la API de Enable Banking para todas las cuentas activas del usuario, las persiste en Supabase (deduplicación por `external_id`) y actualiza balances y `last_synced`
- `lib/categories.ts` con reglas de auto-categorización por regex sobre la descripción del movimiento
- Extensión de `lib/enablebanking.ts` con `getAccountTransactions`, `getAccountBalance` y `signJWTForSession` (JWT con `session_id` en payload para endpoints de recursos)
- `lib/supabase/service.ts` — cliente con service role key para operaciones que requieren bypassear RLS
- Migración SQL con dos RPCs: `refresh_monthly_summary()` y `mark_internal_transfers(p_user_id)`

## Notas técnicas

- `ignoreDuplicates: true` en el upsert preserva `category_manual` del usuario en re-syncs
- La detección de transferencias internas busca pares mismo día con importes exactamente opuestos (`DECIMAL` exacto en PostgreSQL)
- Sync incremental: usa `last_synced` como `date_from` en llamadas a Enable Banking
- Cada cuenta falla de forma independiente (no aborta el sync de las demás)

## Pendiente antes de merge

- Aplicar migración en Supabase: `supabase/migrations/20260507000000_sync_helpers.sql`
- Verificar en entorno Vercel preview con banco real conectado
- Comprobar si Enable Banking pagina la respuesta de `/transactions` (añadir loop de paginación si necesario)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)