### PR TITLE
feat(accounts): pantalla de cuentas completa — API route, sync indicators, empty state

### DIFF
--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { Check } from 'lucide-react'
+import { Check, Landmark } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { AccountCard } from '@/components/accounts/AccountCard'
 import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
@@ -53,9 +53,26 @@ export default async function CuentasPage({
         </div>
       )}
 
-      {(accounts ?? []).map((account: Account) => (
-        <AccountCard key={account.id} account={account} />
-      ))}
+      {(accounts ?? []).length === 0 ? (
+        <div className="flex flex-col items-center text-center gap-3 py-10">
+          <div
+            className="size-16 rounded-[20px] flex items-center justify-center"
+            style={{ background: '#6366f115' }}
+          >
+            <Landmark className="size-7" style={{ color: '#6366f1' }} />
+          </div>
+          <div>
+            <div className="text-[15px] font-bold text-foreground">No tienes cuentas conectadas</div>
+            <div className="text-sm text-muted-foreground mt-1">
+              Conecta tu primer banco para empezar a ver tus finanzas
+            </div>
+          </div>
+        </div>
+      ) : (
+        (accounts ?? []).map((account: Account) => (
+          <AccountCard key={account.id} account={account} />
+        ))
+      )}
 
       <ConnectBankButton />
     </div>

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: accounts, error } = await supabase
+    .from('accounts')
+    .select('id, name, type, source, is_liability, balance, number, color, currency, last_synced, consent_expires_at, created_at')
+    .eq('user_id', user.id)
+    .eq('is_active', true)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('[GET /api/accounts]', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json(accounts ?? [])
+}

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,20 +1,42 @@
-import { Check } from 'lucide-react'
+import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
 import type { Account } from '@/types'
 
-function formatRelativeTime(iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime()
-  const hours = Math.floor(diffMs / 3_600_000)
-  if (hours < 1) return 'hace menos de 1 hora'
-  if (hours < 24) return `hace ${hours} hora${hours > 1 ? 's' : ''}`
-  const days = Math.floor(hours / 24)
-  return `hace ${days} día${days > 1 ? 's' : ''}`
+function getSyncStatus(iso: string | null): { label: string; color: string; Icon: typeof Check } {
+  if (!iso) return { label: 'Nunca sincronizado', color: 'var(--muted-foreground)', Icon: XCircle }
+  const hours = (Date.now() - new Date(iso).getTime()) / 3_600_000
+  const label =
+    hours < 1
+      ? 'hace menos de 1 hora'
+      : hours < 24
+        ? `hace ${Math.floor(hours)} hora${Math.floor(hours) > 1 ? 's' : ''}`
+        : `hace ${Math.floor(hours / 24)} día${Math.floor(hours / 24) > 1 ? 's' : ''}`
+  if (hours < 24) return { label, color: '#22c55e', Icon: Check }
+  if (hours < 72) return { label, color: '#f59e0b', Icon: AlertTriangle }
+  return { label, color: '#ef4444', Icon: XCircle }
+}
+
+function SourceBadge({ source }: { source: Account['source'] }) {
+  const config =
+    source === 'enablebanking'
+      ? { label: 'PSD2', bg: '#6366f122', color: '#6366f1' }
+      : source === 'scraper'
+        ? { label: 'Scraper', bg: '#f59e0b22', color: '#f59e0b' }
+        : { label: 'Manual', bg: '#64748b22', color: '#64748b' }
+  return (
+    <span
+      className="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+      style={{ background: config.bg, color: config.color }}
+    >
+      {config.label}
+    </span>
+  )
 }
 
 export function AccountCard({ account }: { account: Account }) {
   const color = account.color ?? '#6366f1'
-  const isPsd2 = account.source === 'enablebanking'
   const isNegative = (account.balance ?? 0) < 0
+  const { label: syncLabel, color: syncColor, Icon: SyncIcon } = getSyncStatus(account.last_synced)
 
   return (
     <div className="bg-card rounded-[20px] p-5 border border-border">
@@ -36,15 +58,7 @@ export function AccountCard({ account }: { account: Account }) {
           </div>
         </div>
 
-        <span
-          className="text-[11px] font-semibold px-2.5 py-1 rounded-full"
-          style={{
-            background: isPsd2 ? '#6366f122' : '#f59e0b22',
-            color: isPsd2 ? '#6366f1' : '#f59e0b',
-          }}
-        >
-          {isPsd2 ? 'PSD2' : 'Scraper'}
-        </span>
+        <SourceBadge source={account.source} />
       </div>
 
       <div className="flex items-end justify-between">
@@ -66,8 +80,8 @@ export function AccountCard({ account }: { account: Account }) {
       </div>
 
       <div className="mt-3.5 pt-3.5 border-t border-border text-[11px] text-muted-foreground flex items-center gap-1.5">
-        <Check className="size-3 shrink-0" style={{ color: '#22c55e' }} />
-        {account.last_synced ? formatRelativeTime(account.last_synced) : 'Nunca sincronizado'}
+        <SyncIcon className="size-3 shrink-0" style={{ color: syncColor }} />
+        <span style={{ color: syncColor }}>{syncLabel}</span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Resumen

Completa los gaps del issue #16 sobre la pantalla `/cuentas`:

- **`GET /api/accounts`** — nueva route con auth + query Supabase (id, name, type, source, is_liability, balance, number, color, currency, last_synced, consent_expires_at)
- **`AccountCard` mejorado** — indicadores de sincronización verde/ámbar/rojo según §8.3 del spec (< 24h / 24-72h / > 72h), badge "Manual" para cuentas de fuente manual
- **Empty state** — card con icono Landmark, texto explicativo y CTA cuando el usuario no tiene cuentas conectadas

La página y `ConnectBankButton` ya estaban implementados correctamente desde los issues #7 y #8.

## Test plan

- [ ] `/cuentas` con cuentas conectadas: ver cards con badge correcto (PSD2/Scraper/Manual) y color de sync apropiado
- [ ] Modificar `last_synced` en Supabase a >24h y >72h para verificar ámbar y rojo
- [ ] Probar con usuario sin cuentas: ver empty state + CTA "Conectar nueva cuenta"
- [ ] `GET /api/accounts` devuelve JSON array con las cuentas activas del usuario
- [ ] `GET /api/accounts` sin sesión devuelve 401

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)