### PR TITLE
feat(movimientos): pantalla de lista, búsqueda y filtros básicos (#17)

### DIFF
--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -1,8 +1,37 @@
-export default function MovimientosPage() {
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { MovimientosClient } from '@/components/transactions/MovimientosClient'
+import type { TransactionWithAccount } from '@/types'
+
+export default async function MovimientosPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - 90)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  const [{ data: transactions }, { data: accounts }] = await Promise.all([
+    supabase
+      .from('transactions')
+      .select('*, account:accounts(id, name, color)')
+      .eq('is_internal_transfer', false)
+      .gte('date', cutoffStr)
+      .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(200),
+    supabase
+      .from('accounts')
+      .select('id, name, color, number')
+      .eq('is_active', true)
+      .order('created_at', { ascending: true }),
+  ])
+
   return (
-    <div className="px-6 pt-14">
-      <h1 className="text-lg font-bold text-foreground">Movimientos</h1>
-      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
-    </div>
+    <MovimientosClient
+      initialTransactions={(transactions ?? []) as TransactionWithAccount[]}
+      accounts={accounts ?? []}
+    />
   )
 }

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -30,22 +30,39 @@ export async function GET(request: NextRequest) {
     const iban = acc.account_id?.iban ?? null
     const lastFour = iban ? iban.replace(/\s/g, '').slice(-4) : null
 
-    await supabase.from('accounts').upsert(
-      {
-        user_id: user.id,
-        name: acc.name ?? 'Cuenta bancaria',
-        type: 'bank',
-        source: 'enablebanking',
-        balance: null,
-        number: lastFour ? `•••• ${lastFour}` : null,
-        currency: acc.currency ?? 'EUR',
-        external_id: acc.uid,
-        session_id: session.session_id,
-        consent_expires_at: session.access.valid_until,
-        is_active: true,
-      },
-      { onConflict: 'user_id,external_id' }
-    )
+    const accountData = {
+      user_id: user.id,
+      name: acc.product ?? acc.name ?? 'Cuenta bancaria',
+      type: 'bank' as const,
+      source: 'enablebanking' as const,
+      number: lastFour ? `•••• ${lastFour}` : null,
+      iban,
+      currency: acc.currency ?? 'EUR',
+      external_id: acc.uid,
+      session_id: session.session_id,
+      consent_expires_at: session.access.valid_until,
+      is_active: true,
+    }
+
+    if (iban) {
+      const { data: existing } = await supabase
+        .from('accounts')
+        .select('id')
+        .eq('user_id', user.id)
+        .eq('iban', iban)
+        .maybeSingle()
+
+      if (existing) {
+        await supabase.from('accounts').update(accountData).eq('id', existing.id)
+      } else {
+        await supabase.from('accounts').insert({ ...accountData, balance: null })
+      }
+    } else {
+      await supabase.from('accounts').upsert(
+        { ...accountData, balance: null },
+        { onConflict: 'user_id,external_id' }
+      )
+    }
   }
 
   await supabase

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = request.nextUrl
+  const type = searchParams.get('type') ?? 'todos'
+  const accountsParam = searchParams.get('accounts')
+  const limit = Math.min(Number(searchParams.get('limit') ?? '200'), 500)
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - 90)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  let query = supabase
+    .from('transactions')
+    .select('*, account:accounts(id, name, color)')
+    .eq('user_id', user.id)
+    .eq('is_internal_transfer', false)
+    .gte('date', cutoffStr)
+    .order('date', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (type === 'ingresos') {
+    query = query.gt('amount', 0).eq('is_computable', true)
+  } else if (type === 'gastos') {
+    query = query.lt('amount', 0).eq('is_computable', true)
+  } else if (type === 'no-computable') {
+    query = query.eq('is_computable', false)
+  }
+
+  if (accountsParam) {
+    const ids = accountsParam.split(',').filter(Boolean)
+    if (ids.length > 0) query = query.in('account_id', ids)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    console.error('[GET /api/transactions]', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data: data ?? [], meta: { count: data?.length ?? 0 } })
+}

--- a/components/transactions/AccountFilter.tsx
+++ b/components/transactions/AccountFilter.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+import { Box } from 'lucide-react'
+import type { Account } from '@/types'
+
+interface AccountFilterProps {
+  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
+  selectedIds: string[]
+  onSelectionChange: (ids: string[]) => void
+  onClose: () => void
+}
+
+export function AccountFilter({ accounts, selectedIds, onSelectionChange, onClose }: AccountFilterProps) {
+  const allSelected = selectedIds.length === 0
+
+  function toggleAccount(id: string) {
+    if (selectedIds.includes(id)) {
+      const next = selectedIds.filter(s => s !== id)
+      onSelectionChange(next)
+    } else {
+      onSelectionChange([...selectedIds, id])
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', zIndex: 300 }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full mx-auto bg-popover flex flex-col"
+        style={{
+          maxWidth: 420,
+          borderRadius: '28px 28px 0 0',
+          padding: '20px 20px 40px',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Drag handle */}
+        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+
+        <p className="text-base font-bold text-foreground mb-0.5">Filtrar por cuenta</p>
+        <p className="text-xs text-muted-foreground mb-4">Selecciona una o varias cuentas</p>
+
+        <div className="flex flex-col gap-2">
+          {/* Todas las cuentas */}
+          <button
+            className="flex items-center gap-3 px-4 py-3 rounded-2xl text-left transition-colors"
+            style={{
+              background: allSelected ? 'rgba(99,102,241,0.08)' : 'var(--muted)',
+              borderLeft: allSelected ? '3px solid #6366f1' : '3px solid transparent',
+            }}
+            onClick={() => { onSelectionChange([]); onClose() }}
+          >
+            <div
+              className="flex items-center justify-center rounded-[10px] shrink-0"
+              style={{ width: 34, height: 34, background: 'var(--border)' }}
+            >
+              <Box size={15} style={{ color: 'var(--muted-foreground)' }} strokeWidth={2} />
+            </div>
+            <span className="flex-1 text-sm font-semibold text-foreground">Todas las cuentas</span>
+            {allSelected && (
+              <div
+                className="rounded-md flex items-center justify-center shrink-0"
+                style={{ width: 20, height: 20, background: '#6366f1' }}
+              >
+                <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                  <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </div>
+            )}
+          </button>
+
+          {/* Account list */}
+          {accounts.map(account => {
+            const isSelected = selectedIds.includes(account.id)
+            const color = account.color ?? '#6366f1'
+            const maskedNumber = account.number ? `•••• ${account.number.slice(-4)}` : null
+
+            return (
+              <button
+                key={account.id}
+                className="flex items-center gap-3 px-4 py-3 rounded-2xl text-left transition-colors"
+                style={{
+                  background: isSelected ? 'rgba(99,102,241,0.08)' : 'var(--muted)',
+                  borderLeft: isSelected ? '3px solid #6366f1' : '3px solid transparent',
+                }}
+                onClick={() => toggleAccount(account.id)}
+              >
+                <div
+                  className="flex items-center justify-center rounded-[10px] shrink-0"
+                  style={{ width: 34, height: 34, background: color + '22' }}
+                >
+                  <div className="rounded" style={{ width: 14, height: 14, background: color }} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-foreground truncate">{account.name}</p>
+                  {maskedNumber && (
+                    <p className="text-[11px] text-muted-foreground">{maskedNumber}</p>
+                  )}
+                </div>
+                <div
+                  className="rounded-md shrink-0 flex items-center justify-center"
+                  style={{
+                    width: 20,
+                    height: 20,
+                    background: isSelected ? '#6366f1' : 'transparent',
+                    border: isSelected ? 'none' : '1.5px solid var(--border)',
+                  }}
+                >
+                  {isSelected && (
+                    <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                      <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useState } from 'react'
+import { Search, X, ChevronDown, Box } from 'lucide-react'
+import { TxRow } from './TxRow'
+import { AccountFilter } from './AccountFilter'
+import { CATEGORY_META } from '@/lib/theme'
+import { fmt } from '@/lib/formatting'
+import type { Account, CategoryId, TransactionWithAccount } from '@/types'
+
+type TypeFilter = 'todos' | 'ingresos' | 'gastos' | 'no-computable'
+
+const TYPE_PILLS: { key: TypeFilter; label: string }[] = [
+  { key: 'todos', label: 'Todos' },
+  { key: 'ingresos', label: 'Ingresos' },
+  { key: 'gastos', label: 'Gastos' },
+  { key: 'no-computable', label: 'No Computable' },
+]
+
+interface MovimientosClientProps {
+  initialTransactions: TransactionWithAccount[]
+  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
+}
+
+function formatDayLabel(dateStr: string): string {
+  const today = new Date().toISOString().slice(0, 10)
+  const yest = new Date()
+  yest.setDate(yest.getDate() - 1)
+  const yesterdayStr = yest.toISOString().slice(0, 10)
+  if (dateStr === today) return 'Hoy'
+  if (dateStr === yesterdayStr) return 'Ayer'
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+  return `${d} ${MONTHS[m - 1]} ${y}`
+}
+
+export function MovimientosClient({ initialTransactions, accounts }: MovimientosClientProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
+  const [showAccountFilter, setShowAccountFilter] = useState(false)
+
+  // Derived: account button label
+  const accountLabel =
+    selectedAccountIds.length === 0
+      ? 'Todas las cuentas'
+      : selectedAccountIds.length === 1
+        ? (accounts.find(a => a.id === selectedAccountIds[0])?.name ?? '1 cuenta')
+        : `${selectedAccountIds.length} cuentas`
+
+  // Client-side filtering
+  let filtered = initialTransactions
+
+  if (selectedAccountIds.length > 0) {
+    filtered = filtered.filter(tx => selectedAccountIds.includes(tx.account_id))
+  }
+
+  if (typeFilter === 'ingresos') {
+    filtered = filtered.filter(tx => tx.amount > 0 && tx.is_computable)
+  } else if (typeFilter === 'gastos') {
+    filtered = filtered.filter(tx => tx.amount < 0 && tx.is_computable)
+  } else if (typeFilter === 'no-computable') {
+    filtered = filtered.filter(tx => !tx.is_computable)
+  }
+
+  if (searchQuery.trim()) {
+    const q = searchQuery.trim().toLowerCase()
+    filtered = filtered.filter(tx => {
+      if (tx.description.toLowerCase().includes(q)) return true
+      const cat = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+      const label = CATEGORY_META[cat]?.label ?? ''
+      return label.toLowerCase().includes(q)
+    })
+  }
+
+  // Group by date
+  const groups = new Map<string, { transactions: TransactionWithAccount[]; net: number }>()
+  for (const tx of filtered) {
+    const existing = groups.get(tx.date)
+    if (existing) {
+      existing.transactions.push(tx)
+      existing.net += tx.amount
+    } else {
+      groups.set(tx.date, { transactions: [tx], net: tx.amount })
+    }
+  }
+
+  const sortedDates = Array.from(groups.keys()).sort((a, b) => b.localeCompare(a))
+
+  return (
+    <div className="px-5 pt-14 pb-6 flex flex-col gap-4">
+      <h1 className="text-xl font-bold text-foreground">Movimientos</h1>
+
+      {/* Search */}
+      <div
+        className="flex items-center gap-2 px-3.5 py-2.5 rounded-[14px] bg-muted"
+        style={{ border: '1px solid var(--border)' }}
+      >
+        <Search size={16} className="text-muted-foreground shrink-0" />
+        <input
+          type="text"
+          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+          placeholder="Buscar por descripción o categoría…"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+        />
+        {searchQuery && (
+          <button onClick={() => setSearchQuery('')} className="text-muted-foreground hover:text-foreground shrink-0">
+            <X size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* Account filter button — full width */}
+      <button
+        className="w-full flex items-center justify-between px-3.5 py-2.5 rounded-[14px] transition-colors"
+        style={{
+          background: selectedAccountIds.length > 0 ? 'rgba(99,102,241,0.1)' : 'var(--muted)',
+          border: selectedAccountIds.length > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border)',
+        }}
+        onClick={() => setShowAccountFilter(true)}
+      >
+        <div className="flex items-center gap-2">
+          <Box size={14} style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }} strokeWidth={2} />
+          <span
+            className="text-sm font-semibold"
+            style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }}
+          >
+            {accountLabel}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {selectedAccountIds.length > 0 && (
+            <span
+              className="rounded-full text-[10px] font-bold px-1.5 py-0.5 leading-none"
+              style={{ background: '#6366f1', color: 'white' }}
+            >
+              {selectedAccountIds.length}
+            </span>
+          )}
+          <ChevronDown size={12} className="text-muted-foreground" />
+        </div>
+      </button>
+
+      {/* Type pills */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-0.5">
+        {TYPE_PILLS.map(pill => (
+          <button
+            key={pill.key}
+            className="px-3.5 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0"
+            style={{
+              background: typeFilter === pill.key ? '#6366f1' : 'var(--muted)',
+              color: typeFilter === pill.key ? 'white' : 'var(--muted-foreground)',
+            }}
+            onClick={() => setTypeFilter(pill.key)}
+          >
+            {pill.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Transaction list */}
+      {sortedDates.length === 0 ? (
+        <div className="flex items-center justify-center py-16">
+          <p className="text-sm text-muted-foreground text-center">No hay movimientos con estos filtros</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {sortedDates.map(date => {
+            const group = groups.get(date)!
+            const net = group.net
+            const netStr = (net >= 0 ? '+' : '') + fmt(net, 2) + ' €'
+            const netColor = net >= 0 ? '#22c55e' : 'var(--foreground)'
+
+            return (
+              <div key={date} className="flex flex-col gap-0.5">
+                {/* Day header */}
+                <div className="flex items-center justify-between px-3 pb-1">
+                  <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
+                    {formatDayLabel(date)}
+                  </span>
+                  <span className="text-xs font-bold" style={{ color: netColor }}>
+                    {netStr}
+                  </span>
+                </div>
+
+                {/* Transactions */}
+                <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+                  {group.transactions.map(tx => (
+                    <TxRow key={tx.id} tx={tx} />
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Account filter bottom sheet */}
+      {showAccountFilter && (
+        <AccountFilter
+          accounts={accounts}
+          selectedIds={selectedAccountIds}
+          onSelectionChange={setSelectedAccountIds}
+          onClose={() => setShowAccountFilter(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -1,0 +1,50 @@
+import { CATEGORY_META } from '@/lib/theme'
+import { fmt } from '@/lib/formatting'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+interface TxRowProps {
+  tx: TransactionWithAccount
+}
+
+export function TxRow({ tx }: TxRowProps) {
+  const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+  const meta = CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other
+  const Icon = meta.Icon
+
+  const absAmount = fmt(Math.abs(tx.amount), 2)
+  const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
+  const amountColor = tx.amount > 0 ? '#22c55e' : '#ef4444'
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5 rounded-2xl hover:bg-muted/40 transition-colors">
+      <div
+        className="flex items-center justify-center rounded-[14px] shrink-0"
+        style={{
+          width: 42,
+          height: 42,
+          background: meta.color + '18',
+        }}
+      >
+        <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
+        <div className="flex items-center gap-1 mt-0.5">
+          <span
+            className="rounded-full shrink-0"
+            style={{ width: 7, height: 7, background: meta.color }}
+          />
+          <span className="text-[11px] text-muted-foreground truncate">{meta.label}</span>
+        </div>
+      </div>
+
+      <span
+        className="text-[15px] font-bold shrink-0"
+        style={{ color: amountColor }}
+      >
+        {amountStr}
+      </span>
+    </div>
+  )
+}

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -23,6 +23,7 @@ export interface EBAccount {
   uid: string
   account_id: { iban: string | null } | null
   name: string | null
+  product: string | null
   currency: string
 }
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,3 +1,5 @@
+import { ShoppingCart, UtensilsCrossed, Car, Home, Gamepad2, ShoppingBag, HeartPulse, TrendingUp, MoreHorizontal } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import type { CategoryId } from '@/types'
 
 interface ThemeColors {
@@ -52,6 +54,24 @@ export const CATEGORY_COLORS: Record<CategoryId, string> = {
   health: '#10b981',
   income: '#3b82f6',
   other: '#64748b',
+}
+
+interface CategoryMeta {
+  label: string
+  color: string
+  Icon: LucideIcon
+}
+
+export const CATEGORY_META: Record<CategoryId, CategoryMeta> = {
+  groceries:  { label: 'Supermercado', color: '#22c55e', Icon: ShoppingCart    },
+  restaurant: { label: 'Restaurante',  color: '#f59e0b', Icon: UtensilsCrossed },
+  transport:  { label: 'Transporte',   color: '#8b5cf6', Icon: Car             },
+  home:       { label: 'Hogar',        color: '#06b6d4', Icon: Home            },
+  leisure:    { label: 'Ocio',         color: '#ef4444', Icon: Gamepad2        },
+  shopping:   { label: 'Compras',      color: '#ec4899', Icon: ShoppingBag     },
+  health:     { label: 'Salud',        color: '#10b981', Icon: HeartPulse      },
+  income:     { label: 'Ingresos',     color: '#3b82f6', Icon: TrendingUp      },
+  other:      { label: 'Otros',        color: '#64748b', Icon: MoreHorizontal  },
 }
 
 export const GRADIENTS = {

--- a/supabase/migrations/20260508000000_accounts_iban.sql
+++ b/supabase/migrations/20260508000000_accounts_iban.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS iban TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS accounts_user_iban_unique
+  ON accounts (user_id, iban)
+  WHERE iban IS NOT NULL;

--- a/types/index.ts
+++ b/types/index.ts
@@ -53,6 +53,10 @@ export interface Category {
   color: string
 }
 
+export interface TransactionWithAccount extends Transaction {
+  account: Pick<Account, 'id' | 'name' | 'color'>
+}
+
 export interface UserConfig {
   user_id: string
   has_onboarded: boolean


### PR DESCRIPTION
## Resumen

- Pantalla `/movimientos` con lista de transacciones agrupadas por día, neto diario, buscador local y filtros de tipo + cuenta
- `GET /api/transactions` con filtros `?type=` y `?accounts=` server-side
- Componentes `TxRow`, `AccountFilter` (via portal para z-index correcto), `MovimientosClient`
- `CATEGORY_META` con iconos Lucide y colores por categoría
- Deduplicación de cuentas bancarias por IBAN (migración + lógica en callback)
- `product` como nombre de cuenta en Enable Banking en lugar del nombre del titular

## Notas técnicas

- `AccountFilter` usa `createPortal` para evitar el stacking context creado por `animate-fade-in` en `<main>`
- Filtrado y agrupación por día en cliente (dataset acotado a 90 días)
- Migración `20260508000000_accounts_iban.sql` añade columna `iban` con índice único `(user_id, iban)`

## Plan de pruebas

- [ ] Aplicar migración SQL en Supabase
- [ ] Sincronizar transacciones y verificar lista agrupada por día
- [ ] Buscador no pierde foco al escribir
- [ ] Pills de tipo filtran correctamente
- [ ] Bottom sheet de cuentas aparece por encima del NavBar
- [ ] Reconectar banco no crea duplicados (deduplicación por IBAN)
- [ ] `pnpm build` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)