### PR TITLE
feat(dashboard): balance total, sparkline SVG y grid de cuentas (#22)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import { ThemeToggle } from '@/components/theme-toggle'
+import { getDashboardData } from '@/lib/dashboard'
+import { DashboardBalanceCard } from '@/components/dashboard/DashboardBalanceCard'
+import { DashboardAccountGrid } from '@/components/dashboard/DashboardAccountGrid'
 
 export default async function HomePage() {
   const supabase = await createClient()
@@ -16,12 +18,16 @@ export default async function HomePage() {
     if (!config?.has_onboarded) redirect('/onboarding')
   }
 
+  const { balance, weeklyDelta, dailyBalances, accounts } = await getDashboardData()
+
   return (
-    <div className="px-6 pt-14 flex flex-col gap-4">
-      <div className="flex justify-end">
-        <ThemeToggle />
-      </div>
-      <p className="text-muted-foreground text-sm">Dashboard — próximamente</p>
+    <div className="px-4 pt-12 pb-6 flex flex-col gap-4">
+      <DashboardBalanceCard
+        balance={balance}
+        weeklyDelta={weeklyDelta}
+        dailyBalances={dailyBalances}
+      />
+      <DashboardAccountGrid accounts={accounts} />
     </div>
   )
 }

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getDashboardData } from '@/lib/dashboard'
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const data = await getDashboardData()
+    return NextResponse.json(data)
+  } catch (e) {
+    console.error('[GET /api/dashboard]', e)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+}

--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link'
+import { fmt } from '@/lib/formatting'
+import type { Account, AccountType } from '@/types'
+
+const typeLabel: Record<AccountType, string> = {
+  bank:     'Cuenta',
+  card:     'Tarjeta',
+  edenred:  'Edenred',
+  cash:     'Efectivo',
+}
+
+function AccountMiniCard({ account }: { account: Account }) {
+  const color = account.color ?? '#6366f1'
+  const balance = account.balance ?? 0
+  const isNegative = balance < 0
+
+  return (
+    <Link
+      href="/cuentas"
+      className="block bg-card rounded-[16px] p-3.5 border border-border active:opacity-70 transition-opacity"
+    >
+      <div className="flex items-center justify-between mb-2.5">
+        <div
+          className="size-8 rounded-[10px] flex items-center justify-center"
+          style={{ background: color + '22' }}
+        >
+          <div className="size-3 rounded-[3px]" style={{ background: color }} />
+        </div>
+        <span className="text-[9px] font-bold text-muted-foreground uppercase tracking-wide">
+          {typeLabel[account.type]}
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground truncate mb-0.5">{account.name}</div>
+      <div
+        className="text-[17px] font-bold leading-tight"
+        style={{ color: isNegative ? '#ef4444' : undefined }}
+      >
+        {fmt(balance, 2)} €
+      </div>
+      {account.number && (
+        <div className="text-[10px] text-muted-foreground mt-0.5">{account.number}</div>
+      )}
+    </Link>
+  )
+}
+
+interface DashboardAccountGridProps {
+  accounts: Account[]
+}
+
+export function DashboardAccountGrid({ accounts }: DashboardAccountGridProps) {
+  if (accounts.length === 0) return null
+
+  return (
+    <div>
+      <div className="text-[13px] font-semibold text-muted-foreground mb-3">Mis cuentas</div>
+      <div className="grid grid-cols-2 gap-3">
+        {accounts.map(account => (
+          <AccountMiniCard key={account.id} account={account} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -1,4 +1,3 @@
-import { TrendingUp, TrendingDown } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
 import { Sparkline } from './Sparkline'
 
@@ -10,27 +9,54 @@ interface DashboardBalanceCardProps {
 
 export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: DashboardBalanceCardProps) {
   const isPositive = weeklyDelta >= 0
-  const DeltaIcon = isPositive ? TrendingUp : TrendingDown
-  const deltaColor = isPositive ? '#4ade80' : '#fca5a5'
+  const deltaSign = isPositive ? '+' : ''
+  // Pill colors matching prototype: green tint for positive, red tint for negative
+  const pillColor    = isPositive ? '#a7f3d0' : '#fca5a5'
+  const pillBg       = isPositive ? 'rgba(167,243,208,0.18)' : 'rgba(252,165,165,0.18)'
+  const deltaArrow   = isPositive ? '↑' : '↓'
 
   return (
     <div
-      className="rounded-3xl px-5 pt-5 overflow-hidden"
-      style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
+      className="rounded-3xl overflow-hidden relative"
+      style={{
+        background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a78bfa 100%)',
+        boxShadow: '0 20px 60px rgba(99,102,241,0.35)',
+      }}
     >
-      <div className="text-[13px] font-medium text-white/70 mb-1">Balance total</div>
-      <div className="text-[36px] font-extrabold text-white tracking-tight leading-none mb-3">
-        {fmt(balance, 2)} €
-      </div>
-      <div className="flex items-center gap-1.5 mb-4">
-        <DeltaIcon className="size-3.5" style={{ color: deltaColor }} />
-        <span className="text-[13px] font-semibold" style={{ color: deltaColor }}>
-          {isPositive ? '+' : ''}{fmt(weeklyDelta, 2)} € esta semana
-        </span>
-      </div>
-      <Sparkline data={dailyBalances} />
-      <div className="text-[10px] mt-1 pb-4" style={{ color: 'rgba(255,255,255,0.55)' }}>
-        Últimos 30 días
+      {/* Decorative bubbles */}
+      <div
+        className="absolute rounded-full pointer-events-none"
+        style={{ top: -20, right: -20, width: 120, height: 120, background: 'rgba(255,255,255,0.08)' }}
+      />
+      <div
+        className="absolute rounded-full pointer-events-none"
+        style={{ bottom: -30, left: 40, width: 80, height: 80, background: 'rgba(255,255,255,0.05)' }}
+      />
+
+      {/* Content */}
+      <div className="relative z-10 px-6 pt-6">
+        <div className="text-[12px] font-medium mb-1.5" style={{ color: 'rgba(255,255,255,0.7)' }}>
+          Balance total
+        </div>
+        <div className="text-[36px] font-extrabold text-white tracking-tight leading-none mb-1">
+          {fmt(balance, 2)} €
+        </div>
+
+        {/* Weekly delta pill */}
+        <div className="flex items-center gap-2 mb-3.5">
+          <span
+            className="text-[12px] font-bold px-2 py-0.5 rounded-full"
+            style={{ color: pillColor, background: pillBg }}
+          >
+            {deltaArrow} {deltaSign}{fmt(weeklyDelta, 2)} €
+          </span>
+          <span className="text-[11px]" style={{ color: 'rgba(255,255,255,0.7)' }}>esta semana</span>
+        </div>
+
+        <Sparkline data={dailyBalances} />
+        <div className="text-[10px] mt-1 pb-5" style={{ color: 'rgba(255,255,255,0.55)' }}>
+          Últimos 30 días
+        </div>
       </div>
     </div>
   )

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -15,7 +15,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
 
   return (
     <div
-      className="rounded-[24px] px-5 pt-5 overflow-hidden"
+      className="rounded-3xl px-5 pt-5 overflow-hidden"
       style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
     >
       <div className="text-[13px] font-medium text-white/70 mb-1">Balance total</div>
@@ -29,6 +29,9 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
         </span>
       </div>
       <Sparkline data={dailyBalances} />
+      <div className="text-[10px] mt-1 pb-4" style={{ color: 'rgba(255,255,255,0.55)' }}>
+        Últimos 30 días
+      </div>
     </div>
   )
 }

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -1,0 +1,34 @@
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { fmt } from '@/lib/formatting'
+import { Sparkline } from './Sparkline'
+
+interface DashboardBalanceCardProps {
+  balance: number
+  weeklyDelta: number
+  dailyBalances: number[]
+}
+
+export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: DashboardBalanceCardProps) {
+  const isPositive = weeklyDelta >= 0
+  const DeltaIcon = isPositive ? TrendingUp : TrendingDown
+  const deltaColor = isPositive ? '#4ade80' : '#fca5a5'
+
+  return (
+    <div
+      className="rounded-[24px] px-5 pt-5 overflow-hidden"
+      style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
+    >
+      <div className="text-[13px] font-medium text-white/70 mb-1">Balance total</div>
+      <div className="text-[36px] font-extrabold text-white tracking-tight leading-none mb-3">
+        {fmt(balance, 2)} €
+      </div>
+      <div className="flex items-center gap-1.5 mb-4">
+        <DeltaIcon className="size-3.5" style={{ color: deltaColor }} />
+        <span className="text-[13px] font-semibold" style={{ color: deltaColor }}>
+          {isPositive ? '+' : ''}{fmt(weeklyDelta, 2)} € esta semana
+        </span>
+      </div>
+      <Sparkline data={dailyBalances} />
+    </div>
+  )
+}

--- a/components/dashboard/Sparkline.tsx
+++ b/components/dashboard/Sparkline.tsx
@@ -1,0 +1,48 @@
+interface SparklineProps {
+  data: number[]
+}
+
+export function Sparkline({ data }: SparklineProps) {
+  const points = data.length > 0 ? data : [0]
+  const min = Math.min(...points)
+  const max = Math.max(...points)
+  const range = max - min || 1
+  const w = 300, h = 40, pad = 4
+
+  const coords = points.map((v, i) => {
+    const x = points.length > 1 ? (i / (points.length - 1)) * w : w / 2
+    const y = h - pad - ((v - min) / range) * (h - 2 * pad)
+    return [x, y] as [number, number]
+  })
+
+  const linePath = coords
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`)
+    .join(' ')
+  const areaPath = `${linePath} L${w},${h} L0,${h} Z`
+
+  return (
+    <svg
+      width="100%"
+      height="40"
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      style={{ display: 'block' }}
+    >
+      <defs>
+        <linearGradient id="sparkGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.4)" />
+          <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill="url(#sparkGrad)" />
+      <path
+        d={linePath}
+        fill="none"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,69 @@
+import { createClient } from '@/lib/supabase/server'
+import type { Account } from '@/types'
+
+export interface DashboardData {
+  balance: number
+  weeklyDelta: number
+  dailyBalances: number[]
+  accounts: Account[]
+}
+
+export async function getDashboardData(): Promise<DashboardData> {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Unauthorized')
+
+  const { data: accounts, error: accError } = await supabase
+    .from('accounts')
+    .select('id, name, type, is_liability, balance, number, color, currency, source, last_synced, consent_expires_at, created_at, user_id, external_id, session_id, is_active')
+    .eq('user_id', user.id)
+    .eq('is_active', true)
+    .order('created_at', { ascending: true })
+
+  if (accError || !accounts) throw new Error('Failed to fetch accounts')
+
+  const assets = accounts.filter(a => !a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
+  const liabs  = accounts.filter(a =>  a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
+  const balance = assets - Math.abs(liabs)
+
+  const thirtyDaysAgo = new Date()
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 29)
+  thirtyDaysAgo.setHours(0, 0, 0, 0)
+
+  const { data: transactions, error: txError } = await supabase
+    .from('transactions')
+    .select('date, amount')
+    .eq('user_id', user.id)
+    .eq('is_computable', true)
+    .eq('is_internal_transfer', false)
+    .gte('date', thirtyDaysAgo.toISOString())
+
+  if (txError) throw new Error('Failed to fetch transactions')
+
+  // Build 30-day array of dates (oldest → newest)
+  const today = new Date()
+  const days = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(today)
+    d.setDate(d.getDate() - (29 - i))
+    return d.toISOString().split('T')[0]
+  })
+
+  // Aggregate transaction amounts by calendar day
+  const txByDay: Record<string, number> = {}
+  for (const tx of transactions ?? []) {
+    const day = tx.date.split('T')[0]
+    txByDay[day] = (txByDay[day] ?? 0) + tx.amount
+  }
+
+  // Reconstruct historical net balance working backwards from today
+  const dailyBalances: number[] = new Array(30)
+  dailyBalances[29] = balance
+  for (let i = 28; i >= 0; i--) {
+    dailyBalances[i] = dailyBalances[i + 1] - (txByDay[days[i + 1]] ?? 0)
+  }
+
+  // Index 22 = 7 days ago (29 - 7 = 22)
+  const weeklyDelta = balance - dailyBalances[22]
+
+  return { balance, weeklyDelta, dailyBalances, accounts: accounts as Account[] }
+}


### PR DESCRIPTION
## Resumen

- API route `GET /api/dashboard` que devuelve patrimonio neto, delta semanal y 30 puntos de balance diario para la sparkline
- `lib/dashboard.ts` con `getDashboardData()` compartido entre la page y la API route (evita fetch HTTP servidor→servidor)
- `Sparkline.tsx` en SVG puro (sin Recharts) fiel al prototipo: área con gradiente + línea blanca
- `DashboardBalanceCard` con gradiente indigo-violet, balance formateado con `fmt()` e indicador ↑/↓ de delta semanal
- `DashboardAccountGrid` grid 2×2 de mini-cards con navegación a `/cuentas` vía `<Link>`

## Detalles técnicos

- Balance = activos − |pasivos| según §5.5 del spec
- Balance diario: reconstrucción hacia atrás desde el balance actual usando transacciones (`is_computable=true`, `is_internal_transfer=false`)
- `weeklyDelta = balance_hoy − balance_hace_7_días`
- Server Components en toda la cadena; sin `'use client'`
- `overflow: clip` respetado (viene del layout padre)

## Test plan

- [ ] Navegar a `/` y verificar que aparece la card de balance con la sparkline
- [ ] Comprobar que el patrimonio neto refleja activos − |pasivos| (las tarjetas de crédito restan)
- [ ] Verificar que el delta semanal muestra ↑ en verde o ↓ en rojo según corresponda
- [ ] Comprobar que el grid muestra todas las cuentas activas con saldo correcto
- [ ] Tap en cualquier cuenta navega a `/cuentas`
- [ ] Sin scroll horizontal — `overflow: clip` operativo

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)