### PR TITLE
feat(dashboard): gráfica de patrimonio neto 12 meses (#23)

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { getDashboardData } from '@/lib/dashboard'
 import { DashboardBalanceCard } from '@/components/dashboard/DashboardBalanceCard'
 import { DashboardAccountGrid } from '@/components/dashboard/DashboardAccountGrid'
+import { PatrimonioChart } from '@/components/dashboard/PatrimonioChart'
 
 export default async function HomePage() {
   const supabase = await createClient()
@@ -18,7 +19,7 @@ export default async function HomePage() {
     if (!config?.has_onboarded) redirect('/onboarding')
   }
 
-  const { balance, weeklyDelta, dailyBalances, accounts } = await getDashboardData()
+  const { balance, weeklyDelta, dailyBalances, accounts, patrimonioData, annualDelta } = await getDashboardData()
 
   return (
     <div className="px-4 pt-12 pb-6 flex flex-col gap-4">
@@ -27,6 +28,7 @@ export default async function HomePage() {
         weeklyDelta={weeklyDelta}
         dailyBalances={dailyBalances}
       />
+      <PatrimonioChart data={patrimonioData} annualDelta={annualDelta} />
       <DashboardAccountGrid accounts={accounts} />
     </div>
   )

--- a/components/dashboard/PatrimonioChart.tsx
+++ b/components/dashboard/PatrimonioChart.tsx
@@ -1,0 +1,65 @@
+'use client'
+import { AreaChart, Area, XAxis, ResponsiveContainer, Tooltip } from 'recharts'
+import { fmt } from '@/lib/formatting'
+
+interface Props {
+  data: { label: string; value: number }[]
+  annualDelta: number | null
+}
+
+export function PatrimonioChart({ data, annualDelta }: Props) {
+  return (
+    <div className="bg-card rounded-[24px] p-6 border border-border">
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-[15px] font-bold">Patrimonio neto</span>
+        {annualDelta !== null ? (
+          <span className={`text-[11px] font-bold px-2.5 py-0.5 rounded-full ${
+            annualDelta >= 0
+              ? 'text-emerald-600 bg-emerald-500/10'
+              : 'text-red-500 bg-red-500/10'
+          }`}>
+            {annualDelta >= 0 ? '↑' : '↓'} {annualDelta >= 0 ? '+' : ''}
+            {fmt(annualDelta)} € vs hace 12 meses
+          </span>
+        ) : (
+          <span className="text-[11px] text-muted-foreground px-2.5 py-0.5">
+            — vs hace 12 meses
+          </span>
+        )}
+      </div>
+      <p className="text-[12px] text-muted-foreground mb-3.5">
+        Últimos {data.length} {data.length === 1 ? 'mes' : 'meses'}
+      </p>
+      <ResponsiveContainer width="100%" height={80}>
+        <AreaChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 4 }}>
+          <defs>
+            <linearGradient id="patrimonioGrad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#6366f1" stopOpacity={0.18} />
+              <stop offset="100%" stopColor="#6366f1" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 9, fill: 'rgba(0,0,0,0.35)' }}
+            tickLine={false}
+            axisLine={false}
+            interval="preserveStartEnd"
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="#6366f1"
+            strokeWidth={2.5}
+            fill="url(#patrimonioGrad)"
+            dot={false}
+            activeDot={{ r: 4, fill: '#6366f1' }}
+          />
+          <Tooltip
+            formatter={(v) => [typeof v === 'number' ? `${fmt(v)} €` : '—', 'Patrimonio']}
+            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid rgba(0,0,0,0.08)' }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -6,6 +6,8 @@ export interface DashboardData {
   weeklyDelta: number
   dailyBalances: number[]
   accounts: Account[]
+  patrimonioData: { label: string; value: number }[]
+  annualDelta: number | null
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
@@ -65,5 +67,46 @@ export async function getDashboardData(): Promise<DashboardData> {
   // Index 22 = 7 days ago (29 - 7 = 22)
   const weeklyDelta = balance - dailyBalances[22]
 
-  return { balance, weeklyDelta, dailyBalances, accounts: accounts as Account[] }
+  // ── Patrimonio neto mensual (últimos 12 meses) ────────────────────────────
+  const twelveMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 11, 1)
+
+  const { data: monthlyTxData } = await supabase
+    .from('transactions')
+    .select('date, amount')
+    .eq('user_id', user.id)
+    .eq('is_computable', true)
+    .eq('is_internal_transfer', false)
+    .gte('date', twelveMonthsAgo.toISOString().split('T')[0])
+
+  const txByMonth: Record<string, number> = {}
+  for (const tx of monthlyTxData ?? []) {
+    const key = tx.date.substring(0, 7)
+    txByMonth[key] = (txByMonth[key] ?? 0) + tx.amount
+  }
+
+  const allMonths = Array.from({ length: 12 }, (_, i) => {
+    const d = new Date(today.getFullYear(), today.getMonth() - (11 - i), 1)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+  })
+
+  const firstIdx = allMonths.findIndex(m => txByMonth[m] !== undefined)
+  const activeMonths = firstIdx === -1
+    ? [allMonths[allMonths.length - 1]]
+    : allMonths.slice(firstIdx)
+
+  const MONTH_LABELS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+  const values = new Array<number>(activeMonths.length)
+  values[activeMonths.length - 1] = balance
+  for (let i = activeMonths.length - 2; i >= 0; i--) {
+    values[i] = values[i + 1] - (txByMonth[activeMonths[i + 1]] ?? 0)
+  }
+
+  const patrimonioData = activeMonths.map((m, i) => ({
+    label: MONTH_LABELS[Number(m.split('-')[1]) - 1],
+    value: Math.round(values[i]),
+  }))
+
+  const annualDelta = activeMonths.length === 12 ? Math.round(balance - values[0]) : null
+
+  return { balance, weeklyDelta, dailyBalances, accounts: accounts as Account[], patrimonioData, annualDelta }
 }


### PR DESCRIPTION
## Resumen

- Extiende `DashboardData` con `patrimonioData` (array de 12 puntos mensuales) y `annualDelta` (delta anual en €, o `null` si hay < 12 meses de histórico)
- Reconstruye el patrimonio neto mensual hacia atrás desde el balance actual, usando las transacciones `is_computable=true` + `is_internal_transfer=false` (mismo filtro que el sparkline 30 días)
- Nuevo componente `PatrimonioChart.tsx` con Recharts `AreaChart`, curva `monotone`, gradiente indigo y badge de delta anual
- Si no hay 12 meses de histórico, se muestran solo los meses disponibles sin rellenar con ceros (§5.7). El badge muestra `—` si `annualDelta === null`

## Plan de pruebas

- [ ] `pnpm build` sin errores TypeScript ✅
- [ ] `pnpm dev` → abrir dashboard y verificar que la card aparece entre balance y cuentas
- [ ] Comprobar que el último punto de la gráfica coincide con el balance total de la card de arriba
- [ ] Verificar badge de delta anual (positivo → verde, negativo → rojo, sin datos → `—`)
- [ ] Verificar tooltip al pasar el ratón sobre la gráfica

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)