### PR TITLE
feat(movimientos): swipe para recategorizar (#24)

### DIFF
--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -20,6 +20,7 @@ export default async function MovimientosPage() {
       .gte('date', cutoffStr)
       .order('date', { ascending: false })
       .order('created_at', { ascending: false })
+      .order('id', { ascending: false })
       .limit(200),
     supabase
       .from('accounts')

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { CategoryId } from '@/types'
+
+const VALID_CATEGORIES: CategoryId[] = [
+  'groceries', 'restaurant', 'transport', 'home',
+  'leisure', 'shopping', 'health', 'income', 'other',
+]
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+  const { category_manual } = body
+
+  if (category_manual !== null && !VALID_CATEGORIES.includes(category_manual)) {
+    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .update({ category_manual })
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[PATCH /api/transactions/[id]]', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data })
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -25,6 +25,7 @@ export async function GET(request: NextRequest) {
     .gte('date', cutoffStr)
     .order('date', { ascending: false })
     .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
     .limit(limit)
 
   if (type === 'ingresos') {

--- a/components/transactions/CategoryPicker.tsx
+++ b/components/transactions/CategoryPicker.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+import { CATEGORY_META } from '@/lib/theme'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+interface CategoryPickerProps {
+  tx: TransactionWithAccount
+  onClose: () => void
+  onSelect: (txId: string, category: CategoryId) => void
+}
+
+export function CategoryPicker({ tx, onClose, onSelect }: CategoryPickerProps) {
+  const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', zIndex: 400 }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full mx-auto bg-popover flex flex-col"
+        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+        <p className="text-base font-bold text-foreground mb-1">Cambiar categoría</p>
+        <p className="text-xs text-muted-foreground mb-4 truncate">{tx.description}</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+          {(Object.entries(CATEGORY_META) as [CategoryId, typeof CATEGORY_META[CategoryId]][]).map(([id, meta]) => {
+            const Icon = meta.Icon
+            const isCurrent = effectiveCategory === id
+            return (
+              <button
+                key={id}
+                onClick={() => { onSelect(tx.id, id); onClose() }}
+                style={{
+                  padding: '14px 8px',
+                  borderRadius: 14,
+                  border: isCurrent ? `2px solid ${meta.color}` : '1px solid var(--border)',
+                  background: isCurrent ? meta.color + '18' : 'var(--muted)',
+                  cursor: 'pointer',
+                  transition: 'all 0.15s',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 6,
+                }}
+              >
+                <div style={{
+                  width: 36, height: 36, borderRadius: 10,
+                  background: meta.color + '22',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                  <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
+                </div>
+                <span className="text-[11px] font-semibold text-foreground text-center leading-tight">
+                  {meta.label}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Search, X, ChevronDown, Box } from 'lucide-react'
 import { TxRow } from './TxRow'
 import { AccountFilter } from './AccountFilter'
+import { CategoryPicker } from './CategoryPicker'
 import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import type { Account, CategoryId, TransactionWithAccount } from '@/types'
@@ -35,12 +36,14 @@ function formatDayLabel(dateStr: string): string {
 }
 
 export function MovimientosClient({ initialTransactions, accounts }: MovimientosClientProps) {
+  const [transactions, setTransactions] = useState(initialTransactions)
   const [searchQuery, setSearchQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
   const [showAccountFilter, setShowAccountFilter] = useState(false)
+  const [swipedTxId, setSwipedTxId] = useState<string | null>(null)
+  const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
 
-  // Derived: account button label
   const accountLabel =
     selectedAccountIds.length === 0
       ? 'Todas las cuentas'
@@ -48,8 +51,28 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
         ? (accounts.find(a => a.id === selectedAccountIds[0])?.name ?? '1 cuenta')
         : `${selectedAccountIds.length} cuentas`
 
+  function handleRecategorize(tx: TransactionWithAccount) {
+    setCatPickerTx(tx)
+    setSwipedTxId(null)
+  }
+
+  async function handleSelect(txId: string, category: CategoryId) {
+    setTransactions(prev => prev.map(t =>
+      t.id === txId ? { ...t, category_manual: category } : t
+    ))
+    const res = await fetch(`/api/transactions/${txId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category_manual: category }),
+    })
+    if (!res.ok) {
+      setTransactions(initialTransactions)
+      console.error('[handleSelect] Error recategorizando:', await res.text())
+    }
+  }
+
   // Client-side filtering
-  let filtered = initialTransactions
+  let filtered = transactions
 
   if (selectedAccountIds.length > 0) {
     filtered = filtered.filter(tx => selectedAccountIds.includes(tx.account_id))
@@ -187,7 +210,13 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
                 {/* Transactions */}
                 <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
                   {group.transactions.map(tx => (
-                    <TxRow key={tx.id} tx={tx} />
+                    <TxRow
+                      key={tx.id}
+                      tx={tx}
+                      swipedId={swipedTxId}
+                      onSwipe={setSwipedTxId}
+                      onRecategorize={handleRecategorize}
+                    />
                   ))}
                 </div>
               </div>
@@ -203,6 +232,15 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
           selectedIds={selectedAccountIds}
           onSelectionChange={setSelectedAccountIds}
           onClose={() => setShowAccountFilter(false)}
+        />
+      )}
+
+      {/* Category picker bottom sheet */}
+      {catPickerTx && (
+        <CategoryPicker
+          tx={catPickerTx}
+          onClose={() => setCatPickerTx(null)}
+          onSelect={handleSelect}
         />
       )}
     </div>

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -1,50 +1,152 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { Edit3 } from 'lucide-react'
 import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
 interface TxRowProps {
   tx: TransactionWithAccount
+  swipedId: string | null
+  onSwipe: (id: string | null) => void
+  onRecategorize: (tx: TransactionWithAccount) => void
 }
 
-export function TxRow({ tx }: TxRowProps) {
+const ACTION_WIDTH = 120
+
+export function TxRow({ tx, swipedId, onSwipe, onRecategorize }: TxRowProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
   const meta = CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other
   const Icon = meta.Icon
+
+  const isOpen = swipedId === tx.id
+  const startX = useRef<number | null>(null)
+  const [dragX, setDragX] = useState(0)
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0].clientX
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (startX.current === null) return
+    const dx = e.touches[0].clientX - startX.current
+    if (!isOpen && dx > 0) setDragX(Math.min(dx, ACTION_WIDTH))
+    if (isOpen && dx < 0) setDragX(ACTION_WIDTH + Math.max(dx, -ACTION_WIDTH))
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (startX.current === null) return
+    const dx = e.changedTouches[0].clientX - startX.current
+    if (dx > 60) onSwipe(tx.id)
+    if (dx < -60) onSwipe(null)
+    setDragX(0)
+    startX.current = null
+  }
+
+  const handleTouchCancel = () => {
+    startX.current = null
+    setDragX(0)
+  }
+
+  // currentX: how much the slider has moved right (0 = closed, ACTION_WIDTH = fully open)
+  const currentX = isOpen ? ACTION_WIDTH : dragX
+  const isAnimating = dragX === 0
 
   const absAmount = fmt(Math.abs(tx.amount), 2)
   const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
   const amountColor = tx.amount > 0 ? '#22c55e' : '#ef4444'
 
   return (
-    <div className="flex items-center gap-3 px-3 py-2.5 rounded-2xl hover:bg-muted/40 transition-colors">
+    // overflow: hidden clips the action panel when hidden to the left
+    <div style={{ overflow: 'hidden' }}>
+      {/*
+       * Single flex slider: [action panel][content]
+       * At rest:  translateX(-ACTION_WIDTH) → action panel off-screen left, content visible
+       * Swiped:   translateX(0)             → action panel visible, content shifted right
+       */}
       <div
-        className="flex items-center justify-center rounded-[14px] shrink-0"
         style={{
-          width: 42,
-          height: 42,
-          background: meta.color + '18',
+          display: 'flex',
+          alignItems: 'stretch',
+          width: `calc(100% + ${ACTION_WIDTH}px)`,
+          transform: `translateX(${currentX - ACTION_WIDTH}px)`,
+          transition: isAnimating ? 'transform 0.25s' : 'none',
         }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
       >
-        <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
-      </div>
+        {/* Action panel — hidden to the left until swiped */}
+        <div
+          style={{
+            width: ACTION_WIDTH,
+            flexShrink: 0,
+            background: '#6366f1',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <button
+            style={{
+              pointerEvents: isOpen ? 'auto' : 'none',
+              background: 'rgba(255,255,255,0.2)',
+              border: 'none',
+              borderRadius: 10,
+              padding: '6px 12px',
+              color: 'white',
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+            onClick={() => onRecategorize(tx)}
+          >
+            <Edit3 size={13} strokeWidth={2.5} color="white" />
+            Categoría
+          </button>
+        </div>
 
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
-        <div className="flex items-center gap-1 mt-0.5">
-          <span
-            className="rounded-full shrink-0"
-            style={{ width: 7, height: 7, background: meta.color }}
-          />
-          <span className="text-[11px] text-muted-foreground truncate">{meta.label}</span>
+        {/* Main row content */}
+        <div
+          className="flex items-center gap-3 px-3 py-2.5 bg-card"
+          style={{ flex: 1, minWidth: 0 }}
+          onClick={() => isOpen && onSwipe(null)}
+        >
+          <div
+            className="flex items-center justify-center rounded-[14px] shrink-0"
+            style={{ width: 42, height: 42, background: meta.color + '18' }}
+          >
+            <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 min-w-0">
+              <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
+              {tx.category_manual && (
+                <span
+                  className="rounded-full text-[9px] font-bold px-1.5 py-0.5 leading-none shrink-0"
+                  style={{ background: '#6366f1', color: 'white' }}
+                >
+                  EDITADA
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1 mt-0.5">
+              <span className="rounded-full shrink-0" style={{ width: 7, height: 7, background: meta.color }} />
+              <span className="text-[11px] text-muted-foreground truncate">{meta.label}</span>
+            </div>
+          </div>
+
+          <span className="text-[15px] font-bold shrink-0" style={{ color: amountColor }}>
+            {amountStr}
+          </span>
         </div>
       </div>
-
-      <span
-        className="text-[15px] font-bold shrink-0"
-        style={{ color: amountColor }}
-      >
-        {amountStr}
-      </span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Swipe derecha en cualquier fila de Movimientos revela un panel indigo con botón "Categoría"; swipe izquierda o tap sobre el contenido lo cierra
- Nuevo `CategoryPicker` (bottom sheet 3×3) para seleccionar entre las 9 categorías predefinidas; renderizado vía `createPortal` para escapar del `overflow: clip` del layout
- Nuevo endpoint `PATCH /api/transactions/[id]` persiste `category_manual` en Supabase con auth guard y validación de categoría
- Update optimista en `MovimientosClient` con revert automático si falla el PATCH
- Badge **EDITADA** en la fila cuando `category_manual !== null`
- Sort determinista añadiendo `id` como desempate final (`date → created_at → id`) para evitar reordenamiento al refrescar tras editar

## Implementación técnica

- `TxRow` reescrito como `'use client'` con slider flex lado a lado (`[panel acción][contenido]`) — elimina problemas de z-index y fondo transparente de la aproximación con `position: absolute`
- Touch events con feedback en tiempo real (`onTouchMove` actualiza `dragX`), `onTouchCancel` para reset limpio, transición animada solo al soltar (`dragX === 0`)
- `overflow: hidden` en el wrapper de `TxRow` (hoja sin hijos sticky — no viola la convención del proyecto)
- `CategoryPicker` diseñado para reutilización en modales de detalle y nuevo movimiento (issues futuras)

## Test plan

- [ ] Deslizar fila derecha → panel indigo visible con botón "Categoría"
- [ ] Deslizar izquierda / tap sobre fila abierta → cierra el panel
- [ ] Tap "Categoría" → bottom sheet 3×3 aparece sobre el nav bar
- [ ] Seleccionar categoría → fila actualiza inmediatamente (optimista) con badge EDITADA
- [ ] Refrescar página → categoría persiste en la misma posición
- [ ] Abrir otra fila → la anterior se cierra automáticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)