### PR TITLE
feat(movimientos): modal de detalle de movimiento (#25)

### DIFF
--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { CategoryId } from '@/types'
+
+const VALID_CATEGORIES: CategoryId[] = [
+  'groceries', 'restaurant', 'transport', 'home',
+  'leisure', 'shopping', 'health', 'income', 'other',
+]
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+  const { category_manual } = body
+
+  if (category_manual !== null && !VALID_CATEGORIES.includes(category_manual)) {
+    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .update({ category_manual })
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('[PATCH /api/transactions/[id]]', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ data })
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+  const { error } = await supabase
+    .from('transactions')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (error) {
+    console.error('[DELETE /api/transactions/[id]]', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/components/transactions/CategoryPicker.tsx
+++ b/components/transactions/CategoryPicker.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+import { CATEGORY_META } from '@/lib/theme'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+interface CategoryPickerProps {
+  tx: TransactionWithAccount
+  onClose: () => void
+  onSelect: (txId: string, category: CategoryId) => void
+}
+
+export function CategoryPicker({ tx, onClose, onSelect }: CategoryPickerProps) {
+  const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', zIndex: 400 }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full mx-auto bg-popover flex flex-col"
+        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+        <p className="text-base font-bold text-foreground mb-1">Cambiar categoría</p>
+        <p className="text-xs text-muted-foreground mb-4 truncate">{tx.description}</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+          {(Object.entries(CATEGORY_META) as [CategoryId, typeof CATEGORY_META[CategoryId]][]).map(([id, meta]) => {
+            const Icon = meta.Icon
+            const isCurrent = effectiveCategory === id
+            return (
+              <button
+                key={id}
+                onClick={() => { onSelect(tx.id, id); onClose() }}
+                style={{
+                  padding: '14px 8px',
+                  borderRadius: 14,
+                  border: isCurrent ? `2px solid ${meta.color}` : '1px solid var(--border)',
+                  background: isCurrent ? meta.color + '18' : 'var(--muted)',
+                  cursor: 'pointer',
+                  transition: 'all 0.15s',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 6,
+                }}
+              >
+                <div style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: 10,
+                  background: meta.color + '22',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}>
+                  <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
+                </div>
+                <span className="text-[11px] font-semibold text-foreground text-center leading-tight">
+                  {meta.label}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react'
 import { Search, X, ChevronDown, Box } from 'lucide-react'
 import { TxRow } from './TxRow'
+import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
+import { CategoryPicker } from './CategoryPicker'
 import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import type { Account, CategoryId, TransactionWithAccount } from '@/types'
@@ -35,10 +37,15 @@ function formatDayLabel(dateStr: string): string {
 }
 
 export function MovimientosClient({ initialTransactions, accounts }: MovimientosClientProps) {
+  const [transactions, setTransactions] = useState(initialTransactions)
   const [searchQuery, setSearchQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
   const [showAccountFilter, setShowAccountFilter] = useState(false)
+  const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
+  const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
+
+  const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
 
   // Derived: account button label
   const accountLabel =
@@ -48,8 +55,41 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
         ? (accounts.find(a => a.id === selectedAccountIds[0])?.name ?? '1 cuenta')
         : `${selectedAccountIds.length} cuentas`
 
+  function handleTxTap(tx: TransactionWithAccount) {
+    setSelectedTxId(tx.id)
+  }
+
+  function handleRecategorize(tx: TransactionWithAccount) {
+    setCatPickerTx(tx)
+  }
+
+  async function handleSelect(txId: string, category: CategoryId) {
+    setTransactions(prev => prev.map(t =>
+      t.id === txId ? { ...t, category_manual: category } : t
+    ))
+    const res = await fetch(`/api/transactions/${txId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category_manual: category }),
+    })
+    if (!res.ok) {
+      setTransactions(initialTransactions)
+      console.error('[handleSelect] Error recategorizando:', await res.text())
+    }
+  }
+
+  async function handleDelete(txId: string) {
+    setSelectedTxId(null)
+    setTransactions(prev => prev.filter(t => t.id !== txId))
+    const res = await fetch(`/api/transactions/${txId}`, { method: 'DELETE' })
+    if (!res.ok) {
+      setTransactions(initialTransactions)
+      console.error('[handleDelete] Error eliminando:', await res.text())
+    }
+  }
+
   // Client-side filtering
-  let filtered = initialTransactions
+  let filtered = transactions
 
   if (selectedAccountIds.length > 0) {
     filtered = filtered.filter(tx => selectedAccountIds.includes(tx.account_id))
@@ -187,7 +227,7 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
                 {/* Transactions */}
                 <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
                   {group.transactions.map(tx => (
-                    <TxRow key={tx.id} tx={tx} />
+                    <TxRow key={tx.id} tx={tx} onTap={handleTxTap} />
                   ))}
                 </div>
               </div>
@@ -203,6 +243,25 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
           selectedIds={selectedAccountIds}
           onSelectionChange={setSelectedAccountIds}
           onClose={() => setShowAccountFilter(false)}
+        />
+      )}
+
+      {/* Transaction detail bottom sheet */}
+      {selectedTx && (
+        <TxModal
+          tx={selectedTx}
+          onClose={() => setSelectedTxId(null)}
+          onRecategorize={handleRecategorize}
+          onDelete={handleDelete}
+        />
+      )}
+
+      {/* Category picker bottom sheet (zIndex 400, overlays TxModal) */}
+      {catPickerTx && (
+        <CategoryPicker
+          tx={catPickerTx}
+          onClose={() => setCatPickerTx(null)}
+          onSelect={handleSelect}
         />
       )}
     </div>

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Trash2, Calendar, CreditCard, Tag } from 'lucide-react'
+import { CATEGORY_META } from '@/lib/theme'
+import { fmt } from '@/lib/formatting'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+interface TxModalProps {
+  tx: TransactionWithAccount
+  onClose: () => void
+  onRecategorize: (tx: TransactionWithAccount) => void
+  onDelete: (txId: string) => void
+}
+
+interface FieldRowProps {
+  label: string
+  icon: React.ReactNode
+  children: React.ReactNode
+  onClick?: () => void
+  chevron?: boolean
+}
+
+function FieldRow({ label, icon, children, onClick, chevron }: FieldRowProps) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '13px 16px',
+        borderRadius: 16,
+        background: 'var(--muted)',
+        cursor: onClick ? 'pointer' : 'default',
+      }}
+    >
+      <div style={{
+        width: 34,
+        height: 34,
+        borderRadius: 10,
+        background: 'var(--muted-foreground/10)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        opacity: 0.6,
+      }}>
+        {icon}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 10,
+          color: 'var(--muted-foreground)',
+          fontWeight: 600,
+          marginBottom: 2,
+          textTransform: 'uppercase',
+          letterSpacing: 0.4,
+        }}>
+          {label}
+        </div>
+        {children}
+      </div>
+      {chevron && (
+        <span style={{ fontSize: 16, color: 'var(--muted-foreground)', flexShrink: 0, lineHeight: 1 }}>›</span>
+      )}
+    </div>
+  )
+}
+
+export function TxModal({ tx, onClose, onRecategorize, onDelete }: TxModalProps) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+  const meta = CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other
+  const Icon = meta.Icon
+
+  const dateStr = (() => {
+    const [y, m, d] = tx.date.split('-').map(Number)
+    return new Date(y, m - 1, d).toLocaleDateString('es-ES', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+  })()
+
+  const absAmount = fmt(Math.abs(tx.amount), 2)
+  const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
+  const amountColor = tx.amount > 0 ? '#22c55e' : 'var(--foreground)'
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', zIndex: 350 }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full mx-auto bg-popover flex flex-col"
+        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+
+        {/* Importe prominente */}
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <div style={{
+            width: 60,
+            height: 60,
+            borderRadius: 18,
+            background: meta.color + '20',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            margin: '0 auto 12px',
+          }}>
+            <Icon size={26} style={{ color: meta.color }} strokeWidth={2} />
+          </div>
+          <div className="text-sm font-bold text-foreground mb-1 truncate px-4">{tx.description}</div>
+          <div style={{
+            fontSize: 44,
+            fontWeight: 800,
+            letterSpacing: -2,
+            color: amountColor,
+            lineHeight: 1,
+          }}>
+            {amountStr}
+          </div>
+        </div>
+
+        {/* Campos */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
+          <FieldRow
+            label="Fecha"
+            icon={<Calendar size={16} className="text-muted-foreground" />}
+          >
+            <span className="text-sm font-semibold text-foreground capitalize">{dateStr}</span>
+          </FieldRow>
+
+          <FieldRow
+            label="Cuenta"
+            icon={<CreditCard size={16} className="text-muted-foreground" />}
+          >
+            <span className="text-sm font-semibold text-foreground">{tx.account?.name ?? '—'}</span>
+          </FieldRow>
+
+          <FieldRow
+            label="Categoría"
+            chevron
+            onClick={() => onRecategorize(tx)}
+            icon={
+              <div style={{
+                width: 34,
+                height: 34,
+                borderRadius: 10,
+                background: meta.color + '22',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}>
+                <Icon size={16} style={{ color: meta.color }} strokeWidth={2} />
+              </div>
+            }
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span className="text-sm font-semibold text-foreground">{meta.label}</span>
+              {tx.category_manual && (
+                <span
+                  className="rounded-full text-[9px] font-bold px-1.5 py-0.5 leading-none shrink-0"
+                  style={{ background: '#6366f1', color: 'white' }}
+                >
+                  EDITADA
+                </span>
+              )}
+            </div>
+          </FieldRow>
+        </div>
+
+        {/* Eliminar */}
+        {!confirmDelete ? (
+          <button
+            onClick={() => setConfirmDelete(true)}
+            style={{
+              width: '100%',
+              background: 'transparent',
+              border: '1.5px solid rgba(239,68,68,0.3)',
+              borderRadius: 16,
+              padding: '13px',
+              color: '#ef4444',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 6,
+            }}
+          >
+            <Trash2 size={15} />
+            Eliminar movimiento
+          </button>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <p className="text-xs text-muted-foreground text-center mb-1">
+              ¿Seguro que quieres eliminar este movimiento? Esta acción no se puede deshacer.
+            </p>
+            <div style={{ display: 'flex', gap: 10 }}>
+              <button
+                onClick={() => setConfirmDelete(false)}
+                style={{
+                  flex: 1,
+                  background: 'var(--muted)',
+                  border: 'none',
+                  borderRadius: 14,
+                  padding: '13px',
+                  color: 'var(--foreground)',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={() => onDelete(tx.id)}
+                style={{
+                  flex: 1,
+                  background: '#ef4444',
+                  border: 'none',
+                  borderRadius: 14,
+                  padding: '13px',
+                  color: 'white',
+                  fontSize: 14,
+                  fontWeight: 700,
+                  cursor: 'pointer',
+                }}
+              >
+                Sí, eliminar
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -4,9 +4,10 @@ import type { CategoryId, TransactionWithAccount } from '@/types'
 
 interface TxRowProps {
   tx: TransactionWithAccount
+  onTap: (tx: TransactionWithAccount) => void
 }
 
-export function TxRow({ tx }: TxRowProps) {
+export function TxRow({ tx, onTap }: TxRowProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
   const meta = CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other
   const Icon = meta.Icon
@@ -16,7 +17,7 @@ export function TxRow({ tx }: TxRowProps) {
   const amountColor = tx.amount > 0 ? '#22c55e' : '#ef4444'
 
   return (
-    <div className="flex items-center gap-3 px-3 py-2.5 rounded-2xl hover:bg-muted/40 transition-colors">
+    <div className="flex items-center gap-3 px-3 py-2.5 rounded-2xl hover:bg-muted/40 transition-colors cursor-pointer" onClick={() => onTap(tx)}>
       <div
         className="flex items-center justify-center rounded-[14px] shrink-0"
         style={{


### PR DESCRIPTION
## Summary
- Nuevo `TxModal` bottom sheet (zIndex 350) con importe destacado, `FieldRow` para fecha/cuenta/categoría, badge "EDITADA" y borrado en dos pasos
- `CategoryPicker` para cambio de categoría desde el modal (zIndex 400, se superpone al modal sin cerrarlo)
- `DELETE /api/transactions/[id]` con auth y RLS; mismo archivo que el PATCH ya existente
- Tap en cualquier `TxRow` abre el modal; borrado optimista retira la fila sin recarga completa

## Test plan
- [ ] Tap en una fila → abre modal con importe, fecha, cuenta y categoría correctos
- [ ] Campo Categoría → abre CategoryPicker encima del modal; seleccionar actualiza badge "EDITADA"
- [ ] Botón Eliminar → muestra confirmación; Cancelar vuelve al botón rojo
- [ ] Confirmar eliminación → modal cierra, fila desaparece sin recarga
- [ ] Tap en overlay → cierra el modal
- [ ] Swipe (si viene de feature/swipe-recategorizar) no abre el modal accidentalmente

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)