### PR TITLE
feat(categories): tipo expense/income/non_computable + catálogo 41 categorías

### DIFF
--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -3,8 +3,17 @@ import { createClient } from '@/lib/supabase/server'
 import type { CategoryId } from '@/types'
 
 const VALID_CATEGORIES: CategoryId[] = [
-  'groceries', 'restaurant', 'transport', 'home',
-  'leisure', 'shopping', 'health', 'income', 'other',
+  // Gastos
+  'groceries', 'restaurant', 'transport', 'fuel', 'parking', 'vehicle',
+  'mortgage', 'community_fees', 'electricity', 'gas', 'water', 'internet',
+  'home', 'clothing', 'shopping', 'electronics', 'health', 'pharmacy',
+  'leisure', 'sports', 'subscriptions', 'travel', 'education', 'insurance',
+  'beauty', 'gifts', 'charity', 'memberships', 'taxes', 'loans', 'cash',
+  'fees', 'other',
+  // Ingresos
+  'income', 'returns', 'reimbursement', 'other_income',
+  // No Computable
+  'investment', 'savings', 'transfer', 'loan_payment',
 ]
 
 export async function PATCH(

--- a/components/transactions/CategoryPicker.tsx
+++ b/components/transactions/CategoryPicker.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { CATEGORY_META } from '@/lib/theme'
-import type { CategoryId, TransactionWithAccount } from '@/types'
+import type { CategoryId, CategoryType, TransactionWithAccount } from '@/types'
 
 interface CategoryPickerProps {
   tx: TransactionWithAccount
@@ -10,8 +11,25 @@ interface CategoryPickerProps {
   onSelect: (txId: string, category: CategoryId) => void
 }
 
+const TYPE_LABELS: Record<CategoryType, string> = {
+  expense:         'Gastos',
+  income:          'Ingresos',
+  non_computable:  'No Computable',
+}
+
+const ENTRIES = Object.entries(CATEGORY_META) as [CategoryId, typeof CATEGORY_META[CategoryId]][]
+
+function initialTab(tx: TransactionWithAccount): CategoryType {
+  const effective = (tx.category_manual ?? tx.category) as CategoryId | null
+  if (effective && CATEGORY_META[effective]) return CATEGORY_META[effective].type
+  return tx.amount < 0 ? 'expense' : 'income'
+}
+
 export function CategoryPicker({ tx, onClose, onSelect }: CategoryPickerProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+  const [activeType, setActiveType] = useState<CategoryType>(() => initialTab(tx))
+
+  const visibleCategories = ENTRIES.filter(([, meta]) => meta.type === activeType)
 
   return createPortal(
     <div
@@ -21,46 +39,78 @@ export function CategoryPicker({ tx, onClose, onSelect }: CategoryPickerProps) {
     >
       <div
         className="w-full mx-auto bg-popover flex flex-col"
-        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px' }}
+        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px', maxHeight: '82dvh' }}
         onClick={e => e.stopPropagation()}
       >
         <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
         <p className="text-base font-bold text-foreground mb-1">Cambiar categoría</p>
         <p className="text-xs text-muted-foreground mb-4 truncate">{tx.description}</p>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
-          {(Object.entries(CATEGORY_META) as [CategoryId, typeof CATEGORY_META[CategoryId]][]).map(([id, meta]) => {
-            const Icon = meta.Icon
-            const isCurrent = effectiveCategory === id
-            return (
-              <button
-                key={id}
-                onClick={() => { onSelect(tx.id, id); onClose() }}
-                style={{
-                  padding: '14px 8px',
-                  borderRadius: 14,
-                  border: isCurrent ? `2px solid ${meta.color}` : '1px solid var(--border)',
-                  background: isCurrent ? meta.color + '18' : 'var(--muted)',
-                  cursor: 'pointer',
-                  transition: 'all 0.15s',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  gap: 6,
-                }}
-              >
-                <div style={{
-                  width: 36, height: 36, borderRadius: 10,
-                  background: meta.color + '22',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}>
-                  <Icon size={18} style={{ color: meta.color }} strokeWidth={2} />
-                </div>
-                <span className="text-[11px] font-semibold text-foreground text-center leading-tight">
-                  {meta.label}
-                </span>
-              </button>
-            )
-          })}
+
+        {/* Selector de tipo */}
+        <div
+          className="flex mb-4 rounded-xl overflow-clip"
+          style={{ background: 'var(--muted)', padding: 3, gap: 2 }}
+        >
+          {(Object.keys(TYPE_LABELS) as CategoryType[]).map(type => (
+            <button
+              key={type}
+              onClick={() => setActiveType(type)}
+              style={{
+                flex: 1,
+                padding: '7px 4px',
+                borderRadius: 9,
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 12,
+                fontWeight: 600,
+                transition: 'all 0.15s',
+                background: activeType === type ? 'var(--popover)' : 'transparent',
+                color: activeType === type ? 'var(--foreground)' : 'var(--muted-foreground)',
+                boxShadow: activeType === type ? '0 1px 4px rgba(0,0,0,0.12)' : 'none',
+              }}
+            >
+              {TYPE_LABELS[type]}
+            </button>
+          ))}
+        </div>
+
+        {/* Grid de categorías scrollable */}
+        <div style={{ overflowY: 'auto', flex: 1 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+            {visibleCategories.map(([id, meta]) => {
+              const Icon = meta.Icon
+              const isCurrent = effectiveCategory === id
+              return (
+                <button
+                  key={id}
+                  onClick={() => { onSelect(tx.id, id); onClose() }}
+                  style={{
+                    padding: '12px 4px',
+                    borderRadius: 14,
+                    border: isCurrent ? `2px solid ${meta.color}` : '1px solid var(--border)',
+                    background: isCurrent ? meta.color + '18' : 'var(--muted)',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 5,
+                  }}
+                >
+                  <div style={{
+                    width: 32, height: 32, borderRadius: 9,
+                    background: meta.color + '22',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    <Icon size={16} style={{ color: meta.color }} strokeWidth={2} />
+                  </div>
+                  <span className="text-[10px] font-semibold text-foreground text-center leading-tight">
+                    {meta.label}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
         </div>
       </div>
     </div>,

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -97,12 +97,15 @@ export function MovimientosClient({ initialTransactions, accounts }: Movimientos
     filtered = filtered.filter(tx => selectedAccountIds.includes(tx.account_id))
   }
 
-  if (typeFilter === 'ingresos') {
-    filtered = filtered.filter(tx => tx.amount > 0 && tx.is_computable)
-  } else if (typeFilter === 'gastos') {
-    filtered = filtered.filter(tx => tx.amount < 0 && tx.is_computable)
-  } else if (typeFilter === 'no-computable') {
-    filtered = filtered.filter(tx => !tx.is_computable)
+  if (typeFilter !== 'todos') {
+    filtered = filtered.filter(tx => {
+      const catId = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+      const catType = CATEGORY_META[catId]?.type
+      if (typeFilter === 'ingresos')       return catType === 'income'
+      if (typeFilter === 'gastos')         return catType === 'expense'
+      if (typeFilter === 'no-computable')  return catType === 'non_computable' || !tx.is_computable
+      return true
+    })
   }
 
   if (searchQuery.trim()) {

--- a/docs/finanzas-spec.md
+++ b/docs/finanzas-spec.md
@@ -59,7 +59,8 @@ Aplicación web personal de gestión y análisis de finanzas que agrega automát
 
 **Filtros de tipo**
 - Pills horizontales: Todos / Ingresos / Gastos / No Computable
-- "No Computable" = Edenred/tickets restaurante
+- El filtro usa `CATEGORY_META[effectiveCategory].type` — no el signo del importe
+- "No Computable" incluye: transacciones con `is_computable = false` (Edenred) **y** transacciones cuya categoría efectiva tiene `type = 'non_computable'` (inversión, ahorro, transferencias...)
 
 **Lista agrupada por día**
 - Encabezado de día: "Hoy", "Ayer" o fecha formateada + neto del día
@@ -228,25 +229,27 @@ CREATE POLICY "Users access own config" ON user_config
 
 ### 3.2 Categorías predefinidas
 
-```typescript
-const CATEGORIES = [
-  { id: 'groceries',   name: 'Supermercado', color: '#22c55e' },
-  { id: 'restaurant',  name: 'Restaurante',  color: '#f59e0b' },
-  { id: 'transport',   name: 'Transporte',   color: '#8b5cf6' },
-  { id: 'home',        name: 'Hogar',        color: '#06b6d4' },
-  { id: 'leisure',     name: 'Ocio',         color: '#ef4444' },
-  { id: 'shopping',    name: 'Compras',      color: '#ec4899' },
-  { id: 'health',      name: 'Salud',        color: '#10b981' },
-  { id: 'income',      name: 'Ingresos',     color: '#3b82f6' },
-  { id: 'other',       name: 'Otros',        color: '#64748b' },
-]
-```
+**41 categorías** con tres tipos (`CategoryType`): `expense`, `income`, `non_computable`.  
+Definidas en `lib/theme.ts` (`CATEGORY_META`) y en la tabla `categories` de Supabase (para JOINs en queries de Análisis).
 
-La categoría `category_manual` en la tabla `transactions` sobreescribe `category` en la UI. Si `category_manual` tiene valor, se muestra con badge "EDITADA".
+| Tipo | Categorías (IDs) |
+|---|---|
+| `expense` (33) | `groceries`, `restaurant`, `transport`, `fuel`, `parking`, `vehicle`, `mortgage`, `community_fees`, `electricity`, `gas`, `water`, `internet`, `home`, `clothing`, `shopping`, `electronics`, `health`, `pharmacy`, `leisure`, `sports`, `subscriptions`, `travel`, `education`, `insurance`, `beauty`, `gifts`, `charity`, `memberships`, `taxes`, `loans`, `cash`, `fees`, `other` |
+| `income` (4) | `income`, `returns`, `reimbursement`, `other_income` |
+| `non_computable` (4) | `investment`, `savings`, `transfer`, `loan_payment` |
+
+La categoría efectiva se obtiene como `COALESCE(category_manual, category)`. Si `category_manual` tiene valor, se muestra con badge "EDITADA".
+
+El `CategoryPicker` agrupa las categorías por tipo con un selector de 3 tabs (Gastos / Ingresos / No Computable) y abre automáticamente en la sección de la categoría actual.
 
 ### 3.3 Lógica de "No Computable"
 
-Las transacciones de Edenred tienen `is_computable = false`. En el filtro de Movimientos se llaman "No Computable" y se excluyen de los totales de Gastos en Análisis.
+Dos mecanismos que coexisten:
+
+1. **`is_computable = false`** en la transacción — asignado automáticamente a las transacciones de Edenred (scraper). No modificable por el usuario.
+2. **`category.type = 'non_computable'`** — cuando el usuario categoriza una transacción como `investment`, `savings`, `transfer` o `loan_payment`.
+
+Ambos casos se excluyen de los totales de Gastos e Ingresos en Análisis, y ambos aparecen en la pill "No Computable" de Movimientos.
 
 ---
 
@@ -497,24 +500,18 @@ En lugar de barras fantasma adicionales (que añaden ruido visual), se usa una *
 
 ### 5.3 Categorización automática
 
-Al importar transacciones de Enable Banking, aplicar reglas de categorización basadas en la descripción:
+Al importar transacciones de Enable Banking, se aplican reglas en `lib/categories.ts` (`AUTO_RULES`) basadas en la descripción. Devuelven un `CategoryId` (en inglés). Si no hay coincidencia, la transacción queda sin categoría (`null`) y se muestra como `other` en la UI.
 
 ```typescript
+// Ejemplos representativos — ver lib/categories.ts para la lista completa
 const AUTO_RULES = [
-  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski/i, category: 'Supermercado' },
-  { pattern: /netflix|spotify|hbo|disney|amazon prime/i,    category: 'Ocio' },
-  { pattern: /repsol|cepsa|bp\b|galp|campsa/i,              category: 'Transporte' },
-  { pattern: /farmacia|clinica|hospital|sanitas|adeslas/i,  category: 'Salud' },
-  { pattern: /nomina|salario|payroll/i,                     category: 'Ingresos' },
-  // ...añadir más según uso real
+  { pattern: /mercadona|carrefour|lidl|aldi|eroski/i,               category: 'groceries'     },
+  { pattern: /repsol|cepsa|bp\b|galp|campsa/i,                      category: 'fuel'          },
+  { pattern: /netflix|spotify|apple\.com\/bill|youtube premium/i,   category: 'subscriptions' },
+  { pattern: /nomina|salario|payroll/i,                              category: 'income'        },
+  { pattern: /degiro|myinvestor|indexa capital/i,                    category: 'investment'    },
+  // ...
 ]
-
-const categorize = (description: string): string => {
-  for (const rule of AUTO_RULES) {
-    if (rule.pattern.test(description)) return rule.category
-  }
-  return 'Otros'
-}
 ```
 
 Si el usuario ha establecido `category_manual`, esa tiene prioridad sobre la automática.

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,11 +1,58 @@
 import type { CategoryId } from '@/types'
 
 export const AUTO_RULES: { pattern: RegExp; category: CategoryId }[] = [
-  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski/i, category: 'groceries' },
-  { pattern: /netflix|spotify|hbo|disney|amazon prime/i,    category: 'leisure'   },
-  { pattern: /repsol|cepsa|bp\b|galp|campsa/i,              category: 'transport' },
-  { pattern: /farmacia|clinica|hospital|sanitas|adeslas/i,  category: 'health'    },
-  { pattern: /nomina|salario|payroll/i,                     category: 'income'    },
+  // Supermercado
+  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor/i, category: 'groceries' },
+  // Restaurantes
+  { pattern: /restaurante|mcdonalds|burger king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter/i, category: 'restaurant' },
+  // Transporte público
+  { pattern: /renfe|metro|emt\b|avlo|ouigo|blablacar|cabify|uber\b|bolt\b|transporte/i, category: 'transport' },
+  // Gasolina
+  { pattern: /repsol|cepsa|bp\b|galp|campsa|shell\b|gasolinera|carburante/i, category: 'fuel' },
+  // Parking y Peaje
+  { pattern: /parking|aparcamiento|peaje|autopista|via\.t|telepeaje/i, category: 'parking' },
+  // Vehículo
+  { pattern: /taller|itv\b|neumatico|concesionario|mapfre auto|adeslas auto|midas|norauto/i, category: 'vehicle' },
+  // Hipoteca / Alquiler
+  { pattern: /hipoteca|prestamo hipotecario|alquiler|arrendamiento/i, category: 'mortgage' },
+  // Comunidad
+  { pattern: /comunidad de propietarios|comunidad vecinos|administrador fincas/i, category: 'community_fees' },
+  // Electricidad
+  { pattern: /endesa|iberdrola|naturgy|holaluz|octopus energy|luz\b|electricidad/i, category: 'electricity' },
+  // Gas natural
+  { pattern: /naturgy gas|gas natural|repsol gas\b|madrileña de gas/i, category: 'gas' },
+  // Agua
+  { pattern: /canal de isabel|aguas de|abastecimiento|suministro agua/i, category: 'water' },
+  // Internet / Telefonía
+  { pattern: /movistar|vodafone|orange\b|jazztel|masmovil|pepephone|digi\b|yoigo|simyo|telefonica|internet/i, category: 'internet' },
+  // Hogar (reformas, muebles)
+  { pattern: /ikea|leroy merlin|brico|amazon home|el corte ingles hogar|zara home/i, category: 'home' },
+  // Ropa
+  { pattern: /zara\b|mango\b|hm\b|h&m|pull.and.bear|bershka|stradivarius|primark|lefties|el corte ingles moda/i, category: 'clothing' },
+  // Electrónica
+  { pattern: /apple store|fnac|mediamarkt|pccomponentes|worten|samsung store/i, category: 'electronics' },
+  // Salud
+  { pattern: /clinica|hospital|sanitas|adeslas|quironsalud|dentista|oculista|optica|medico/i, category: 'health' },
+  // Farmacia
+  { pattern: /farmacia|parafarmacia|farmacor/i, category: 'pharmacy' },
+  // Ocio
+  { pattern: /cine|teatro|concierto|entradas|ticketmaster|eventbrite|amazon prime video|disney\+|hbo/i, category: 'leisure' },
+  // Deporte
+  { pattern: /gimnasio|gym\b|decathlon|intersport|just eat sport|padel|tenis|natacion/i, category: 'sports' },
+  // Suscripciones
+  { pattern: /netflix|spotify|apple\.com\/bill|google one|microsoft 365|adobe|youtube premium|hbo max|paramount/i, category: 'subscriptions' },
+  // Viajes
+  { pattern: /booking\.com|airbnb|ryanair|vueling|iberia|aena|hotel|hostal|alojamiento/i, category: 'travel' },
+  // Educación
+  { pattern: /udemy|coursera|openwebinars|universidad|escuela|academia|fnac libros/i, category: 'education' },
+  // Seguros
+  { pattern: /seguros|mutua madrilena|linea directa|axa\b|allianz|generali|mapfre seguro/i, category: 'insurance' },
+  // Nómina
+  { pattern: /nomina|salario|payroll|haberes/i, category: 'income' },
+  // Reembolso
+  { pattern: /devolucion|reembolso|hacienda|agencia tributaria|reintegro/i, category: 'reimbursement' },
+  // Inversión
+  { pattern: /degiro|myinvestor|indexa capital|openbroker|interactive brokers|trading212|etf\b|fondo de inversion/i, category: 'investment' },
 ]
 
 export function categorize(description: string): CategoryId | null {

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,6 +1,14 @@
-import { ShoppingCart, UtensilsCrossed, Car, Home, Gamepad2, ShoppingBag, HeartPulse, TrendingUp, MoreHorizontal } from 'lucide-react'
+import {
+  ShoppingCart, UtensilsCrossed, Car, Home, Gamepad2, ShoppingBag,
+  HeartPulse, TrendingUp, MoreHorizontal, Fuel, ParkingCircle, Wrench,
+  Building2, Users, Zap, Flame, Droplets, Wifi, Shirt, Laptop,
+  Stethoscope, Pill, Dumbbell, Repeat2, Plane, BookOpen, Shield,
+  Sparkles, Gift, Heart, Users2, Receipt, CreditCard, Banknote,
+  Landmark, BarChart3, RotateCcw, CirclePlus, PiggyBank, ArrowLeftRight,
+  Wallet, Bus,
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import type { CategoryId } from '@/types'
+import type { CategoryId, CategoryType } from '@/types'
 
 interface ThemeColors {
   bg: string
@@ -45,33 +53,104 @@ export const darkTheme: ThemeColors = {
 }
 
 export const CATEGORY_COLORS: Record<CategoryId, string> = {
-  groceries: '#22c55e',
-  restaurant: '#f59e0b',
-  transport: '#8b5cf6',
-  home: '#06b6d4',
-  leisure: '#ef4444',
-  shopping: '#ec4899',
-  health: '#10b981',
-  income: '#3b82f6',
-  other: '#64748b',
+  // Gastos
+  groceries:      '#22c55e',
+  restaurant:     '#f59e0b',
+  transport:      '#8b5cf6',
+  fuel:           '#7c3aed',
+  parking:        '#6d28d9',
+  vehicle:        '#5b21b6',
+  mortgage:       '#0284c7',
+  community_fees: '#0369a1',
+  electricity:    '#f59e0b',
+  gas:            '#d97706',
+  water:          '#06b6d4',
+  internet:       '#0891b2',
+  home:           '#0e7490',
+  clothing:       '#ec4899',
+  shopping:       '#db2777',
+  electronics:    '#9333ea',
+  health:         '#10b981',
+  pharmacy:       '#059669',
+  leisure:        '#ef4444',
+  sports:         '#dc2626',
+  subscriptions:  '#f97316',
+  travel:         '#0ea5e9',
+  education:      '#a855f7',
+  insurance:      '#84cc16',
+  beauty:         '#f472b6',
+  gifts:          '#fb7185',
+  charity:        '#4ade80',
+  memberships:    '#a3e635',
+  taxes:          '#facc15',
+  loans:          '#fb923c',
+  cash:           '#a8a29e',
+  fees:           '#94a3b8',
+  other:          '#64748b',
+  // Ingresos
+  income:         '#3b82f6',
+  returns:        '#0284c7',
+  reimbursement:  '#16a34a',
+  other_income:   '#6366f1',
+  // No Computable
+  investment:     '#059669',
+  savings:        '#0d9488',
+  transfer:       '#78716c',
+  loan_payment:   '#b45309',
 }
 
 interface CategoryMeta {
   label: string
   color: string
+  type: CategoryType
   Icon: LucideIcon
 }
 
 export const CATEGORY_META: Record<CategoryId, CategoryMeta> = {
-  groceries:  { label: 'Supermercado', color: '#22c55e', Icon: ShoppingCart    },
-  restaurant: { label: 'Restaurante',  color: '#f59e0b', Icon: UtensilsCrossed },
-  transport:  { label: 'Transporte',   color: '#8b5cf6', Icon: Car             },
-  home:       { label: 'Hogar',        color: '#06b6d4', Icon: Home            },
-  leisure:    { label: 'Ocio',         color: '#ef4444', Icon: Gamepad2        },
-  shopping:   { label: 'Compras',      color: '#ec4899', Icon: ShoppingBag     },
-  health:     { label: 'Salud',        color: '#10b981', Icon: HeartPulse      },
-  income:     { label: 'Ingresos',     color: '#3b82f6', Icon: TrendingUp      },
-  other:      { label: 'Otros',        color: '#64748b', Icon: MoreHorizontal  },
+  // ── Gastos ──────────────────────────────────────────────────────────────────
+  groceries:      { label: 'Supermercado',         color: '#22c55e', type: 'expense',         Icon: ShoppingCart    },
+  restaurant:     { label: 'Restaurantes',          color: '#f59e0b', type: 'expense',         Icon: UtensilsCrossed },
+  transport:      { label: 'Transporte público',    color: '#8b5cf6', type: 'expense',         Icon: Bus             },
+  fuel:           { label: 'Gasolina',              color: '#7c3aed', type: 'expense',         Icon: Fuel            },
+  parking:        { label: 'Parking y Peaje',       color: '#6d28d9', type: 'expense',         Icon: ParkingCircle   },
+  vehicle:        { label: 'Vehículo',              color: '#5b21b6', type: 'expense',         Icon: Wrench          },
+  mortgage:       { label: 'Hipoteca / Alquiler',   color: '#0284c7', type: 'expense',         Icon: Building2       },
+  community_fees: { label: 'Comunidad de vecinos',  color: '#0369a1', type: 'expense',         Icon: Users           },
+  electricity:    { label: 'Electricidad',          color: '#f59e0b', type: 'expense',         Icon: Zap             },
+  gas:            { label: 'Gas natural',           color: '#d97706', type: 'expense',         Icon: Flame           },
+  water:          { label: 'Agua',                  color: '#06b6d4', type: 'expense',         Icon: Droplets        },
+  internet:       { label: 'Internet / Telefonía',  color: '#0891b2', type: 'expense',         Icon: Wifi            },
+  home:           { label: 'Hogar',                 color: '#0e7490', type: 'expense',         Icon: Home            },
+  clothing:       { label: 'Ropa y calzado',        color: '#ec4899', type: 'expense',         Icon: Shirt           },
+  shopping:       { label: 'Compras',               color: '#db2777', type: 'expense',         Icon: ShoppingBag     },
+  electronics:    { label: 'Electrónica',           color: '#9333ea', type: 'expense',         Icon: Laptop          },
+  health:         { label: 'Salud',                 color: '#10b981', type: 'expense',         Icon: Stethoscope     },
+  pharmacy:       { label: 'Farmacia',              color: '#059669', type: 'expense',         Icon: Pill            },
+  leisure:        { label: 'Ocio',                  color: '#ef4444', type: 'expense',         Icon: Gamepad2        },
+  sports:         { label: 'Deporte',               color: '#dc2626', type: 'expense',         Icon: Dumbbell        },
+  subscriptions:  { label: 'Suscripciones',         color: '#f97316', type: 'expense',         Icon: Repeat2         },
+  travel:         { label: 'Viajes',                color: '#0ea5e9', type: 'expense',         Icon: Plane           },
+  education:      { label: 'Educación',             color: '#a855f7', type: 'expense',         Icon: BookOpen        },
+  insurance:      { label: 'Seguros',               color: '#84cc16', type: 'expense',         Icon: Shield          },
+  beauty:         { label: 'Cuidado personal',      color: '#f472b6', type: 'expense',         Icon: Sparkles        },
+  gifts:          { label: 'Regalos',               color: '#fb7185', type: 'expense',         Icon: Gift            },
+  charity:        { label: 'Solidaridad',           color: '#4ade80', type: 'expense',         Icon: Heart           },
+  memberships:    { label: 'Asociaciones',          color: '#a3e635', type: 'expense',         Icon: Users2          },
+  taxes:          { label: 'Impuestos',             color: '#facc15', type: 'expense',         Icon: Receipt         },
+  loans:          { label: 'Préstamos',             color: '#fb923c', type: 'expense',         Icon: CreditCard      },
+  cash:           { label: 'Efectivo',              color: '#a8a29e', type: 'expense',         Icon: Banknote        },
+  fees:           { label: 'Comisiones',            color: '#94a3b8', type: 'expense',         Icon: Landmark        },
+  other:          { label: 'Otros gastos',          color: '#64748b', type: 'expense',         Icon: MoreHorizontal  },
+  // ── Ingresos ────────────────────────────────────────────────────────────────
+  income:         { label: 'Nómina',                color: '#3b82f6', type: 'income',          Icon: TrendingUp      },
+  returns:        { label: 'Rendimientos',          color: '#0284c7', type: 'income',          Icon: BarChart3       },
+  reimbursement:  { label: 'Reembolso',             color: '#16a34a', type: 'income',          Icon: RotateCcw       },
+  other_income:   { label: 'Otros ingresos',        color: '#6366f1', type: 'income',          Icon: CirclePlus      },
+  // ── No Computable ───────────────────────────────────────────────────────────
+  investment:     { label: 'Inversión',             color: '#059669', type: 'non_computable',  Icon: BarChart3       },
+  savings:        { label: 'Ahorro',                color: '#0d9488', type: 'non_computable',  Icon: PiggyBank       },
+  transfer:       { label: 'Transferencia interna', color: '#78716c', type: 'non_computable',  Icon: ArrowLeftRight  },
+  loan_payment:   { label: 'Amortización',          color: '#b45309', type: 'non_computable',  Icon: Wallet          },
 }
 
 export const GRADIENTS = {

--- a/supabase/migrations/20260509000000_categories_type.sql
+++ b/supabase/migrations/20260509000000_categories_type.sql
@@ -1,0 +1,63 @@
+-- Tabla de categorías con tipo (expense / income / non_computable)
+-- Ref: issue #32 — necesaria para queries de Análisis (Fase 4)
+
+CREATE TABLE IF NOT EXISTS categories (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  color      TEXT NOT NULL,
+  type       TEXT NOT NULL CHECK (type IN ('expense', 'income', 'non_computable')),
+  sort_order INT  NOT NULL DEFAULT 0
+);
+
+-- Sin RLS: datos de referencia compartidos (no por usuario)
+
+-- ─── GASTOS ──────────────────────────────────────────────────────────────────
+INSERT INTO categories (id, name, color, type, sort_order) VALUES
+  ('groceries',      'Supermercado',          '#22c55e', 'expense',         1),
+  ('restaurant',     'Restaurantes',           '#f59e0b', 'expense',         2),
+  ('transport',      'Transporte público',     '#8b5cf6', 'expense',         3),
+  ('fuel',           'Gasolina',               '#7c3aed', 'expense',         4),
+  ('parking',        'Parking y Peaje',        '#6d28d9', 'expense',         5),
+  ('vehicle',        'Vehículo',               '#5b21b6', 'expense',         6),
+  ('mortgage',       'Hipoteca / Alquiler',    '#0284c7', 'expense',         7),
+  ('community_fees', 'Comunidad de vecinos',   '#0369a1', 'expense',         8),
+  ('electricity',    'Electricidad',           '#f59e0b', 'expense',         9),
+  ('gas',            'Gas natural',            '#d97706', 'expense',        10),
+  ('water',          'Agua',                   '#06b6d4', 'expense',        11),
+  ('internet',       'Internet / Telefonía',   '#0891b2', 'expense',        12),
+  ('home',           'Hogar',                  '#0e7490', 'expense',        13),
+  ('clothing',       'Ropa y calzado',         '#ec4899', 'expense',        14),
+  ('shopping',       'Compras',                '#db2777', 'expense',        15),
+  ('electronics',    'Electrónica',            '#9333ea', 'expense',        16),
+  ('health',         'Salud',                  '#10b981', 'expense',        17),
+  ('pharmacy',       'Farmacia',               '#059669', 'expense',        18),
+  ('leisure',        'Ocio',                   '#ef4444', 'expense',        19),
+  ('sports',         'Deporte',                '#dc2626', 'expense',        20),
+  ('subscriptions',  'Suscripciones',          '#f97316', 'expense',        21),
+  ('travel',         'Viajes',                 '#0ea5e9', 'expense',        22),
+  ('education',      'Educación',              '#a855f7', 'expense',        23),
+  ('insurance',      'Seguros',                '#84cc16', 'expense',        24),
+  ('beauty',         'Cuidado personal',       '#f472b6', 'expense',        25),
+  ('gifts',          'Regalos',                '#fb7185', 'expense',        26),
+  ('charity',        'Solidaridad',            '#4ade80', 'expense',        27),
+  ('memberships',    'Asociaciones',           '#a3e635', 'expense',        28),
+  ('taxes',          'Impuestos',              '#facc15', 'expense',        29),
+  ('loans',          'Préstamos',              '#fb923c', 'expense',        30),
+  ('cash',           'Efectivo',               '#a8a29e', 'expense',        31),
+  ('fees',           'Comisiones',             '#94a3b8', 'expense',        32),
+  ('other',          'Otros gastos',           '#64748b', 'expense',        33),
+
+-- ─── INGRESOS ────────────────────────────────────────────────────────────────
+  ('income',         'Nómina',                 '#3b82f6', 'income',         34),
+  ('returns',        'Rendimientos',           '#0284c7', 'income',         35),
+  ('reimbursement',  'Reembolso',              '#16a34a', 'income',         36),
+  ('other_income',   'Otros ingresos',         '#6366f1', 'income',         37),
+
+-- ─── NO COMPUTABLE ────────────────────────────────────────────────────────────
+  ('investment',     'Inversión',              '#059669', 'non_computable', 38),
+  ('savings',        'Ahorro',                 '#0d9488', 'non_computable', 39),
+  ('transfer',       'Transferencia interna',  '#78716c', 'non_computable', 40),
+  ('loan_payment',   'Amortización',           '#b45309', 'non_computable', 41);
+
+-- Índice para filtrar por tipo en queries de Análisis
+CREATE INDEX IF NOT EXISTS categories_type_idx ON categories (type);

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,15 +1,52 @@
 export type AccountType = 'bank' | 'card' | 'edenred' | 'cash'
 export type DataSource = 'enablebanking' | 'scraper' | 'manual'
+export type CategoryType = 'expense' | 'income' | 'non_computable'
+
 export type CategoryId =
+  // Gastos
   | 'groceries'
   | 'restaurant'
   | 'transport'
+  | 'fuel'
+  | 'parking'
+  | 'vehicle'
+  | 'mortgage'
+  | 'community_fees'
+  | 'electricity'
+  | 'gas'
+  | 'water'
+  | 'internet'
   | 'home'
-  | 'leisure'
+  | 'clothing'
   | 'shopping'
+  | 'electronics'
   | 'health'
-  | 'income'
+  | 'pharmacy'
+  | 'leisure'
+  | 'sports'
+  | 'subscriptions'
+  | 'travel'
+  | 'education'
+  | 'insurance'
+  | 'beauty'
+  | 'gifts'
+  | 'charity'
+  | 'memberships'
+  | 'taxes'
+  | 'loans'
+  | 'cash'
+  | 'fees'
   | 'other'
+  // Ingresos
+  | 'income'
+  | 'returns'
+  | 'reimbursement'
+  | 'other_income'
+  // No Computable
+  | 'investment'
+  | 'savings'
+  | 'transfer'
+  | 'loan_payment'
 
 export interface Account {
   id: string
@@ -51,6 +88,7 @@ export interface Category {
   id: CategoryId
   name: string
   color: string
+  type: CategoryType
 }
 
 export interface TransactionWithAccount extends Transaction {


### PR DESCRIPTION
## Resumen

- Añade campo `type` (`expense | income | non_computable`) a todas las categorías
- Amplía el catálogo de 9 a 41 categorías granulares (estilo Fintonic), todos los IDs en inglés
- Tabla `categories` en Supabase para JOIN en queries de Análisis (Fase 4)
- `CategoryPicker` rediseñado con selector de tipo + grid 4 columnas scrollable

## Cambios

- `supabase/migrations/20260509000000_categories_type.sql` — tabla `categories` con 41 entradas seeded
- `types/index.ts` — `CategoryType` + `CategoryId` expandido (41 IDs)
- `lib/theme.ts` — `CATEGORY_META` con campo `type` e iconos Lucide para todas las categorías
- `lib/categories.ts` — `AUTO_RULES` ampliado con patrones para nuevas categorías españolas
- `app/api/transactions/[id]/route.ts` — `VALID_CATEGORIES` actualizado con lista completa
- `components/transactions/CategoryPicker.tsx` — selector tipo (Gastos / Ingresos / No Computable) + grid scrollable

## Test plan

- [ ] Migración aplicada en Supabase local — 41 filas en tabla `categories`
- [ ] `pnpm build` sin errores TypeScript ✅
- [ ] CategoryPicker abre en la sección correcta según la categoría actual de la transacción
- [ ] Se puede recategorizar a cualquiera de las 41 categorías desde swipe y desde modal
- [ ] Una transacción categorizada como `investment` no suma en totales de Análisis

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)