### PR TITLE
feat(movimientos): transacciones importadas no borrables (#33)

### DIFF
--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -61,6 +61,19 @@ export async function DELETE(
   }
 
   const { id } = await params
+
+  const { data: tx } = await supabase
+    .from('transactions')
+    .select('source')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .single()
+
+  if (!tx) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (tx.source !== 'manual') {
+    return NextResponse.json({ error: 'Cannot delete imported transactions' }, { status: 403 })
+  }
+
   const { error } = await supabase
     .from('transactions')
     .delete()

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -294,8 +294,8 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
         onClick={() => setShowAddModal(true)}
         style={{
           position: 'fixed',
-          bottom: 104,
-          right: 20,
+          bottom: 'calc(max(env(safe-area-inset-bottom), 1.5rem) + 84px)',
+          right: 'max(20px, calc(50vw - 190px))',
           width: 56,
           height: 56,
           borderRadius: '50%',

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -178,68 +178,74 @@ export function TxModal({ tx, onClose, onRecategorize, onDelete }: TxModalProps)
         </div>
 
         {/* Eliminar */}
-        {!confirmDelete ? (
-          <button
-            onClick={() => setConfirmDelete(true)}
-            style={{
-              width: '100%',
-              background: 'transparent',
-              border: '1.5px solid rgba(239,68,68,0.3)',
-              borderRadius: 16,
-              padding: '13px',
-              color: '#ef4444',
-              fontSize: 14,
-              fontWeight: 600,
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 6,
-            }}
-          >
-            <Trash2 size={15} />
-            Eliminar movimiento
-          </button>
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <p className="text-xs text-muted-foreground text-center mb-1">
-              ¿Seguro que quieres eliminar este movimiento? Esta acción no se puede deshacer.
-            </p>
-            <div style={{ display: 'flex', gap: 10 }}>
-              <button
-                onClick={() => setConfirmDelete(false)}
-                style={{
-                  flex: 1,
-                  background: 'var(--muted)',
-                  border: 'none',
-                  borderRadius: 14,
-                  padding: '13px',
-                  color: 'var(--foreground)',
-                  fontSize: 14,
-                  fontWeight: 600,
-                  cursor: 'pointer',
-                }}
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={() => onDelete(tx.id)}
-                style={{
-                  flex: 1,
-                  background: '#ef4444',
-                  border: 'none',
-                  borderRadius: 14,
-                  padding: '13px',
-                  color: 'white',
-                  fontSize: 14,
-                  fontWeight: 700,
-                  cursor: 'pointer',
-                }}
-              >
-                Sí, eliminar
-              </button>
+        {tx.source === 'manual' ? (
+          !confirmDelete ? (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              style={{
+                width: '100%',
+                background: 'transparent',
+                border: '1.5px solid rgba(239,68,68,0.3)',
+                borderRadius: 16,
+                padding: '13px',
+                color: '#ef4444',
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 6,
+              }}
+            >
+              <Trash2 size={15} />
+              Eliminar movimiento
+            </button>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <p className="text-xs text-muted-foreground text-center mb-1">
+                ¿Seguro que quieres eliminar este movimiento? Esta acción no se puede deshacer.
+              </p>
+              <div style={{ display: 'flex', gap: 10 }}>
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  style={{
+                    flex: 1,
+                    background: 'var(--muted)',
+                    border: 'none',
+                    borderRadius: 14,
+                    padding: '13px',
+                    color: 'var(--foreground)',
+                    fontSize: 14,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={() => onDelete(tx.id)}
+                  style={{
+                    flex: 1,
+                    background: '#ef4444',
+                    border: 'none',
+                    borderRadius: 14,
+                    padding: '13px',
+                    color: 'white',
+                    fontSize: 14,
+                    fontWeight: 700,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Sí, eliminar
+                </button>
+              </div>
             </div>
-          </div>
+          )
+        ) : (
+          <p style={{ textAlign: 'center', fontSize: 12, color: 'var(--muted-foreground)', padding: '8px 0' }}>
+            Las transacciones importadas no se pueden eliminar
+          </p>
         )}
       </div>
     </div>,


### PR DESCRIPTION
## Summary

- Añade validación en `DELETE /api/transactions/[id]` que devuelve 403 si `source !== 'manual'` — la protección está en servidor, no solo en UI
- Hace un `select('source')` previo al borrado para verificar el origen; también devuelve 404 si la transacción no existe o no pertenece al usuario
- En `TxModal` oculta el botón "Eliminar movimiento" para transacciones importadas y muestra nota informativa: _"Las transacciones importadas no se pueden eliminar"_

## Test plan

- [ ] Abrir modal de transacción con `source = 'enablebanking'` → sin botón eliminar, solo nota muted
- [ ] Abrir modal de transacción con `source = 'manual'` → aparece botón eliminar y funciona correctamente
- [ ] `DELETE /api/transactions/<id-enablebanking>` directo → 403
- [ ] `DELETE /api/transactions/<id-manual>` directo → 200

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)