### PR TITLE
feat(categories): ampliar reglas de categorización automática (#34)

### DIFF
--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getAccountTransactions } from '@/lib/enablebanking'
-import { categorize } from '@/lib/categories'
+import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 
 export async function POST() {
   // Auth: verify user via cookie client
@@ -15,17 +15,28 @@ export async function POST() {
   // All DB writes via service client (bypasses RLS)
   const db = createServiceClient()
 
-  const { data: accounts, error: accError } = await db
-    .from('accounts')
-    .select('id, external_id, session_id, last_synced')
-    .eq('user_id', user.id)
-    .eq('source', 'enablebanking')
-    .eq('is_active', true)
+  const [accountsResult, rulesResult] = await Promise.all([
+    db
+      .from('accounts')
+      .select('id, external_id, session_id, last_synced')
+      .eq('user_id', user.id)
+      .eq('source', 'enablebanking')
+      .eq('is_active', true),
+    db
+      .from('categorization_rules')
+      .select('pattern, field, category_id')
+      .eq('user_id', user.id)
+      .eq('is_active', true)
+      .order('priority', { ascending: false }),
+  ])
 
-  if (accError) {
-    console.error('[sync/eb] fetch accounts:', accError)
+  if (accountsResult.error) {
+    console.error('[sync/eb] fetch accounts:', accountsResult.error)
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
+
+  const accounts = accountsResult.data
+  const dbRules: DbCategorizationRule[] = (rulesResult.data ?? []) as DbCategorizationRule[]
 
   if (!accounts || accounts.length === 0) {
     return NextResponse.json({ synced: 0, accounts: 0 })
@@ -60,6 +71,7 @@ export async function POST() {
           tx.creditor?.name ||
           tx.debtor?.name ||
           'Sin descripción'
+        const merchant = tx.creditor?.name ?? tx.debtor?.name ?? undefined
         const sign = tx.credit_debit_indicator === 'DBIT' ? -1 : 1
         const amount = parseFloat(tx.transaction_amount.amount) * sign
 
@@ -69,7 +81,7 @@ export async function POST() {
           date:                 tx.booking_date,
           amount,
           description,
-          category:             categorize(description),
+          category:             categorizeWithRules(dbRules, description, merchant ?? undefined),
           source:               'enablebanking' as const,
           external_id:          externalId,
           is_computable:        true,

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,10 +1,14 @@
 import type { CategoryId } from '@/types'
 
-export const AUTO_RULES: { pattern: RegExp; category: CategoryId }[] = [
+type RuleField = 'description' | 'merchant'
+
+export const AUTO_RULES: { pattern: RegExp; category: CategoryId; field?: RuleField }[] = [
   // Supermercado
   { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor/i, category: 'groceries' },
   // Restaurantes
-  { pattern: /restaurante|mcdonalds|burger king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter/i, category: 'restaurant' },
+  { pattern: /restaurante|mcdonalds|burger.?king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter/i, category: 'restaurant' },
+  // Comida a domicilio
+  { pattern: /glovo|deliveroo|just.?eat|uber.?eats/i, category: 'restaurant' },
   // Transporte público
   { pattern: /renfe|metro|emt\b|avlo|ouigo|blablacar|cabify|uber\b|bolt\b|transporte/i, category: 'transport' },
   // Gasolina
@@ -15,12 +19,14 @@ export const AUTO_RULES: { pattern: RegExp; category: CategoryId }[] = [
   { pattern: /taller|itv\b|neumatico|concesionario|mapfre auto|adeslas auto|midas|norauto/i, category: 'vehicle' },
   // Hipoteca / Alquiler
   { pattern: /hipoteca|prestamo hipotecario|alquiler|arrendamiento/i, category: 'mortgage' },
-  // Comunidad
+  // Amortización de préstamo
+  { pattern: /cuota prestamo|cuota credito|amortizacion prestamo|pago prestamo/i, category: 'loan_payment' },
+  // Comunidad de propietarios
   { pattern: /comunidad de propietarios|comunidad vecinos|administrador fincas/i, category: 'community_fees' },
   // Electricidad
   { pattern: /endesa|iberdrola|naturgy|holaluz|octopus energy|luz\b|electricidad/i, category: 'electricity' },
   // Gas natural
-  { pattern: /naturgy gas|gas natural|repsol gas\b|madrileña de gas/i, category: 'gas' },
+  { pattern: /naturgy gas|gas natural|repsol gas\b|madrile.a de gas/i, category: 'gas' },
   // Agua
   { pattern: /canal de isabel|aguas de|abastecimiento|suministro agua/i, category: 'water' },
   // Internet / Telefonía
@@ -31,33 +37,70 @@ export const AUTO_RULES: { pattern: RegExp; category: CategoryId }[] = [
   { pattern: /zara\b|mango\b|hm\b|h&m|pull.and.bear|bershka|stradivarius|primark|lefties|el corte ingles moda/i, category: 'clothing' },
   // Electrónica
   { pattern: /apple store|fnac|mediamarkt|pccomponentes|worten|samsung store/i, category: 'electronics' },
+  // Compras generales (Amazon, El Corte Inglés, paquetería)
+  { pattern: /amazon\b|el corte ingles|correos\b|mrw\b|seur\b|ups\b|dhl\b/i, category: 'shopping' },
   // Salud
   { pattern: /clinica|hospital|sanitas|adeslas|quironsalud|dentista|oculista|optica|medico/i, category: 'health' },
   // Farmacia
   { pattern: /farmacia|parafarmacia|farmacor/i, category: 'pharmacy' },
+  // Belleza y cuidado personal
+  { pattern: /peluquer|barberia|estetica|manicura|beauty/i, category: 'beauty' },
   // Ocio
   { pattern: /cine|teatro|concierto|entradas|ticketmaster|eventbrite|amazon prime video|disney\+|hbo/i, category: 'leisure' },
   // Deporte
-  { pattern: /gimnasio|gym\b|decathlon|intersport|just eat sport|padel|tenis|natacion/i, category: 'sports' },
+  { pattern: /gimnasio|gym\b|decathlon|intersport|padel|tenis|natacion/i, category: 'sports' },
   // Suscripciones
   { pattern: /netflix|spotify|apple\.com\/bill|google one|microsoft 365|adobe|youtube premium|hbo max|paramount/i, category: 'subscriptions' },
   // Viajes
-  { pattern: /booking\.com|airbnb|ryanair|vueling|iberia|aena|hotel|hostal|alojamiento/i, category: 'travel' },
+  { pattern: /booking\.com|airbnb|ryanair|vueling|iberia\b|iberia express|easyjet|aena|hotel|hostal|alojamiento/i, category: 'travel' },
   // Educación
   { pattern: /udemy|coursera|openwebinars|universidad|escuela|academia|fnac libros/i, category: 'education' },
-  // Seguros
+  // Recibo de seguro (antes que recibo genérico)
+  { pattern: /recibo\s+(?:seguro|axa|mapfre|allianz|mutua|linea directa|generali)/i, category: 'insurance' },
+  // Seguros (descripción o comercio)
   { pattern: /seguros|mutua madrilena|linea directa|axa\b|allianz|generali|mapfre seguro/i, category: 'insurance' },
-  // Nómina
-  { pattern: /nomina|salario|payroll|haberes/i, category: 'income' },
-  // Reembolso
-  { pattern: /devolucion|reembolso|hacienda|agencia tributaria|reintegro/i, category: 'reimbursement' },
+  // Recibo genérico (domiciliaciones)
+  { pattern: /recibo\b/i, category: 'fees' },
+  // Impuestos y tasas
+  { pattern: /hacienda|agencia tributaria|aeat\b|impuesto|ivtm|ibi\b|tasa\b/i, category: 'taxes' },
+  // Nómina e ingresos laborales
+  { pattern: /nomina|salario|payroll|haberes|retribucion/i, category: 'income' },
+  // Reembolso / Devolución (antes que hacienda genérico)
+  { pattern: /devolucion|reembolso|reintegro/i, category: 'reimbursement' },
+  // Transferencia entre cuentas propias
+  { pattern: /transferencia propia|traspaso propio|traspaso entre cuentas/i, category: 'transfer' },
+  // Retirada de efectivo
+  { pattern: /cajero|reintegro efectivo|retirada efectivo|withdrawal/i, category: 'cash' },
+  // Bizum (demasiado genérico para categorizar con precisión)
+  { pattern: /bizum/i, category: 'other' },
   // Inversión
   { pattern: /degiro|myinvestor|indexa capital|openbroker|interactive brokers|trading212|etf\b|fondo de inversion/i, category: 'investment' },
 ]
 
-export function categorize(description: string): CategoryId | null {
+export interface DbCategorizationRule {
+  pattern: string
+  field: 'description' | 'merchant' | 'iban'
+  category_id: string
+}
+
+export function categorize(description: string, merchant?: string): CategoryId | null {
   for (const rule of AUTO_RULES) {
-    if (rule.pattern.test(description)) return rule.category
+    const target = rule.field === 'merchant' ? (merchant ?? '') : description
+    if (target && rule.pattern.test(target)) return rule.category
   }
   return null
+}
+
+export function categorizeWithRules(
+  dbRules: DbCategorizationRule[],
+  description: string,
+  merchant?: string
+): CategoryId | null {
+  for (const rule of dbRules) {
+    const target = rule.field === 'merchant' ? (merchant ?? '') : description
+    if (target && new RegExp(rule.pattern, 'i').test(target)) {
+      return rule.category_id as CategoryId
+    }
+  }
+  return categorize(description, merchant)
 }

--- a/supabase/migrations/20260510000000_categorization_rules.sql
+++ b/supabase/migrations/20260510000000_categorization_rules.sql
@@ -1,0 +1,23 @@
+-- Reglas de categorización persistentes definidas por el usuario.
+-- Se evalúan en orden de prioridad antes que las reglas estáticas de lib/categories.ts.
+-- Ref: §14.1 del spec.
+
+CREATE TABLE categorization_rules (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  pattern     TEXT NOT NULL,
+  field       TEXT NOT NULL CHECK (field IN ('description', 'merchant', 'iban')),
+  category_id TEXT NOT NULL REFERENCES categories(id),
+  priority    INTEGER NOT NULL DEFAULT 0,
+  is_active   BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE categorization_rules ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "own_rules" ON categorization_rules
+  FOR ALL USING (user_id = auth.uid());
+
+CREATE INDEX idx_categorization_rules_user
+  ON categorization_rules (user_id, priority DESC)
+  WHERE is_active;


### PR DESCRIPTION
## Summary

- Crea tabla `categorization_rules` en DB para reglas persistentes de usuario (§14.1 del spec), con RLS y campo `field` ('description' | 'merchant' | 'iban')
- Amplía `lib/categories.ts` de 25 a 35 reglas estáticas: Bizum, Amazon/El Corte Inglés, Glovo/Deliveroo/Just Eat, belleza, seguros por recibo, impuestos/AEAT, préstamos, transferencias propias, retiradas de cajero, más aerolíneas
- `categorize()` acepta `merchant?` como segundo parámetro para matching por nombre de comercio (creditor/debtor name de EnableBanking)
- Nueva función `categorizeWithRules()` que aplica reglas DB (mayor prioridad) antes que las estáticas
- Sync route carga reglas DB en paralelo con la query de cuentas y extrae merchant de cada transacción

## Decisiones de diseño

- `category_manual` TEXT existente ya distingue auto (NULL) vs manual (NOT NULL) — no hace falta el booleano del issue
- `ignoreDuplicates: true` en upsert ya protege las categorizaciones manuales del usuario
- Las transacciones de EnableBanking no exponen IBAN en creditor/debtor, por lo que el matching por IBAN queda para reglas de usuario en DB (futura UI en §14.2)

## Test plan

- [ ] Aplicar migración en Supabase (`supabase db push`)
- [ ] `POST /api/sync/enablebanking` — verificar que transacciones nuevas reciben categoría
- [ ] Comprobar que transacciones con `category_manual` existente no se sobreescriben
- [ ] Insertar una fila en `categorization_rules` y verificar que tiene prioridad sobre las estáticas

🤖 Generated with [Claude Code](https://claude.com/claude-code)