### PR TITLE
feat(analytics): SQL de agregación + API route de período (#40)

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getWindowPeriods, getYoYRange, toISODate } from '@/lib/analytics'
+import type { Granularity, PeriodData, AnalyticsResponse } from '@/types'
+
+const VALID_GRAN: Granularity[] = ['week', 'month', 'quarter', 'year']
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const gran = searchParams.get('gran') as Granularity
+  const offset = parseInt(searchParams.get('offset') ?? '0', 10)
+
+  if (!VALID_GRAN.includes(gran) || isNaN(offset) || offset < 0) {
+    return NextResponse.json({ error: 'Invalid params' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const window = getWindowPeriods(gran, offset)
+
+    const periods: PeriodData[] = await Promise.all(
+      window.map(async (range) => {
+        const yoy = getYoYRange(range)
+        const [cur, prev] = await Promise.all([
+          supabase.rpc('get_period_data', {
+            p_user_id:    user.id,
+            p_start_date: toISODate(range.start),
+            p_end_date:   toISODate(range.end),
+          }),
+          supabase.rpc('get_period_data', {
+            p_user_id:    user.id,
+            p_start_date: toISODate(yoy.start),
+            p_end_date:   toISODate(yoy.end),
+          }),
+        ])
+
+        const curRow  = cur.data?.[0]
+        const prevRow = prev.data?.[0]
+        // §5.7: null cuando no hay transacciones del período del año anterior
+        const hasYoy  = prevRow && (Number(prevRow.ingresos) > 0 || Number(prevRow.gastos) > 0)
+
+        return {
+          label:       range.label,
+          start:       toISODate(range.start),
+          end:         toISODate(range.end),
+          ingresos:    Number(curRow?.ingresos   ?? 0),
+          gastos:      Number(curRow?.gastos     ?? 0),
+          ahorro:      Number(curRow?.ahorro     ?? 0),
+          byCategory:  curRow?.by_category ?? [],
+          yoyIngresos: hasYoy ? Number(prevRow.ingresos) : null,
+          yoyGastos:   hasYoy ? Number(prevRow.gastos)   : null,
+        }
+      })
+    )
+
+    return NextResponse.json({ gran, periods } satisfies AnalyticsResponse)
+  } catch (e) {
+    console.error('[GET /api/analytics]', e)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,100 @@
+import type { Granularity } from '@/types'
+
+export interface PeriodRange {
+  start: Date
+  end: Date
+  label: string
+}
+
+const WINDOW_SIZE: Record<Granularity, number> = {
+  week: 9,
+  month: 12,
+  quarter: 10,
+  year: 8,
+}
+
+const MONTH_LABELS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
+// Semana lun–dom que contiene hoy, desplazada `offset` semanas atrás (§5.1)
+function getWeekRange(offset: number): PeriodRange {
+  const now = new Date()
+  const dow = now.getDay() // 0=dom … 6=sab
+  const daysToMonday = (dow + 6) % 7
+  const monday = new Date(now)
+  monday.setDate(now.getDate() - daysToMonday - offset * 7)
+  monday.setHours(0, 0, 0, 0)
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+  sunday.setHours(23, 59, 59, 999)
+
+  const d = monday.getDate()
+  const m = MONTH_LABELS[monday.getMonth()]
+  const label = `${d} ${m}`
+
+  return { start: monday, end: sunday, label }
+}
+
+function getMonthRange(offset: number): PeriodRange {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() - offset
+  const start = new Date(year, month, 1)
+  const end = new Date(year, month + 1, 0, 23, 59, 59, 999)
+  const label = MONTH_LABELS[((month % 12) + 12) % 12]
+  return { start, end, label }
+}
+
+function getQuarterRange(offset: number): PeriodRange {
+  const now = new Date()
+  const totalMonths = now.getFullYear() * 12 + now.getMonth() - offset * 3
+  const year = Math.floor(totalMonths / 12)
+  const month = totalMonths % 12
+  const q = Math.floor(month / 3)
+  const startMonth = q * 3
+  const start = new Date(year, startMonth, 1)
+  const end = new Date(year, startMonth + 3, 0, 23, 59, 59, 999)
+  const label = `Q${q + 1} ${year}`
+  return { start, end, label }
+}
+
+function getYearRange(offset: number): PeriodRange {
+  const year = new Date().getFullYear() - offset
+  const start = new Date(year, 0, 1)
+  const end = new Date(year, 11, 31, 23, 59, 59, 999)
+  return { start, end, label: String(year) }
+}
+
+export function getPeriodRange(gran: Granularity, offset: number): PeriodRange {
+  switch (gran) {
+    case 'week':    return getWeekRange(offset)
+    case 'month':   return getMonthRange(offset)
+    case 'quarter': return getQuarterRange(offset)
+    case 'year':    return getYearRange(offset)
+  }
+}
+
+// Devuelve N rangos terminando en (período actual − offset), del más antiguo al más reciente
+export function getWindowPeriods(gran: Granularity, offset: number): PeriodRange[] {
+  const n = WINDOW_SIZE[gran]
+  return Array.from({ length: n }, (_, i) => getPeriodRange(gran, offset + (n - 1 - i)))
+}
+
+// Mismo rango pero −1 año (para comparativa YoY, §5.2)
+export function getYoYRange(range: PeriodRange): PeriodRange {
+  const start = new Date(range.start)
+  const end = new Date(range.end)
+  start.setFullYear(start.getFullYear() - 1)
+  end.setFullYear(end.getFullYear() - 1)
+  return { start, end, label: range.label }
+}
+
+// '+X%' / '-X%' / 'N/A' si previous === 0  (§5.2)
+export function yoyDelta(current: number, previous: number): string {
+  if (previous === 0) return 'N/A'
+  const pct = ((current - previous) / previous) * 100
+  return `${pct >= 0 ? '+' : ''}${pct.toFixed(0)}%`
+}
+
+export function toISODate(d: Date): string {
+  return d.toISOString().split('T')[0]
+}

--- a/supabase/migrations/20260510000001_analytics_period_function.sql
+++ b/supabase/migrations/20260510000001_analytics_period_function.sql
@@ -1,0 +1,46 @@
+-- Issue #40: Función get_period_data para la API de análisis (§5.4)
+-- Agrega transacciones computables en un rango de fechas arbitrario,
+-- soportando las 4 granularidades (semana, mes, trimestre, año).
+
+CREATE OR REPLACE FUNCTION get_period_data(
+  p_user_id    UUID,
+  p_start_date DATE,
+  p_end_date   DATE
+) RETURNS TABLE (
+  ingresos    DECIMAL,
+  gastos      DECIMAL,
+  ahorro      DECIMAL,
+  by_category JSONB
+) LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH txs AS (
+    SELECT amount, COALESCE(category_manual, category) AS cat
+    FROM   transactions
+    WHERE  user_id              = p_user_id
+      AND  date BETWEEN p_start_date AND p_end_date
+      AND  is_computable        = true
+      AND  is_internal_transfer = false
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0)       AS inc,
+      COALESCE(ABS(SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END)), 0)  AS exp
+    FROM txs
+  ),
+  cats AS (
+    SELECT cat, SUM(amount) AS total
+    FROM   txs
+    GROUP  BY cat
+  )
+  SELECT
+    totals.inc,
+    totals.exp,
+    totals.inc - totals.exp AS sav,
+    COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object('category', cat, 'amount', total)) FROM cats),
+      '[]'::jsonb
+    )
+  FROM totals;
+END;
+$$;

--- a/types/index.ts
+++ b/types/index.ts
@@ -103,3 +103,27 @@ export interface UserConfig {
   created_at: string
   updated_at: string
 }
+
+export type Granularity = 'week' | 'month' | 'quarter' | 'year'
+
+export interface CategoryBreakdown {
+  category: CategoryId | null
+  amount: number
+}
+
+export interface PeriodData {
+  label: string
+  start: string        // 'YYYY-MM-DD'
+  end: string          // 'YYYY-MM-DD'
+  ingresos: number
+  gastos: number
+  ahorro: number
+  byCategory: CategoryBreakdown[]
+  yoyIngresos: number | null  // null si no hay histórico suficiente (§5.7)
+  yoyGastos: number | null
+}
+
+export interface AnalyticsResponse {
+  gran: Granularity
+  periods: PeriodData[]
+}


### PR DESCRIPTION
## Resumen

- Migración SQL con la función `get_period_data()` que agrega transacciones en un rango arbitrario de fechas (ingresos, gastos, ahorro, by_category JSONB)
- `lib/analytics.ts`: helpers de rangos para las 4 granularidades (semana lun–dom, mes, trimestre, año), ventana de N períodos, comparativa YoY y `yoyDelta`
- `GET /api/analytics?gran=&offset=`: devuelve array de N períodos con datos reales + YoY nulo cuando no hay histórico (§5.7)
- Tipos `Granularity`, `CategoryBreakdown`, `PeriodData`, `AnalyticsResponse` en `types/index.ts`

## Plan de verificación

- [ ] Aplicar migración `20260510000001_analytics_period_function.sql` en Supabase SQL Editor
- [ ] `GET /api/analytics?gran=month&offset=0` devuelve 12 períodos con datos reales
- [ ] `GET /api/analytics?gran=week&offset=0` devuelve 9 semanas
- [ ] `GET /api/analytics?gran=quarter&offset=0` devuelve 10 trimestres
- [ ] `GET /api/analytics?gran=year&offset=0` devuelve 8 años
- [ ] `yoyIngresos` / `yoyGastos` son `null` cuando no hay histórico del año anterior
- [ ] `pnpm build` pasa sin errores TypeScript ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)