### PR TITLE
feat(analytics): pantalla base, GranPicker y Card de Ahorro (#41)

### DIFF
--- a/app/(app)/analisis/layout.tsx
+++ b/app/(app)/analisis/layout.tsx
@@ -1,0 +1,5 @@
+import { AnalyticsProvider } from '@/contexts/AnalyticsContext'
+
+export default function AnalisisLayout({ children }: { children: React.ReactNode }) {
+  return <AnalyticsProvider>{children}</AnalyticsProvider>
+}

--- a/app/(app)/analisis/page.tsx
+++ b/app/(app)/analisis/page.tsx
@@ -1,8 +1,5 @@
+import AnalyticsClient from '@/components/analytics/AnalyticsClient'
+
 export default function AnalisisPage() {
-  return (
-    <div className="px-6 pt-14">
-      <h1 className="text-lg font-bold text-foreground">Análisis</h1>
-      <p className="text-muted-foreground text-sm mt-2">Próximamente</p>
-    </div>
-  )
+  return <AnalyticsClient />
 }

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { AnalyticsResponse } from '@/types'
+import { useAnalytics } from '@/contexts/AnalyticsContext'
+import { PERIOD_LABELS } from '@/lib/analytics'
+import GranPicker from './GranPicker'
+import SavingsCard from './SavingsCard'
+
+function CalendarIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  )
+}
+
+function SavingsCardSkeleton() {
+  return (
+    <div
+      className="animate-pulse"
+      style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20, height: 120 }}
+    />
+  )
+}
+
+export default function AnalyticsClient() {
+  const { gran, showPicker, setShowPicker } = useAnalytics()
+  const [data, setData] = useState<AnalyticsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    setData(null)
+    fetch(`/api/analytics?gran=${gran}&offset=0`)
+      .then(r => r.json())
+      .then((d: AnalyticsResponse) => {
+        setData(d)
+        setLoading(false)
+      })
+  }, [gran])
+
+  const current = data?.periods[data.periods.length - 1]
+
+  return (
+    <div>
+      {/* Sticky header */}
+      <div
+        className="sticky top-0 z-50 flex items-center justify-between border-b border-border px-5 pb-3.5"
+        style={{
+          background: 'color-mix(in srgb, var(--background) 92%, transparent)',
+          backdropFilter: 'blur(16px)',
+          paddingTop: 52,
+        }}
+      >
+        <span className="text-xl font-bold text-foreground">Análisis</span>
+        <button
+          onClick={() => setShowPicker(true)}
+          className="flex items-center gap-1.5 rounded-full px-3 py-1.5 cursor-pointer"
+          style={{
+            background: 'color-mix(in srgb, #6366f1 12%, transparent)',
+            border: '1px solid color-mix(in srgb, #6366f1 27%, transparent)',
+            color: '#6366f1',
+          }}
+        >
+          <CalendarIcon />
+          <span className="text-xs font-bold">{PERIOD_LABELS[gran]}</span>
+          <span className="text-[10px] opacity-70">▾</span>
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-5 py-3 flex flex-col gap-4">
+        {loading || !current ? (
+          <SavingsCardSkeleton />
+        ) : (
+          <SavingsCard ingresos={current.ingresos} ahorro={current.ahorro} gran={gran} />
+        )}
+      </div>
+
+      {showPicker && <GranPicker />}
+    </div>
+  )
+}

--- a/components/analytics/GranPicker.tsx
+++ b/components/analytics/GranPicker.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+import type { Granularity } from '@/types'
+import { useAnalytics } from '@/contexts/AnalyticsContext'
+
+const MONTHS_LONG = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
+const MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic']
+const QUARTER_MONTHS: [string, string, string][] = [
+  ['ene', 'feb', 'mar'],
+  ['abr', 'may', 'jun'],
+  ['jul', 'ago', 'sep'],
+  ['oct', 'nov', 'dic'],
+]
+
+function getSubtitle(gran: Granularity, now: Date): string {
+  const y = now.getFullYear()
+  const m = now.getMonth()
+  const d = now.getDate()
+
+  if (gran === 'week') {
+    const dayOfWeek = (now.getDay() + 6) % 7 // Monday = 0
+    const monday = new Date(now)
+    monday.setDate(d - dayOfWeek)
+    const weekOfMonth = Math.ceil(monday.getDate() / 7)
+    return `Sem ${weekOfMonth} de ${MONTHS_LONG[monday.getMonth()]}`
+  }
+  if (gran === 'month') return `${MONTHS_LONG[m]} ${y}`
+  if (gran === 'quarter') {
+    const q = Math.floor(m / 3)
+    const [a, b, c] = QUARTER_MONTHS[q]
+    return `T${q + 1} · ${a}-${c} ${y}`
+  }
+  return String(y)
+}
+
+const OPTIONS: { id: Granularity; label: string }[] = [
+  { id: 'week', label: 'Semana' },
+  { id: 'month', label: 'Mes' },
+  { id: 'quarter', label: 'Trimestre' },
+  { id: 'year', label: 'Año' },
+]
+
+export default function GranPicker() {
+  const { gran, setGran, setShowPicker } = useAnalytics()
+  const now = new Date()
+
+  function select(g: Granularity) {
+    setGran(g)
+    setShowPicker(false)
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(8px)', zIndex: 300 }}
+      onClick={() => setShowPicker(false)}
+    >
+      <div
+        className="w-full mx-auto bg-popover flex flex-col"
+        style={{ maxWidth: 420, borderRadius: '28px 28px 0 0', padding: '20px 20px 40px' }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+        <p className="text-base font-bold text-foreground text-center mb-4">Ver por período</p>
+        <div className="flex flex-col gap-2">
+          {OPTIONS.map(o => {
+            const active = gran === o.id
+            return (
+              <button
+                key={o.id}
+                onClick={() => select(o.id)}
+                className="flex items-center justify-between rounded-2xl border-none cursor-pointer transition-all duration-150"
+                style={{
+                  padding: '14px 16px',
+                  background: active ? 'color-mix(in srgb, #6366f1 12%, transparent)' : 'var(--secondary)',
+                  borderLeft: active ? '3px solid #6366f1' : '3px solid transparent',
+                }}
+              >
+                <div className="text-left">
+                  <p className="text-sm font-bold" style={{ color: active ? '#6366f1' : 'var(--foreground)' }}>
+                    {o.label}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{getSubtitle(o.id, now)}</p>
+                </div>
+                {active && (
+                  <div
+                    className="flex items-center justify-center shrink-0"
+                    style={{ width: 22, height: 22, borderRadius: '50%', background: '#6366f1' }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M20 6L9 17l-5-5" />
+                    </svg>
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/analytics/SavingsCard.tsx
+++ b/components/analytics/SavingsCard.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import type { Granularity } from '@/types'
+import { fmt } from '@/lib/formatting'
+import { PERIOD_LABELS } from '@/lib/analytics'
+
+interface SavingsCardProps {
+  ingresos: number
+  ahorro: number
+  gran: Granularity
+}
+
+export default function SavingsCard({ ingresos, ahorro, gran }: SavingsCardProps) {
+  const isNegative = ahorro < 0
+  const pct = ingresos > 0 && !isNegative ? Math.min(100, Math.round((ahorro / ingresos) * 100)) : 0
+
+  const bg = isNegative
+    ? 'linear-gradient(135deg, #ef4444, #dc2626)'
+    : 'linear-gradient(135deg, #059669, #10b981)'
+  const shadow = isNegative
+    ? '0 10px 40px rgba(239,68,68,0.25)'
+    : '0 10px 40px rgba(16,185,129,0.25)'
+
+  return (
+    <div style={{ background: bg, borderRadius: 20, padding: 20, boxShadow: shadow }}>
+      <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.7)', marginBottom: 4 }}>
+        Ahorro · {PERIOD_LABELS[gran]}
+      </p>
+      <p style={{ fontSize: 32, fontWeight: 800, color: 'white', marginBottom: 8 }}>
+        {fmt(ahorro)} €
+      </p>
+      <div style={{ height: 6, background: 'rgba(255,255,255,0.2)', borderRadius: 3 }}>
+        <div
+          style={{
+            width: `${pct}%`,
+            height: '100%',
+            background: 'white',
+            borderRadius: 3,
+            transition: 'width 0.6s ease',
+          }}
+        />
+      </div>
+      <p style={{ fontSize: 12, color: 'rgba(255,255,255,0.7)', marginTop: 6 }}>
+        {isNegative ? 'Gastos superiores a los ingresos' : `${pct}% de tus ingresos`}
+      </p>
+    </div>
+  )
+}

--- a/components/dashboard/PatrimonioChart.tsx
+++ b/components/dashboard/PatrimonioChart.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export function PatrimonioChart({ data, annualDelta }: Props) {
   return (
-    <div className="bg-card rounded-[24px] p-6 border border-border">
+    <div className="bg-card rounded-3xl p-6 border border-border">
       <div className="flex justify-between items-center mb-1">
         <span className="text-[15px] font-bold">Patrimonio neto</span>
         {annualDelta !== null ? (

--- a/contexts/AnalyticsContext.tsx
+++ b/contexts/AnalyticsContext.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+import type { Granularity } from '@/types'
+
+interface AnalyticsContextValue {
+  gran: Granularity
+  setGran: (g: Granularity) => void
+  showPicker: boolean
+  setShowPicker: (v: boolean) => void
+}
+
+const AnalyticsContext = createContext<AnalyticsContextValue | null>(null)
+
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const [gran, setGran] = useState<Granularity>('month')
+  const [showPicker, setShowPicker] = useState(false)
+
+  return (
+    <AnalyticsContext.Provider value={{ gran, setGran, showPicker, setShowPicker }}>
+      {children}
+    </AnalyticsContext.Provider>
+  )
+}
+
+export function useAnalytics() {
+  const ctx = useContext(AnalyticsContext)
+  if (!ctx) throw new Error('useAnalytics must be used within AnalyticsProvider')
+  return ctx
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -98,3 +98,10 @@ export function yoyDelta(current: number, previous: number): string {
 export function toISODate(d: Date): string {
   return d.toISOString().split('T')[0]
 }
+
+export const PERIOD_LABELS: Record<Granularity, string> = {
+  week: 'Esta semana',
+  month: 'Este mes',
+  quarter: 'Este trimestre',
+  year: 'Este año',
+}


### PR DESCRIPTION
## Resumen

- **`AnalyticsContext`** — estado `gran` compartido entre la pantalla de Análisis y la futura `CategoryDetailScreen`, envuelto en `app/(app)/analisis/layout.tsx` para que ambas rutas lo hereden sin prop-drilling (§13 nota 12).
- **`GranPicker`** — bottom sheet con 4 opciones (Semana / Mes / Trimestre / Año), subtítulo dinámico con el período actual, opción activa destacada con acento `#6366f1`. Usa `createPortal` al igual que los demás modales del proyecto.
- **`SavingsCard`** — card con gradiente verde (o rojo si ahorro negativo), importe en blanco, barra de progreso como % sobre ingresos, label dinámico según `gran`.
- **`AnalyticsClient`** — sticky header (funciona gracias al `overflow-clip` del layout padre), botón de período con estilo accent, fetch de `/api/analytics?gran=X&offset=0`, skeleton mientras carga.
- **`PERIOD_LABELS`** exportado desde `lib/analytics.ts` para uso compartido entre componentes.

## Test plan

- [ ] Header queda sticky al hacer scroll en la lista
- [ ] Botón de período muestra el label correcto ("Este mes" por defecto)
- [ ] Pulsar el botón abre el GranPicker bottom sheet
- [ ] Seleccionar "Esta semana" cierra el sheet y actualiza botón + Card de Ahorro
- [ ] Card muestra datos reales de `/api/analytics` (ingresos − gastos del período)
- [ ] Si ahorro negativo → card roja, barra al 0%
- [ ] `pnpm build` pasa sin errores TypeScript ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)