### PR TITLE
feat(analytics): sub-pantalla Detalle de categoría (#44)

### DIFF
--- a/app/(app)/analisis/categoria/[id]/page.tsx
+++ b/app/(app)/analisis/categoria/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from 'next/navigation'
+import { CATEGORY_META } from '@/lib/theme'
+import type { CategoryId } from '@/types'
+import CategoryDetailClient from '@/components/analytics/CategoryDetailClient'
+
+export default async function CategoryDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  if (!(id in CATEGORY_META)) notFound()
+  return <CategoryDetailClient categoryId={id as CategoryId} />
+}

--- a/app/api/analytics/categoria/route.ts
+++ b/app/api/analytics/categoria/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getWindowPeriods, toISODate } from '@/lib/analytics'
+import type { Granularity, CategoryId, CategoryAnalyticsResponse } from '@/types'
+import { CATEGORY_META } from '@/lib/theme'
+
+const VALID_GRAN: Granularity[] = ['week', 'month', 'quarter', 'year']
+const WINDOW = 6
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl
+  const gran = searchParams.get('gran') as Granularity
+  const id   = searchParams.get('id') as CategoryId
+
+  if (!VALID_GRAN.includes(gran) || !id || !(id in CATEGORY_META)) {
+    return NextResponse.json({ error: 'Invalid params' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const allPeriods = getWindowPeriods(gran, 0)
+    const window = allPeriods.slice(-WINDOW)
+
+    const periods = await Promise.all(
+      window.map(async (range) => {
+        const { data } = await supabase.rpc('get_period_data', {
+          p_user_id:    user.id,
+          p_start_date: toISODate(range.start),
+          p_end_date:   toISODate(range.end),
+        })
+        const row = data?.[0]
+        const byCategory: { category: string | null; amount: number }[] = row?.by_category ?? []
+        const match = byCategory.find(bc => bc.category === id)
+        return {
+          label:  range.label,
+          start:  toISODate(range.start),
+          end:    toISODate(range.end),
+          amount: match ? Math.abs(Number(match.amount)) : 0,
+        }
+      })
+    )
+
+    return NextResponse.json({
+      gran,
+      categoryId: id,
+      periods,
+    } satisfies CategoryAnalyticsResponse)
+  } catch (e) {
+    console.error('[GET /api/analytics/categoria]', e)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -49,6 +49,9 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl
   const type = searchParams.get('type') ?? 'todos'
   const accountsParam = searchParams.get('accounts')
+  const category = searchParams.get('category')
+  const dateFrom = searchParams.get('dateFrom')
+  const dateTo   = searchParams.get('dateTo')
   const limit = Math.min(Number(searchParams.get('limit') ?? '200'), 500)
 
   const cutoff = new Date()
@@ -60,11 +63,14 @@ export async function GET(request: NextRequest) {
     .select('*, account:accounts(id, name, color)')
     .eq('user_id', user.id)
     .eq('is_internal_transfer', false)
-    .gte('date', cutoffStr)
     .order('date', { ascending: false })
     .order('created_at', { ascending: false })
     .order('id', { ascending: false })
     .limit(limit)
+
+  if (dateFrom) query = query.gte('date', dateFrom)
+  else          query = query.gte('date', cutoffStr)
+  if (dateTo)   query = query.lte('date', dateTo)
 
   if (type === 'ingresos') {
     query = query.gt('amount', 0).eq('is_computable', true)
@@ -77,6 +83,12 @@ export async function GET(request: NextRequest) {
   if (accountsParam) {
     const ids = accountsParam.split(',').filter(Boolean)
     if (ids.length > 0) query = query.in('account_id', ids)
+  }
+
+  if (category) {
+    query = query.or(
+      `category_manual.eq.${category},and(category_manual.is.null,category.eq.${category})`
+    )
   }
 
   const { data, error } = await query

--- a/components/analytics/CategoryBarChart.tsx
+++ b/components/analytics/CategoryBarChart.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts'
+import type { CategoryPeriodData } from '@/types'
+
+interface BarShapeProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  background?: { height?: number; y?: number }
+  isSelected?: boolean
+  barColor: string
+  gradId: string
+  onBarClick?: () => void
+}
+
+function BarShape({
+  x = 0, y = 0, width = 0, height = 0,
+  background,
+  isSelected = false,
+  barColor, gradId, onBarClick,
+}: BarShapeProps) {
+  if (!width || width <= 0) return null
+
+  const hitY = background?.y ?? y
+  const hitH = (background?.height ?? 0) || height
+  const topColor = barColor + 'cc'
+
+  return (
+    <g
+      onClick={onBarClick}
+      tabIndex={-1}
+      style={{ cursor: 'pointer', outline: 'none', opacity: isSelected ? 1 : 0.4, transition: 'opacity 0.2s' }}
+    >
+      <rect x={x} y={hitY} width={width} height={hitH} fill="transparent" />
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={topColor} />
+          <stop offset="100%" stopColor={barColor} />
+        </linearGradient>
+      </defs>
+      {height > 0 && (
+        <rect
+          x={x} y={y} width={width} height={height} rx={4} ry={4}
+          fill={isSelected ? `url(#${gradId})` : barColor}
+          style={{ filter: isSelected ? `drop-shadow(0 4px 14px ${barColor}66)` : 'none' }}
+        />
+      )}
+    </g>
+  )
+}
+
+interface TickProps {
+  x?: number
+  y?: number
+  payload?: { value: string; index: number }
+  clampedSel: number
+  onTickClick?: () => void
+}
+
+function CustomTick({ x = 0, y = 0, payload, clampedSel, onTickClick }: TickProps) {
+  if (!payload) return null
+  const isSel = payload.index === clampedSel
+  return (
+    <g onClick={onTickClick} tabIndex={-1} style={{ cursor: 'pointer', outline: 'none' }}>
+      <rect x={x - 16} y={y} width={32} height={20} fill="transparent" />
+      <text
+        x={x} y={y + 10} textAnchor="middle" dominantBaseline="middle"
+        fontSize={isSel ? 10 : 9} fontWeight={isSel ? 700 : 400}
+        fill={isSel ? 'var(--foreground)' : 'var(--muted-foreground)'}
+        opacity={isSel ? 0.9 : 0.35}
+        style={{ userSelect: 'none', pointerEvents: 'none' }}
+      >
+        {payload.value}
+      </text>
+    </g>
+  )
+}
+
+interface CategoryBarChartProps {
+  periods: CategoryPeriodData[]
+  selectedIdx: number
+  onSelect: (idx: number) => void
+  color: string
+}
+
+export default function CategoryBarChart({ periods, selectedIdx, onSelect, color }: CategoryBarChartProps) {
+  const maxVal = Math.max(...periods.map(p => p.amount), 1)
+
+  const chartData = periods.map((p, i) => ({
+    label: p.label,
+    amount: p.amount,
+    isSelected: i === selectedIdx,
+  }))
+
+  return (
+    <ResponsiveContainer width="100%" height={110}>
+      <BarChart
+        data={chartData}
+        barCategoryGap="18%"
+        margin={{ top: 4, right: 4, bottom: 0, left: 4 }}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+      >
+        <YAxis domain={[0, maxVal]} hide />
+        <Bar
+          dataKey="amount"
+          shape={(props: object) => {
+            const p = props as BarShapeProps & { index?: number; isSelected?: boolean }
+            return (
+              <BarShape
+                {...p}
+                barColor={color}
+                gradId="grad-cat-sel"
+                onBarClick={() => typeof p.index === 'number' && onSelect(p.index)}
+              />
+            )
+          }}
+          isAnimationActive={false}
+        />
+        <XAxis
+          dataKey="label"
+          axisLine={false}
+          tickLine={false}
+          tick={(props: object) => {
+            const p = props as TickProps
+            const localIdx = p.payload?.index
+            return (
+              <CustomTick
+                {...p}
+                clampedSel={selectedIdx}
+                onTickClick={() => typeof localIdx === 'number' && onSelect(localIdx)}
+              />
+            )
+          }}
+          height={22}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -148,7 +148,7 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
                   key={item.key}
                   onClick={() => {
                     handleSelect(effectiveIdx === i ? null : i)
-                    if (isNavigable) router.push(`/analisis/${item.categoryId}`)
+                    if (isNavigable) router.push(`/analisis/categoria/${item.categoryId}`)
                   }}
                   style={{ cursor: 'pointer', opacity: isDimmed ? 0.35 : 1, transition: 'opacity 0.25s' }}
                 >

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAnalytics } from '@/contexts/AnalyticsContext'
+import { CATEGORY_META } from '@/lib/theme'
+import { fmt } from '@/lib/formatting'
+import { PERIOD_LABELS } from '@/lib/analytics'
+import type { CategoryId, CategoryPeriodData, TransactionWithAccount } from '@/types'
+import { TxRow } from '@/components/transactions/TxRow'
+import { TxModal } from '@/components/transactions/TxModal'
+import { CategoryPicker } from '@/components/transactions/CategoryPicker'
+import GranPicker from './GranPicker'
+import CategoryBarChart from './CategoryBarChart'
+
+const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
+function formatDayLabel(dateStr: string): string {
+  const today = new Date().toISOString().slice(0, 10)
+  const yest = new Date()
+  yest.setDate(yest.getDate() - 1)
+  const yesterdayStr = yest.toISOString().slice(0, 10)
+  if (dateStr === today) return 'Hoy'
+  if (dateStr === yesterdayStr) return 'Ayer'
+  const [y, m, d] = dateStr.split('-').map(Number)
+  return `${d} ${MONTHS[m - 1]} ${y}`
+}
+
+function CalendarIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  )
+}
+
+interface Props {
+  categoryId: CategoryId
+}
+
+export default function CategoryDetailClient({ categoryId }: Props) {
+  const router = useRouter()
+  const { gran, showPicker, setShowPicker } = useAnalytics()
+  const meta = CATEGORY_META[categoryId]
+  const { Icon, label, color } = meta
+
+  const [periods, setPeriods] = useState<CategoryPeriodData[]>([])
+  const [selectedBarIdx, setSelectedBarIdx] = useState(5)
+  const [transactions, setTransactions] = useState<TransactionWithAccount[]>([])
+  const [loadingPeriods, setLoadingPeriods] = useState(true)
+  const [loadingTxs, setLoadingTxs] = useState(true)
+  const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
+  const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
+  const [swipedTxId, setSwipedTxId] = useState<string | null>(null)
+
+  const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
+
+  // Fetch 6-period chart data when gran changes
+  useEffect(() => {
+    let cancelled = false
+    setLoadingPeriods(true)
+    fetch(`/api/analytics/categoria?id=${categoryId}&gran=${gran}`)
+      .then(r => r.json())
+      .then(d => {
+        if (!cancelled) {
+          setPeriods(d.periods ?? [])
+          setSelectedBarIdx(5)
+          setLoadingPeriods(false)
+        }
+      })
+    return () => { cancelled = true }
+  }, [gran, categoryId])
+
+  // Fetch transactions when selected bar or periods change
+  useEffect(() => {
+    if (periods.length === 0) return
+    const period = periods[selectedBarIdx]
+    if (!period) return
+    let cancelled = false
+    setLoadingTxs(true)
+    fetch(
+      `/api/transactions?category=${categoryId}&dateFrom=${period.start}&dateTo=${period.end}&limit=500`
+    )
+      .then(r => r.json())
+      .then(d => {
+        if (!cancelled) {
+          setTransactions(d.data ?? [])
+          setLoadingTxs(false)
+        }
+      })
+    return () => { cancelled = true }
+  }, [selectedBarIdx, periods, categoryId])
+
+  async function handleDelete(txId: string) {
+    setSelectedTxId(null)
+    setTransactions(prev => prev.filter(t => t.id !== txId))
+    const res = await fetch(`/api/transactions/${txId}`, { method: 'DELETE' })
+    if (!res.ok) console.error('[handleDelete]', await res.text())
+  }
+
+  async function handleSelect(txId: string, category: CategoryId) {
+    setTransactions(prev => prev.map(t =>
+      t.id === txId ? { ...t, category_manual: category } : t
+    ))
+    const res = await fetch(`/api/transactions/${txId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category_manual: category }),
+    })
+    if (!res.ok) console.error('[handleSelect]', await res.text())
+  }
+
+  // Group transactions by date
+  const groups = new Map<string, { transactions: TransactionWithAccount[]; net: number }>()
+  for (const tx of transactions) {
+    const existing = groups.get(tx.date)
+    if (existing) {
+      existing.transactions.push(tx)
+      existing.net += tx.amount
+    } else {
+      groups.set(tx.date, { transactions: [tx], net: tx.amount })
+    }
+  }
+  const sortedDates = Array.from(groups.keys()).sort((a, b) => b.localeCompare(a))
+
+  const selectedPeriod = periods[selectedBarIdx]
+  const periodTotal = selectedPeriod?.amount ?? 0
+
+  return (
+    <div>
+      {/* Sticky header */}
+      <div
+        className="sticky top-0 z-50 border-b border-border px-5 pb-3"
+        style={{
+          background: 'color-mix(in srgb, var(--background) 92%, transparent)',
+          backdropFilter: 'blur(16px)',
+          paddingTop: 52,
+        }}
+      >
+        <div className="flex items-center justify-between">
+          {/* Left: back + icon + name */}
+          <div className="flex items-center gap-2.5 min-w-0 flex-1">
+            <button
+              onClick={() => router.back()}
+              style={{
+                width: 34, height: 34, borderRadius: 10, border: 'none',
+                background: 'var(--secondary)', cursor: 'pointer', flexShrink: 0,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: 'var(--foreground)',
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+            </button>
+            <div
+              className="flex items-center justify-center shrink-0"
+              style={{ width: 30, height: 30, borderRadius: 8, background: color + '20' }}
+            >
+              <Icon size={15} color={color} strokeWidth={2} />
+            </div>
+            <span
+              className="text-base font-bold text-foreground truncate"
+            >
+              {label}
+            </span>
+          </div>
+          {/* Right: period selector */}
+          <button
+            onClick={() => setShowPicker(true)}
+            className="flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1.5 shrink-0 ml-2"
+            style={{
+              background: 'color-mix(in srgb, #6366f1 12%, transparent)',
+              border: '1px solid color-mix(in srgb, #6366f1 27%, transparent)',
+              color: '#6366f1',
+            }}
+          >
+            <CalendarIcon />
+            <span className="text-xs font-bold">{PERIOD_LABELS[gran]}</span>
+            <span className="text-[10px] opacity-70">▾</span>
+          </button>
+        </div>
+        {!loadingTxs && selectedPeriod && (
+          <p className="mt-1 text-xs text-muted-foreground" style={{ paddingLeft: 44 }}>
+            {transactions.length} movimiento{transactions.length !== 1 ? 's' : ''}{' '}
+            ·{' '}
+            <span style={{ fontWeight: 700, color }}>{fmt(periodTotal, 2)} €</span>
+          </p>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col gap-4 px-5 py-4">
+        {/* Evolution card */}
+        <div style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20 }}>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-[15px] font-bold text-foreground">Evolución</span>
+            <span className="text-xs text-muted-foreground capitalize">{PERIOD_LABELS[gran]}</span>
+          </div>
+
+          {/* KPI */}
+          <div className="mb-4">
+            {loadingPeriods ? (
+              <div className="h-9 w-32 animate-pulse rounded-lg" style={{ background: 'var(--muted)' }} />
+            ) : (
+              <>
+                <span style={{ fontSize: 32, fontWeight: 800, color, letterSpacing: -1 }}>
+                  {fmt(periodTotal, 2)} €
+                </span>
+                {selectedPeriod && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    en {selectedPeriod.label}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Bar chart */}
+          {loadingPeriods ? (
+            <div className="h-[110px] animate-pulse rounded-lg" style={{ background: 'var(--muted)' }} />
+          ) : periods.length > 0 ? (
+            <CategoryBarChart
+              periods={periods}
+              selectedIdx={selectedBarIdx}
+              onSelect={setSelectedBarIdx}
+              color={color}
+            />
+          ) : (
+            <p className="py-4 text-center text-sm text-muted-foreground">Sin datos</p>
+          )}
+        </div>
+
+        {/* Transaction list */}
+        <span className="text-[15px] font-bold text-foreground">Movimientos</span>
+
+        {loadingTxs ? (
+          <div className="flex flex-col gap-2">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="h-14 animate-pulse rounded-2xl" style={{ background: 'var(--secondary)' }} />
+            ))}
+          </div>
+        ) : sortedDates.length === 0 ? (
+          <div className="flex items-center justify-center py-10">
+            <p className="text-sm text-muted-foreground">No hay movimientos en este período</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {sortedDates.map(date => {
+              const group = groups.get(date)!
+              const net = group.net
+              const netStr = (net >= 0 ? '+' : '') + fmt(net, 2) + ' €'
+              const netColor = net >= 0 ? '#22c55e' : 'var(--foreground)'
+              return (
+                <div key={date} className="flex flex-col gap-0.5">
+                  <div className="flex items-center justify-between px-3 pb-1">
+                    <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
+                      {formatDayLabel(date)}
+                    </span>
+                    <span className="text-xs font-bold" style={{ color: netColor }}>
+                      {netStr}
+                    </span>
+                  </div>
+                  <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+                    {group.transactions.map(tx => (
+                      <TxRow
+                        key={tx.id}
+                        tx={tx}
+                        swipedId={swipedTxId}
+                        onSwipe={setSwipedTxId}
+                        onRecategorize={tx => { setCatPickerTx(tx); setSwipedTxId(null) }}
+                        onTap={tx => { setSelectedTxId(tx.id); setSwipedTxId(null) }}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {selectedTx && (
+        <TxModal
+          tx={selectedTx}
+          onClose={() => setSelectedTxId(null)}
+          onRecategorize={tx => { setCatPickerTx(tx); setSelectedTxId(null) }}
+          onDelete={handleDelete}
+        />
+      )}
+
+      {catPickerTx && (
+        <CategoryPicker
+          tx={catPickerTx}
+          onClose={() => setCatPickerTx(null)}
+          onSelect={handleSelect}
+        />
+      )}
+
+      {showPicker && <GranPicker />}
+    </div>
+  )
+}

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
 
 export function BottomNav() {
   const pathname = usePathname()
+  if (pathname.startsWith('/analisis/categoria/')) return null
 
   return (
     <nav

--- a/types/index.ts
+++ b/types/index.ts
@@ -127,3 +127,16 @@ export interface AnalyticsResponse {
   gran: Granularity
   periods: PeriodData[]
 }
+
+export interface CategoryPeriodData {
+  label: string
+  start: string
+  end: string
+  amount: number
+}
+
+export interface CategoryAnalyticsResponse {
+  gran: Granularity
+  categoryId: CategoryId
+  periods: CategoryPeriodData[]
+}


### PR DESCRIPTION
## Summary

- Nueva ruta `/analisis/categoria/[id]` con header sticky (botón atrás, icono + nombre, selector de período), gráfica de evolución de 6 períodos y lista de movimientos filtrada por categoría y período seleccionado
- Nuevo endpoint `GET /api/analytics/categoria?id=X&gran=Y` que devuelve los últimos 6 períodos de gasto/ingreso para una categoría concreta
- `GET /api/transactions` extendido con filtros `category`, `dateFrom` y `dateTo`
- `BottomNav` oculto en rutas `/analisis/categoria/*` (se siente como sub-página)
- `CategoryBarChart` (Recharts, un color) con el mismo estilo de `BarShape` que `DualBarChart`
- `gran` compartida con la pantalla de Análisis vía `AnalyticsContext` — cambiar el período en la sub-pantalla actualiza simultáneamente la pantalla padre

## Test plan

- [ ] Navegar a Análisis → pulsar en una categoría del desglose → redirige a `/analisis/categoria/[id]`
- [ ] El BottomNav no se ve en la sub-pantalla
- [ ] El selector de período actualiza la gráfica y la lista de movimientos
- [ ] Cambiar de barra → la lista se actualiza al período correspondiente
- [ ] Al volver a Análisis, el período sigue sincronizado
- [ ] Swipe en un movimiento → abre CategoryPicker y guarda la recategorización
- [ ] Tap en un movimiento → abre TxModal con detalle y opciones de edición
- [ ] `pnpm build` pasa sin errores TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)