### PR TITLE
feat(api): webhook POST /api/edenred + auto-create de cuenta

### DIFF
--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server'
+import { timingSafeEqual } from 'node:crypto'
+import { createServiceClient } from '@/lib/supabase/service'
+
+type EdenredTx = {
+  external_id: string
+  amount: number
+  description: string
+  transaction_date: string
+}
+
+type EdenredPayload = {
+  balance: number
+  last_synced_at: string
+  transactions: EdenredTx[]
+}
+
+function isValidPayload(data: unknown): data is EdenredPayload {
+  if (!data || typeof data !== 'object') return false
+  const p = data as Record<string, unknown>
+  if (typeof p.balance !== 'number') return false
+  if (typeof p.last_synced_at !== 'string') return false
+  if (!Array.isArray(p.transactions)) return false
+  return p.transactions.every(tx =>
+    tx
+    && typeof tx === 'object'
+    && typeof (tx as EdenredTx).external_id === 'string'
+    && typeof (tx as EdenredTx).amount === 'number'
+    && typeof (tx as EdenredTx).description === 'string'
+    && typeof (tx as EdenredTx).transaction_date === 'string'
+  )
+}
+
+function safeBearerMatch(header: string | null, secret: string): boolean {
+  if (!header) return false
+  const expected = `Bearer ${secret}`
+  const a = Buffer.from(header)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export async function POST(req: Request) {
+  const secret = process.env.EDENRED_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[edenred] EDENRED_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+  if (!isValidPayload(payload)) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+
+  const db = createServiceClient()
+
+  // App de usuario único: el webhook no tiene sesión, así que el user_id se
+  // resuelve leyendo el único registro de user_config (decisión documentada
+  // en el plan de #53).
+  const { data: userRow, error: userErr } = await db
+    .from('user_config')
+    .select('user_id')
+    .limit(1)
+    .maybeSingle()
+  if (userErr || !userRow) {
+    console.error('[edenred] no user_config:', userErr)
+    return NextResponse.json({ error: 'No user configured' }, { status: 500 })
+  }
+  const userId = userRow.user_id as string
+
+  const { data: existingAccount, error: accSelErr } = await db
+    .from('accounts')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('source', 'scraper')
+    .eq('name', 'Edenred')
+    .maybeSingle()
+  if (accSelErr) {
+    console.error('[edenred] select account:', accSelErr)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  let accountId: string
+  let createdAccount = false
+  if (existingAccount) {
+    accountId = existingAccount.id as string
+    const { error: updErr } = await db
+      .from('accounts')
+      .update({ balance: payload.balance, last_synced: payload.last_synced_at })
+      .eq('id', accountId)
+    if (updErr) {
+      console.error('[edenred] update account:', updErr)
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+  } else {
+    const { data: inserted, error: insErr } = await db
+      .from('accounts')
+      .insert({
+        user_id: userId,
+        name: 'Edenred',
+        type: 'edenred',
+        source: 'scraper',
+        is_liability: false,
+        balance: payload.balance,
+        last_synced: payload.last_synced_at,
+        currency: 'EUR',
+      })
+      .select('id')
+      .single()
+    if (insErr || !inserted) {
+      console.error('[edenred] insert account:', insErr)
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+    accountId = inserted.id as string
+    createdAccount = true
+  }
+
+  let upserted = 0
+  if (payload.transactions.length > 0) {
+    const rows = payload.transactions.map(tx => ({
+      user_id: userId,
+      account_id: accountId,
+      date: tx.transaction_date,
+      amount: tx.amount,
+      description: tx.description,
+      category: 'restaurant',
+      source: 'scraper' as const,
+      external_id: tx.external_id,
+      is_computable: false,
+      is_internal_transfer: false,
+    }))
+
+    const { error: upsertErr } = await db
+      .from('transactions')
+      .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: false })
+    if (upsertErr) {
+      console.error('[edenred] upsert transactions:', upsertErr)
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+    upserted = rows.length
+  }
+
+  return NextResponse.json({ created_account: createdAccount, upserted })
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,11 @@ import { createServerClient } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function proxy(request: NextRequest) {
+  // Webhooks públicos con auth Bearer: saltar el chequeo de sesión.
+  if (request.nextUrl.pathname.startsWith('/api/edenred')) {
+    return NextResponse.next({ request })
+  }
+
   let supabaseResponse = NextResponse.next({ request })
 
   const supabase = createServerClient(


### PR DESCRIPTION
Closes #53

## Resumen

Nuevo endpoint `POST /api/edenred` para recibir los datos del scraper de Edenred (que correrá en GitHub Actions, ver Fase 5 Bloque A).

- **Auth Bearer** contra `EDENRED_WEBHOOK_SECRET` (comparación `timingSafeEqual`). Sin auth → `401` sin body.
- **Resolución de `user_id`**: app de usuario único — el webhook lee el único registro de `user_config` con service role (decisión documentada en el código). Se descartó añadir un nuevo env var.
- **Auto-create** de la cuenta Edenred (`source='scraper'`, `name='Edenred'`, `type='edenred'`, `is_liability=false`) en el primer POST; en sucesivos, `UPDATE` de `balance` + `last_synced`.
- **Upsert idempotente** de transacciones sobre el `UNIQUE(user_id, external_id)` existente. Campos fijos: `source='scraper'`, `is_computable=false`, `category='restaurant'` (§3.3, §5.3 del spec).
- No llama a `refresh_monthly_summary` ni `mark_internal_transfers` (las txns Edenred no entran en la vista materializada porque `is_computable=false`).

## Tests

⚠️ El criterio de aceptación de tests Vitest queda pendiente: el repo no tiene infraestructura de tests (ni `vitest.config.ts`, ni script `test`). Se abrirá issue de seguimiento para introducir Vitest globalmente y añadir los tests del handler (auth ok/ko, auto-create, idempotencia).

## Plan de test manual

```bash
# 1) Sin auth → 401
curl -i -X POST http://localhost:3000/api/edenred \
  -H 'Content-Type: application/json' -d '{}'

# 2) Auth válida + primer POST (auto-crea cuenta)
curl -i -X POST http://localhost:3000/api/edenred \
  -H "Authorization: Bearer $EDENRED_WEBHOOK_SECRET" \
  -H 'Content-Type: application/json' \
  -d '{
    "balance": 123.45,
    "last_synced_at": "2026-05-14T07:00:00Z",
    "transactions": [
      {"external_id":"edenred-tx-abc123","amount":-8.50,"description":"Restaurante La Tasca","transaction_date":"2026-05-13"}
    ]
  }'

# 3) Mismo POST → 200, upserted=1, no duplica
# 4) Body malformado → 400
```

- [x] `pnpm build` sin errores (route registrada como `/api/edenred`)
- [ ] Smoke test con `curl` en local (a ejecutar antes del merge)
- [ ] Verificar en Supabase que la txn entra con `is_computable=false`, `category='restaurant'`, `source='scraper'`
- [ ] Confirmar que la txn NO aparece en `transactions_monthly_summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)