### PR TITLE
feat(scraper): script Playwright de Edenred con storageState

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ ENABLEBANKING_SECRET_KEY=
 
 # Edenred scraper (GitHub Actions → webhook)
 EDENRED_WEBHOOK_SECRET=    # genera con: openssl rand -hex 32
+EDENRED_USER=              # solo para regenerar storage-state localmente
+EDENRED_PASS=              # solo para regenerar storage-state localmente
+APP_URL=http://localhost:3000   # destino del webhook al ejecutar scrape:edenred
 
 # App
 NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# edenred scraper — sesión Playwright con cookies válidas, nunca commitear
+scripts/storage-state.json

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -7,6 +7,7 @@ type EdenredTx = {
   amount: number
   description: string
   transaction_date: string
+  category?: string
 }
 
 type EdenredPayload = {
@@ -21,14 +22,16 @@ function isValidPayload(data: unknown): data is EdenredPayload {
   if (typeof p.balance !== 'number') return false
   if (typeof p.last_synced_at !== 'string') return false
   if (!Array.isArray(p.transactions)) return false
-  return p.transactions.every(tx =>
-    tx
-    && typeof tx === 'object'
-    && typeof (tx as EdenredTx).external_id === 'string'
-    && typeof (tx as EdenredTx).amount === 'number'
-    && typeof (tx as EdenredTx).description === 'string'
-    && typeof (tx as EdenredTx).transaction_date === 'string'
-  )
+  return p.transactions.every(tx => {
+    if (!tx || typeof tx !== 'object') return false
+    const t = tx as EdenredTx
+    if (typeof t.external_id !== 'string') return false
+    if (typeof t.amount !== 'number') return false
+    if (typeof t.description !== 'string') return false
+    if (typeof t.transaction_date !== 'string') return false
+    if (t.category !== undefined && typeof t.category !== 'string') return false
+    return true
+  })
 }
 
 function safeBearerMatch(header: string | null, secret: string): boolean {
@@ -132,7 +135,7 @@ export async function POST(req: Request) {
       date: tx.transaction_date,
       amount: tx.amount,
       description: tx.description,
-      category: 'restaurant',
+      category: tx.category ?? 'restaurant',
       source: 'scraper' as const,
       external_id: tx.external_id,
       is_computable: false,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Node scripts ejecutados fuera del bundle de Next.
+    "scripts/**",
   ]),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "scrape:edenred": "node scripts/scrape-edenred.mjs",
-    "scrape:edenred:login": "node scripts/login-edenred.mjs"
+    "scrape:edenred": "node --env-file-if-exists=.env.local scripts/scrape-edenred.mjs",
+    "scrape:edenred:login": "node --env-file=.env.local scripts/login-edenred.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "tunnel": "ngrok http --domain=decidable-rendering-propeller.ngrok-free.dev 3000",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "scrape:edenred": "node scripts/scrape-edenred.mjs",
+    "scrape:edenred:login": "node scripts/login-edenred.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -32,6 +34,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       tailwindcss:
         specifier: ^4
         version: 4.2.4
@@ -1783,6 +1786,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2599,6 +2607,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5050,6 +5068,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -5794,6 +5815,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/login-edenred.mjs
+++ b/scripts/login-edenred.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Edenred login — regeneración manual de storage-state.json.
+//
+// Uso:
+//   pnpm scrape:edenred:login
+//
+// Requiere en .env.local: EDENRED_USER, EDENRED_PASS.
+//
+// El script lanza Chromium en modo headed, rellena las credenciales, pausa
+// para que el usuario complete el 2FA a mano, y al volver guarda el
+// storage-state. Luego imprime el comando para actualizar el secret de GitHub.
+
+import { chromium } from 'playwright'
+import { existsSync, mkdirSync } from 'node:fs'
+import readline from 'node:readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
+
+const LOCAL_STORAGE_PATH = 'scripts/storage-state.json'
+const EDENRED_LOGIN_URL = 'https://www.myedenred.es/'
+
+// Selectores del formulario de login: tunear tras inspeccionar.
+const SELECTORS = {
+  username: 'input[name="username"], input[type="email"]',
+  password: 'input[name="password"], input[type="password"]',
+  submit: 'button[type="submit"], button:has-text("Entrar")',
+}
+
+function requireEnv(name) {
+  const v = process.env[name]
+  if (!v) {
+    console.error(`[login-edenred] Falta env var: ${name}`)
+    process.exit(1)
+  }
+  return v
+}
+
+async function main() {
+  const user = requireEnv('EDENRED_USER')
+  const pass = requireEnv('EDENRED_PASS')
+
+  if (!existsSync('scripts')) mkdirSync('scripts')
+
+  const browser = await chromium.launch({ headless: false })
+  try {
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    console.log('[login-edenred] abriendo Edenred…')
+    await page.goto(EDENRED_LOGIN_URL, { waitUntil: 'domcontentloaded' })
+
+    await page.locator(SELECTORS.username).first().fill(user)
+    await page.locator(SELECTORS.password).first().fill(pass)
+    await page.locator(SELECTORS.submit).first().click()
+
+    const rl = readline.createInterface({ input, output })
+    await rl.question(
+      '\n→ Completa el 2FA en el navegador (si lo pide).\n' +
+      '→ Cuando estés dentro de la cuenta, pulsa ENTER aquí para guardar la sesión…\n'
+    )
+    rl.close()
+
+    await context.storageState({ path: LOCAL_STORAGE_PATH, indexedDB: true })
+    console.log(`[login-edenred] ✓ Guardado: ${LOCAL_STORAGE_PATH}`)
+    console.log(
+      `\nPara subirlo a GitHub Secrets:\n` +
+      `  base64 -i ${LOCAL_STORAGE_PATH} | gh secret set EDENRED_STORAGE_STATE --repo MrClit/fin-app\n`
+    )
+  } finally {
+    await browser.close()
+  }
+}
+
+main().catch(err => {
+  console.error('[login-edenred] error:', err)
+  process.exit(1)
+})

--- a/scripts/login-edenred.mjs
+++ b/scripts/login-edenred.mjs
@@ -6,9 +6,11 @@
 //
 // Requiere en .env.local: EDENRED_USER, EDENRED_PASS.
 //
-// El script lanza Chromium en modo headed, rellena las credenciales, pausa
-// para que el usuario complete el 2FA a mano, y al volver guarda el
-// storage-state. Luego imprime el comando para actualizar el secret de GitHub.
+// El script lanza Chromium en modo headed e intenta rellenar las
+// credenciales automáticamente. El auto-fill es best-effort: si los
+// selectores no encajan o ya estás logueado en la máquina (sin form),
+// no peta — termina el login a mano. Cuando estés dentro, pulsa ENTER
+// para capturar la sesión.
 
 import { chromium } from 'playwright'
 import { existsSync, mkdirSync } from 'node:fs'
@@ -16,14 +18,19 @@ import readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 
 const LOCAL_STORAGE_PATH = 'scripts/storage-state.json'
-const EDENRED_LOGIN_URL = 'https://www.myedenred.es/'
+const EDENRED_LOGIN_URL = 'https://empleados.edenred.es/login'
 
-// Selectores del formulario de login: tunear tras inspeccionar.
-const SELECTORS = {
-  username: 'input[name="username"], input[type="email"]',
-  password: 'input[name="password"], input[type="password"]',
-  submit: 'button[type="submit"], button:has-text("Entrar")',
-}
+// Locators del formulario de login (capturados con `playwright codegen`
+// sobre empleados.edenred.es/login).
+const locators = page => ({
+  username: page.getByRole('textbox', { name: 'Usuario (campo requerido)' }),
+  password: page.getByRole('textbox', { name: 'Contraseña (campo requerido)' }),
+  submit: page.getByTestId('login'),
+})
+
+// Timeout corto: si el form no aparece pronto, asumimos que no hay que
+// auto-rellenar (ya logueado, redirección a home, o selectores cambiados).
+const AUTOFILL_TIMEOUT_MS = 5000
 
 function requireEnv(name) {
   const v = process.env[name]
@@ -32,6 +39,26 @@ function requireEnv(name) {
     process.exit(1)
   }
   return v
+}
+
+async function tryAutofill(page, user, pass) {
+  const { username, password, submit } = locators(page)
+  try {
+    await username.waitFor({ timeout: AUTOFILL_TIMEOUT_MS })
+  } catch {
+    console.log('[login-edenred] no se vio el form de login (¿ya logueado?). Sigue a mano.')
+    return false
+  }
+  try {
+    await username.fill(user)
+    await password.fill(pass)
+    await submit.click()
+    console.log('[login-edenred] credenciales auto-rellenadas, completa 2FA si lo pide.')
+    return true
+  } catch (err) {
+    console.log(`[login-edenred] auto-fill falló (${err.message}). Termina el login a mano.`)
+    return false
+  }
 }
 
 async function main() {
@@ -48,9 +75,7 @@ async function main() {
     console.log('[login-edenred] abriendo Edenred…')
     await page.goto(EDENRED_LOGIN_URL, { waitUntil: 'domcontentloaded' })
 
-    await page.locator(SELECTORS.username).first().fill(user)
-    await page.locator(SELECTORS.password).first().fill(pass)
-    await page.locator(SELECTORS.submit).first().click()
+    await tryAutofill(page, user, pass)
 
     const rl = readline.createInterface({ input, output })
     await rl.question(

--- a/scripts/scrape-edenred.mjs
+++ b/scripts/scrape-edenred.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// Edenred scraper — Playwright headless.
+//
+// Uso (local):
+//   pnpm scrape:edenred
+//
+// Uso (CI): el workflow (#A3) inyecta EDENRED_STORAGE_STATE como base64.
+//
+// Exit codes:
+//   0 — éxito (webhook 200)
+//   1 — falta storage-state (regenerar con pnpm scrape:edenred:login)
+//   2 — sesión Edenred caducada o pide 2FA (regenerar localmente)
+//   3 — error de webhook (status != 200 o red)
+//   4 — error de scraping (no se encontraron selectores en el DOM)
+
+import { chromium } from 'playwright'
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const LOCAL_STORAGE_PATH = 'scripts/storage-state.json'
+
+// URLs y selectores: tunear tras inspeccionar edenred.es con DevTools o
+// `pnpm exec playwright codegen https://www.myedenred.es`.
+const EDENRED_ACCOUNT_URL = 'https://www.myedenred.es/'
+
+const SELECTORS = {
+  // Si el navegador termina en cualquiera de estos, la sesión no es válida.
+  loginIndicators: ['input[type="password"]', 'text=/iniciar sesi[oó]n/i'],
+  twoFactorIndicators: ['input[name="otp"]', 'text=/c[oó]digo de verificaci[oó]n/i'],
+  // Saldo: contenedor con el saldo de la tarjeta restaurante.
+  balance: '[data-testid="card-balance"], .card-balance, .balance-amount',
+  // Filas de transacciones (cada elemento = 1 movimiento).
+  transactionRow: '[data-testid="transaction-row"], .transaction-item, li.movement',
+  // Dentro de cada fila:
+  txDate: '[data-testid="tx-date"], .tx-date, time',
+  txAmount: '[data-testid="tx-amount"], .tx-amount, .amount',
+  txDescription: '[data-testid="tx-description"], .tx-description, .merchant',
+  txId: '[data-id], [data-tx-id]', // opcional: si Edenred expone un id estable
+}
+
+function die(code, msg) {
+  console.error(`[scrape-edenred] ${msg}`)
+  process.exit(code)
+}
+
+function requireEnv(name) {
+  const v = process.env[name]
+  if (!v) die(1, `Falta env var: ${name}`)
+  return v
+}
+
+function resolveStorageStatePath() {
+  if (process.env.EDENRED_STORAGE_STATE) {
+    const dir = mkdtempSync(join(tmpdir(), 'edenred-'))
+    const path = join(dir, 'storage-state.json')
+    const decoded = Buffer.from(process.env.EDENRED_STORAGE_STATE, 'base64').toString('utf-8')
+    writeFileSync(path, decoded, 'utf-8')
+    return path
+  }
+  if (existsSync(LOCAL_STORAGE_PATH)) return LOCAL_STORAGE_PATH
+  die(1, `No hay storage-state. Ejecuta: pnpm scrape:edenred:login`)
+}
+
+// Parsea importes en formato español ("12,50 €" o "-12,50 €") a number.
+function parseAmount(raw) {
+  const cleaned = raw.replace(/[^0-9,.\-]/g, '').replace(/\./g, '').replace(',', '.')
+  const n = Number.parseFloat(cleaned)
+  if (Number.isNaN(n)) throw new Error(`No se pudo parsear importe: "${raw}"`)
+  return n
+}
+
+// "15/05/2026" o "15 may 2026" → "2026-05-15".
+function parseDate(raw) {
+  const m = raw.trim().match(/(\d{1,2})[\/\s-](\d{1,2}|[a-záéíóú]+)[\/\s-](\d{4})/i)
+  if (!m) throw new Error(`No se pudo parsear fecha: "${raw}"`)
+  const day = m[1].padStart(2, '0')
+  const monthRaw = m[2].toLowerCase()
+  const months = {
+    ene: '01', feb: '02', mar: '03', abr: '04', may: '05', jun: '06',
+    jul: '07', ago: '08', sep: '09', oct: '10', nov: '11', dic: '12',
+  }
+  const month = /^\d+$/.test(monthRaw)
+    ? monthRaw.padStart(2, '0')
+    : months[monthRaw.slice(0, 3)] || die(4, `Mes desconocido: "${monthRaw}"`)
+  return `${m[3]}-${month}-${day}`
+}
+
+async function isSessionInvalid(page) {
+  for (const sel of SELECTORS.loginIndicators) {
+    if (await page.locator(sel).first().isVisible().catch(() => false)) return 'login'
+  }
+  for (const sel of SELECTORS.twoFactorIndicators) {
+    if (await page.locator(sel).first().isVisible().catch(() => false)) return '2fa'
+  }
+  return null
+}
+
+async function extractBalance(page) {
+  const el = page.locator(SELECTORS.balance).first()
+  if (!(await el.isVisible().catch(() => false))) die(4, 'Saldo no encontrado en el DOM')
+  const text = (await el.textContent()) ?? ''
+  return parseAmount(text)
+}
+
+async function extractTransactions(page) {
+  const rows = await page.locator(SELECTORS.transactionRow).all()
+  if (rows.length === 0) die(4, 'No se encontró ninguna fila de transacciones')
+
+  const counters = new Map() // fallback: contar tx por fecha para generar external_id estable
+  const txs = []
+  for (const row of rows) {
+    const rawDate = (await row.locator(SELECTORS.txDate).first().textContent()) ?? ''
+    const rawAmount = (await row.locator(SELECTORS.txAmount).first().textContent()) ?? ''
+    const rawDesc = (await row.locator(SELECTORS.txDescription).first().textContent()) ?? ''
+
+    const transaction_date = parseDate(rawDate)
+    const amount = parseAmount(rawAmount)
+    const description = rawDesc.trim().replace(/\s+/g, ' ')
+
+    // Preferir un id estable expuesto por Edenred; fallback determinista.
+    const idAttr = await row.locator(SELECTORS.txId).first().getAttribute('data-id').catch(() => null)
+    let external_id
+    if (idAttr) {
+      external_id = `edenred-${idAttr}`
+    } else {
+      const idx = counters.get(transaction_date) ?? 0
+      counters.set(transaction_date, idx + 1)
+      external_id = `edenred-${transaction_date}-${idx}`
+    }
+
+    txs.push({ external_id, amount, description, transaction_date })
+  }
+  return txs
+}
+
+async function postToWebhook({ balance, transactions }) {
+  const appUrl = requireEnv('APP_URL').replace(/\/$/, '')
+  const secret = requireEnv('EDENRED_WEBHOOK_SECRET')
+
+  const body = JSON.stringify({
+    balance,
+    last_synced_at: new Date().toISOString(),
+    transactions,
+  })
+
+  const res = await fetch(`${appUrl}/api/edenred`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${secret}`,
+    },
+    body,
+  })
+
+  if (res.status !== 200) {
+    const text = await res.text().catch(() => '')
+    die(3, `Webhook respondió ${res.status}: ${text}`)
+  }
+
+  return res.json()
+}
+
+async function main() {
+  const storageStatePath = resolveStorageStatePath()
+
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const context = await browser.newContext({ storageState: storageStatePath })
+    const page = await context.newPage()
+
+    await page.goto(EDENRED_ACCOUNT_URL, { waitUntil: 'domcontentloaded' })
+    // Pequeña espera para que la SPA hidrate antes de inspeccionar el DOM.
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+
+    const invalid = await isSessionInvalid(page)
+    if (invalid) {
+      die(2, `Sesión Edenred no válida (${invalid}). Regenera con: pnpm scrape:edenred:login`)
+    }
+
+    const balance = await extractBalance(page)
+    const transactions = await extractTransactions(page)
+
+    console.log(`[scrape-edenred] saldo=${balance} EUR, txs=${transactions.length}`)
+
+    const result = await postToWebhook({ balance, transactions })
+    console.log(`[scrape-edenred] OK: ${JSON.stringify(result)}`)
+  } finally {
+    await browser.close()
+  }
+}
+
+main().catch(err => {
+  // process.exit ya disparado por die(); cualquier otro error es inesperado.
+  console.error('[scrape-edenred] error inesperado:', err)
+  process.exit(4)
+})

--- a/scripts/scrape-edenred.mjs
+++ b/scripts/scrape-edenred.mjs
@@ -22,7 +22,7 @@ const LOCAL_STORAGE_PATH = 'scripts/storage-state.json'
 
 // URLs y selectores: tunear tras inspeccionar edenred.es con DevTools o
 // `pnpm exec playwright codegen https://www.myedenred.es`.
-const EDENRED_ACCOUNT_URL = 'https://www.myedenred.es/'
+const EDENRED_ACCOUNT_URL = 'https://empleados.edenred.es/login'
 
 const SELECTORS = {
   // Si el navegador termina en cualquiera de estos, la sesión no es válida.

--- a/scripts/scrape-edenred.mjs
+++ b/scripts/scrape-edenred.mjs
@@ -22,21 +22,22 @@ const LOCAL_STORAGE_PATH = 'scripts/storage-state.json'
 
 // URLs y selectores: tunear tras inspeccionar edenred.es con DevTools o
 // `pnpm exec playwright codegen https://www.myedenred.es`.
-const EDENRED_ACCOUNT_URL = 'https://empleados.edenred.es/login'
+const EDENRED_ACCOUNT_URL = 'https://empleados.edenred.es'
 
+// Selectores capturados sobre empleados.edenred.es con el design system
+// "ore-*". Si Edenred refactoriza el front, revisar con:
+//   pnpm exec playwright codegen --load-storage=scripts/storage-state.json https://empleados.edenred.es
 const SELECTORS = {
-  // Si el navegador termina en cualquiera de estos, la sesión no es válida.
-  loginIndicators: ['input[type="password"]', 'text=/iniciar sesi[oó]n/i'],
+  // El form de login sólo aparece si la sesión no es válida.
+  loginIndicators: ['input[type="password"]'],
   twoFactorIndicators: ['input[name="otp"]', 'text=/c[oó]digo de verificaci[oó]n/i'],
-  // Saldo: contenedor con el saldo de la tarjeta restaurante.
-  balance: '[data-testid="card-balance"], .card-balance, .balance-amount',
-  // Filas de transacciones (cada elemento = 1 movimiento).
-  transactionRow: '[data-testid="transaction-row"], .transaction-item, li.movement',
-  // Dentro de cada fila:
-  txDate: '[data-testid="tx-date"], .tx-date, time',
-  txAmount: '[data-testid="tx-amount"], .tx-amount, .amount',
-  txDescription: '[data-testid="tx-description"], .tx-description, .merchant',
-  txId: '[data-id], [data-tx-id]', // opcional: si Edenred expone un id estable
+  // Saldo: span con clase de heading que contiene el símbolo €.
+  balance: 'span.ore-heading-title-sm:has-text("€")',
+  // Filas de transacciones (scopeadas a tbody para excluir la cabecera,
+  // que también tiene tr.ore-table-row). Columnas (por posición):
+  //   td[0]=fecha "DD/MM/YYYY", td[1]=hora "HH:MM:SS",
+  //   td[2]=descripción, td[3]=importe "X,YY €"
+  transactionRow: 'tbody tr.ore-table-row',
 }
 
 function die(code, msg) {
@@ -107,29 +108,31 @@ async function extractTransactions(page) {
   const rows = await page.locator(SELECTORS.transactionRow).all()
   if (rows.length === 0) die(4, 'No se encontró ninguna fila de transacciones')
 
-  const counters = new Map() // fallback: contar tx por fecha para generar external_id estable
   const txs = []
   for (const row of rows) {
-    const rawDate = (await row.locator(SELECTORS.txDate).first().textContent()) ?? ''
-    const rawAmount = (await row.locator(SELECTORS.txAmount).first().textContent()) ?? ''
-    const rawDesc = (await row.locator(SELECTORS.txDescription).first().textContent()) ?? ''
+    const cells = row.locator('td')
+    const rawDate = (await cells.nth(0).textContent()) ?? ''
+    const rawTime = (await cells.nth(1).textContent()) ?? ''
+    const rawDesc = (await cells.nth(2).textContent()) ?? ''
+    const rawAmount = (await cells.nth(3).textContent()) ?? ''
 
     const transaction_date = parseDate(rawDate)
-    const amount = parseAmount(rawAmount)
+    const time = rawTime.trim()
     const description = rawDesc.trim().replace(/\s+/g, ' ')
 
-    // Preferir un id estable expuesto por Edenred; fallback determinista.
-    const idAttr = await row.locator(SELECTORS.txId).first().getAttribute('data-id').catch(() => null)
-    let external_id
-    if (idAttr) {
-      external_id = `edenred-${idAttr}`
-    } else {
-      const idx = counters.get(transaction_date) ?? 0
-      counters.set(transaction_date, idx + 1)
-      external_id = `edenred-${transaction_date}-${idx}`
-    }
+    // Edenred muestra los importes sin signo. Distinguimos por la
+    // descripción literal: "RECARGA" es un ingreso (top-up de empresa),
+    // todo lo demás es consumo en restaurante.
+    const isRecarga = description.toUpperCase() === 'RECARGA'
+    const amount = isRecarga ? parseAmount(rawAmount) : -parseAmount(rawAmount)
+    const category = isRecarga ? 'income' : 'restaurant'
 
-    txs.push({ external_id, amount, description, transaction_date })
+    // external_id estable: fecha + hora (resolución de segundos). Si dos
+    // movimientos colisionasen en el mismo segundo, el upsert los trataría
+    // como uno solo — aceptable.
+    const external_id = `edenred-${transaction_date}-${time}`
+
+    txs.push({ external_id, amount, description, transaction_date, category })
   }
   return txs
 }


### PR DESCRIPTION
Closes #54

## Resumen

Productor del flujo Edenred: dos scripts Node ESM que hacen scraping de edenred.es con Playwright headless y envían el resultado al webhook `/api/edenred` (mergeado en #60).

- `scripts/scrape-edenred.mjs` — ejecución headless (local + CI #A3). Reutiliza `storage-state.json` (cookies + localStorage + IndexedDB). Si la sesión caduca o aparece 2FA → exit ≠ 0 con mensaje claro, **sin** intentar resolverlo.
- `scripts/login-edenred.mjs` — regeneración manual local en modo headed. Pausa para 2FA, guarda `storage-state.json` con `indexedDB: true` (Playwright 1.59+), imprime el comando para subirlo a `EDENRED_STORAGE_STATE` (base64).

## Cambios

- `scripts/scrape-edenred.mjs` + `scripts/login-edenred.mjs` nuevos
- `playwright: ^1.60.0` como devDependency (última estable, sin breaking changes para nuestro uso)
- Scripts `pnpm scrape:edenred` y `pnpm scrape:edenred:login`
- `scripts/storage-state.json` en `.gitignore` (cookies sensibles, nunca commitear)
- `.env.example` con `EDENRED_USER`, `EDENRED_PASS`, `APP_URL`
- `eslint.config.mjs` ignora `scripts/**` (scripts Node fuera del bundle Next)

## Decisiones

- **N transacciones**: todas las visibles en la 1ª página (sin paginar). El webhook hace upsert idempotente por `external_id`.
- **storage-state en CI**: base64 dentro del secret `EDENRED_STORAGE_STATE`, decodificado al `tmpdir` por el script.
- **Sin reintentos**: un fallo limpio es preferible a reintentos silenciosos.
- **`indexedDB: true`** en `context.storageState()` (Playwright 1.59+) por si Edenred guarda tokens ahí.

## Códigos de salida

| Código | Significado |
|---|---|
| 0 | OK, webhook 200 |
| 1 | Falta storage-state o env var |
| 2 | Sesión caducada o 2FA → regenerar con `pnpm scrape:edenred:login` |
| 3 | Webhook respondió ≠ 200 |
| 4 | Selectores no encontrados (DOM cambió) |

## Plan de test

- [ ] `pnpm scrape:edenred:login` abre Chromium, permite login + 2FA manual y guarda `scripts/storage-state.json`
- [ ] **Tunear selectores** en `scripts/scrape-edenred.mjs` (constante `SELECTORS`) tras inspeccionar el DOM real de edenred.es — están marcados con valores plausibles pero deben validarse con `pnpm exec playwright codegen`
- [ ] `pnpm dev` + `pnpm scrape:edenred` con storage válido → exit 0 y aparece cuenta `Edenred` + transacciones en Supabase
- [ ] Borrar `scripts/storage-state.json` → exit 1 con mensaje claro
- [ ] Corromper storage-state → exit 2
- [ ] `EDENRED_WEBHOOK_SECRET` incorrecto → exit 3
- [ ] `pnpm build` sigue compilando ✅ (ya verificado)

## Fuera de scope

- Workflow de GitHub Actions (#A3) — esta PR solo aporta el script y el `package.json`.
- Notificaciones de fallo — decisión explícita en la issue: mirar GH Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)