### PR TITLE
refactor: eliminar is_computable e is_internal_transfer de transactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ export const fmt = (n: number, decimals = 0): string => {
 ## Base de datos
 - Todas las tablas tienen `user_id` con RLS activada
 - `is_liability` en `accounts` para distinguir activos de pasivos
-- `is_internal_transfer` en `transactions` para evitar duplicados tarjeta/cuenta
+- La clasificación de una transacción (`income` / `expense` / `non_computable`) viene determinada por `categories.type` de su categoría efectiva (`COALESCE(category_manual, category)`). El signo del `amount` nunca se usa para clasificar tipo, sólo para presentación visual.
 - Vista materializada `transactions_monthly_summary` para agregaciones
 
 ## Lo que NO hacer

--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -16,7 +16,6 @@ export default async function MovimientosPage() {
     supabase
       .from('transactions')
       .select('*, account:accounts(id, name, color)')
-      .eq('is_internal_transfer', false)
       .gte('date', cutoffStr)
       .order('date', { ascending: false })
       .order('created_at', { ascending: false })

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -138,8 +138,6 @@ export async function POST(req: Request) {
       category: tx.category ?? 'restaurant',
       source: 'scraper' as const,
       external_id: tx.external_id,
-      is_computable: false,
-      is_internal_transfer: false,
     }))
 
     const { error: upsertErr } = await db

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -84,8 +84,6 @@ export async function POST() {
           category:             categorizeWithRules(dbRules, description, merchant ?? undefined),
           source:               'enablebanking' as const,
           external_id:          externalId,
-          is_computable:        true,
-          is_internal_transfer: false,
         }
       })
 
@@ -110,9 +108,6 @@ export async function POST() {
       .update({ ...(balance !== null && { balance }), last_synced: new Date().toISOString() })
       .eq('id', account.id)
   }
-
-  const { error: transferError } = await db.rpc('mark_internal_transfers', { p_user_id: user.id })
-  if (transferError) console.error('[sync/eb] mark_internal_transfers:', transferError)
 
   const { error: refreshError } = await db.rpc('refresh_monthly_summary')
   if (refreshError) console.error('[sync/eb] refresh_monthly_summary:', refreshError)

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -25,8 +25,6 @@ export async function POST(request: NextRequest) {
       date,
       category_manual: category_manual ?? null,
       source: 'manual',
-      is_computable: true,
-      is_internal_transfer: false,
     })
     .select('*, account:accounts(id, name, color)')
     .single()
@@ -47,7 +45,6 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = request.nextUrl
-  const type = searchParams.get('type') ?? 'todos'
   const accountsParam = searchParams.get('accounts')
   const category = searchParams.get('category')
   const dateFrom = searchParams.get('dateFrom')
@@ -62,7 +59,6 @@ export async function GET(request: NextRequest) {
     .from('transactions')
     .select('*, account:accounts(id, name, color)')
     .eq('user_id', user.id)
-    .eq('is_internal_transfer', false)
     .order('date', { ascending: false })
     .order('created_at', { ascending: false })
     .order('id', { ascending: false })
@@ -71,14 +67,6 @@ export async function GET(request: NextRequest) {
   if (dateFrom) query = query.gte('date', dateFrom)
   else          query = query.gte('date', cutoffStr)
   if (dateTo)   query = query.lte('date', dateTo)
-
-  if (type === 'ingresos') {
-    query = query.gt('amount', 0).eq('is_computable', true)
-  } else if (type === 'gastos') {
-    query = query.lt('amount', 0).eq('is_computable', true)
-  } else if (type === 'no-computable') {
-    query = query.eq('is_computable', false)
-  }
 
   if (accountsParam) {
     const ids = accountsParam.split(',').filter(Boolean)

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -4,14 +4,13 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { MoreHorizontal } from 'lucide-react'
 import type { CategoryBreakdown } from '@/types'
-import { CATEGORY_META, SIN_CATEGORIA } from '@/lib/theme'
+import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import DonutChart, { type DonutItem } from './DonutChart'
 
 const MIN_PCT = 5
 const RESTO_KEY = '__resto__'
 const RESTO_COLOR = '#94a3b8'
-const SIN_CAT_KEY = '__sin_categoria__'
 
 interface CategoryBreakdownSectionProps {
   byCategory: CategoryBreakdown[]
@@ -30,7 +29,7 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
   const rawItems = byCategory
     .filter(bc => {
       if (bc.amount === 0) return false
-      if (bc.category === null) return (typeFilter === 'expense') === (bc.amount < 0)
+      if (bc.category === null) return false
       return CATEGORY_META[bc.category]?.type === typeFilter
     })
     .map(bc => ({ ...bc, amount: Math.abs(bc.amount) }))
@@ -47,21 +46,12 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
   const rest = withPct.filter(bc => bc.pct < MIN_PCT)
 
   const toItem = (bc: (typeof withPct)[0]): DonutItem => {
-    if (bc.category === null) {
-      return {
-        key: SIN_CAT_KEY,
-        categoryId: null,
-        label: SIN_CATEGORIA.label,
-        color: SIN_CATEGORIA.color,
-        Icon: SIN_CATEGORIA.Icon,
-        amount: bc.amount,
-        pct: bc.pct,
-      }
-    }
-    const meta = CATEGORY_META[bc.category]
+    // bc.category never null here (filtered out above)
+    const catId = bc.category as NonNullable<typeof bc.category>
+    const meta = CATEGORY_META[catId]
     return {
-      key: bc.category,
-      categoryId: bc.category,
+      key: catId,
+      categoryId: catId,
       label: meta.label,
       color: meta.color,
       Icon: meta.Icon,

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -102,7 +102,8 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
 
   if (typeFilter !== 'todos') {
     filtered = filtered.filter(tx => {
-      const catId = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+      const catId = (tx.category_manual ?? tx.category) as CategoryId | null
+      if (catId === null) return false
       const catType = CATEGORY_META[catId]?.type
       if (typeFilter === 'ingresos')       return catType === 'income'
       if (typeFilter === 'gastos')         return catType === 'expense'

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -106,7 +106,7 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
       const catType = CATEGORY_META[catId]?.type
       if (typeFilter === 'ingresos')       return catType === 'income'
       if (typeFilter === 'gastos')         return catType === 'expense'
-      if (typeFilter === 'no-computable')  return catType === 'non_computable' || !tx.is_computable
+      if (typeFilter === 'no-computable')  return catType === 'non_computable'
       return true
     })
   }

--- a/docs/claude-code-plan.md
+++ b/docs/claude-code-plan.md
@@ -67,7 +67,7 @@ export const fmt = (n: number, decimals = 0): string => {
 ## Base de datos
 - Todas las tablas tienen `user_id` con RLS activada
 - `is_liability` en `accounts` para distinguir activos de pasivos
-- `is_internal_transfer` en `transactions` para evitar duplicados tarjeta/cuenta
+- La clasificación ingreso/gasto/no-computable viene de `categories.type`, no del signo del `amount`
 - Vista materializada `transactions_monthly_summary` para agregaciones
 
 ## Lo que NO hacer
@@ -152,7 +152,7 @@ Una issue está **Ready** cuando:
 #6  [chore] Utilidades compartidas: fmt(), theme tokens, tipos TypeScript
     Ref: §13 nota 6. Crear lib/formatting.ts, lib/theme.ts y types/index.ts.
     El tipo Account debe incluir is_liability. El tipo Transaction debe incluir
-    is_internal_transfer y category_manual.
+    category_manual.
 ```
 
 ### Issues de la Fase 2 — Conexión bancaria

--- a/docs/finanzas-spec.md
+++ b/docs/finanzas-spec.md
@@ -60,7 +60,8 @@ Aplicación web personal de gestión y análisis de finanzas que agrega automát
 **Filtros de tipo**
 - Pills horizontales: Todos / Ingresos / Gastos / No Computable
 - El filtro usa `CATEGORY_META[effectiveCategory].type` — no el signo del importe
-- "No Computable" incluye: transacciones con `is_computable = false` (Edenred) **y** transacciones cuya categoría efectiva tiene `type = 'non_computable'` (inversión, ahorro, transferencias...)
+- "No Computable" incluye las transacciones cuya categoría efectiva tiene `type = 'non_computable'` (inversión, ahorro, transferencias, amortizaciones)
+- Las transacciones sin categoría sólo aparecen en "Todos" hasta que el usuario las categorice
 
 **Lista agrupada por día**
 - Encabezado de día: "Hoy", "Ayer" o fecha formateada + neto del día
@@ -183,14 +184,12 @@ transactions (
   user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   account_id      UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
   date            DATE NOT NULL,
-  amount          DECIMAL(12,2) NOT NULL,  -- negativo = gasto, positivo = ingreso
+  amount          DECIMAL(12,2) NOT NULL,  -- el signo no clasifica tipo; sólo dirección del dinero
   description     TEXT NOT NULL,
-  category        TEXT,                    -- categoría asignada automáticamente
+  category        TEXT,                    -- categoría asignada automáticamente (FK lógica a categories.id)
   category_manual TEXT,                    -- categoría editada por el usuario (override)
   source          TEXT NOT NULL,           -- 'enablebanking' | 'scraper' | 'manual'
-  external_id     TEXT,                    -- ID de transacción en Enable Banking para evitar duplicados
-  is_computable   BOOLEAN DEFAULT true,    -- false = No Computable (Edenred)
-  is_internal_transfer BOOLEAN DEFAULT false, -- traspaso entre cuentas propias
+  external_id     TEXT,                    -- ID de transacción externo para evitar duplicados
   notes           TEXT,
   created_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   UNIQUE(user_id, external_id)             -- evita duplicados solo dentro del mismo user
@@ -245,12 +244,11 @@ El `CategoryPicker` agrupa las categorías por tipo con un selector de 3 tabs (G
 
 ### 3.3 Lógica de "No Computable"
 
-Dos mecanismos que coexisten:
+La única vía para que una transacción quede fuera de los totales de Análisis es **categorizarla con una categoría cuyo `type = 'non_computable'`** (`investment`, `savings`, `transfer`, `loan_payment`). Esas transacciones se excluyen de los KPIs y donuts de Ingresos/Gastos, y aparecen en la pill "No Computable" de Movimientos.
 
-1. **`is_computable = false`** en la transacción — asignado automáticamente a las transacciones de Edenred (scraper). No modificable por el usuario.
-2. **`category.type = 'non_computable'`** — cuando el usuario categoriza una transacción como `investment`, `savings`, `transfer` o `loan_payment`.
+Las transacciones sin categoría tampoco computan en los totales de Análisis ni aparecen en sus donuts; sólo se ven en la pill "Todos" de Movimientos hasta que el usuario las categorice.
 
-Ambos casos se excluyen de los totales de Gastos e Ingresos en Análisis, y ambos aparecen en la pill "No Computable" de Movimientos.
+El signo del `amount` no determina nunca el tipo (income / expense / non_computable); sólo se usa para presentación visual del importe.
 
 ---
 
@@ -424,7 +422,8 @@ GitHub Actions (cron: 0 7 * * * Europe/Madrid)
         ├── Login en edenred.es con credenciales (GitHub Secrets)
         ├── Extrae saldo actual y últimos movimientos
         └── POST a /api/edenred con Authorization: Bearer {EDENRED_WEBHOOK_SECRET}
-              └── Next.js guarda en transactions con source='scraper', is_computable=false
+              └── Next.js guarda en transactions con source='scraper'
+                  (RECARGA → category='income', consumos → category='restaurant')
                   y actualiza balance en accounts
 ```
 
@@ -535,19 +534,25 @@ Las agregaciones por período (KPIs, donut, barras) son consultas frecuentes y p
 ```sql
 CREATE MATERIALIZED VIEW transactions_monthly_summary AS
 SELECT
-  user_id,
-  account_id,
-  DATE_TRUNC('month', date)::date AS month,
-  COALESCE(category_manual, category) AS effective_category,
-  SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS ingresos,
-  SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END) AS gastos,
+  t.user_id,
+  t.account_id,
+  DATE_TRUNC('month', t.date)::date AS month,
+  COALESCE(t.category_manual, t.category) AS effective_category,
+  SUM(CASE WHEN c.type = 'income'  THEN t.amount ELSE 0 END) AS ingresos,
+  SUM(CASE WHEN c.type = 'expense' THEN t.amount ELSE 0 END) AS gastos,
   COUNT(*) AS tx_count
-FROM transactions
-WHERE is_computable = true AND is_internal_transfer = false
-GROUP BY user_id, account_id, DATE_TRUNC('month', date), effective_category;
+FROM transactions t
+JOIN categories c ON c.id = COALESCE(t.category_manual, t.category)
+WHERE c.type IN ('income', 'expense')
+GROUP BY t.user_id, t.account_id, DATE_TRUNC('month', t.date), effective_category;
 
 CREATE INDEX idx_monthly_user_month ON transactions_monthly_summary(user_id, month DESC);
 ```
+
+Notas:
+- `INNER JOIN categories` excluye transacciones sin categoría.
+- Las categorías `non_computable` quedan fuera de la vista (no aportan a `ingresos`/`gastos`).
+- Los importes se clasifican por `c.type`, **no por el signo del `amount`**: una devolución de nómina (`type='income'`, amount<0) suma al total de ingresos como negativa (resta correctamente).
 
 Esta vista se refresca tras cada sincronización con:
 ```sql
@@ -567,7 +572,11 @@ CREATE OR REPLACE FUNCTION get_period_data(
   ahorro DECIMAL,
   by_category JSONB
 ) AS $$
-  -- Implementación: agrega desde transactions filtrando por user_id, fecha y is_computable
+  -- Implementación: LEFT JOIN con categories sobre COALESCE(category_manual, category).
+  -- ingresos = SUM(amount) FILTER (WHERE c.type = 'income')
+  -- gastos   = ABS(SUM(amount) FILTER (WHERE c.type = 'expense'))
+  -- by_category sólo incluye categorías con type IN ('income','expense').
+  -- Las transacciones sin categoría o con type='non_computable' se excluyen de totales y breakdown.
 $$ LANGUAGE plpgsql STABLE;
 ```
 
@@ -589,22 +598,9 @@ El **Balance total** del Dashboard muestra el patrimonio neto, no la suma bruta 
 
 ### 5.6 Conciliación entre tarjeta y cuenta corriente
 
-Problema: cuando Enable Banking sincroniza tanto la cuenta como la tarjeta, una compra de 50€ con la tarjeta aparece dos veces:
-- En la tarjeta: el día de la compra (50€)
-- En la cuenta corriente: el día del cargo mensual de la tarjeta (cargo agregado)
+Actualmente Enable Banking sólo devuelve transacciones de cuentas bancarias (no tarjetas de crédito), por lo que no hay doble conteo.
 
-**Solución:** detectar el cargo agregado de la tarjeta y marcarlo como `is_internal_transfer = true` para que no compute en gastos:
-
-```typescript
-const RECONCILIATION_RULES = [
-  // Patrón típico: "LIQUIDACION TARJETA", "CARGO TARJETA VISA"
-  { pattern: /liquidacion\s+tarjeta|cargo\s+tarjeta/i, mark: 'internal_transfer' },
-  // Bizum o transferencia entre cuentas propias del mismo titular
-  { pattern: /traspaso\s+entre\s+cuentas/i, mark: 'internal_transfer' },
-]
-```
-
-Idealmente el usuario debería poder confirmar/rechazar la conciliación en la UI (futura mejora).
+Si en el futuro entra en juego una tarjeta cuyo cargo mensual aparece liquidado en la cuenta bancaria, la transacción de liquidación se categorizará como `loan_payment` o `transfer` (ambas con `type='non_computable'`). Esto la excluye de los totales de Análisis sin necesidad de un flag dedicado.
 
 ### 5.7 Comparativa YoY con histórico insuficiente
 
@@ -944,7 +940,7 @@ Al trabajar con este proyecto:
 
 9. **Patrimonio neto vs balance bruto.** Las cuentas con `is_liability = true` (tarjetas de crédito) deben restarse del patrimonio neto, no sumarse. La pantalla de Cuentas las muestra agrupadas separando "Activos" de "Deudas".
 
-10. **Conciliación.** Antes de mostrar gastos en Análisis, filtrar `is_internal_transfer = true`. Las reglas de conciliación se aplican al sincronizar, no al renderizar.
+10. **Clasificación por categoría, no por signo.** La fuente única de verdad para si una transacción es ingreso/gasto/no-computable es `categories.type` de la categoría efectiva (`COALESCE(category_manual, category)`). El signo del `amount` nunca se usa para clasificar tipo: una devolución de nómina (amount<0, `type='income'`) sigue siendo ingreso. Las transacciones sin categoría quedan fuera de los totales de Análisis hasta que el usuario las categorice.
 
 11. **`overflow: clip` obligatorio.** El contenedor raíz de la app debe usar `overflow: clip`, no `overflow: hidden`. Ver §6.5 para la explicación completa. Sin esto, los headers sticky no funcionan.
 

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -36,8 +36,6 @@ export async function getDashboardData(): Promise<DashboardData> {
     .from('transactions')
     .select('date, amount')
     .eq('user_id', user.id)
-    .eq('is_computable', true)
-    .eq('is_internal_transfer', false)
     .gte('date', thirtyDaysAgo.toISOString())
 
   if (txError) throw new Error('Failed to fetch transactions')
@@ -74,8 +72,6 @@ export async function getDashboardData(): Promise<DashboardData> {
     .from('transactions')
     .select('date, amount')
     .eq('user_id', user.id)
-    .eq('is_computable', true)
-    .eq('is_internal_transfer', false)
     .gte('date', twelveMonthsAgo.toISOString().split('T')[0])
 
   const txByMonth: Record<string, number> = {}

--- a/supabase/migrations/20260516000000_drop_is_computable_and_internal_transfer.sql
+++ b/supabase/migrations/20260516000000_drop_is_computable_and_internal_transfer.sql
@@ -1,0 +1,92 @@
+-- Refactor (#63): la fuente única de verdad para clasificar una transacción
+-- en Análisis es ahora `categories.type` ('expense' | 'income' | 'non_computable').
+-- Se eliminan `is_computable` e `is_internal_transfer` de `transactions`, y las
+-- agregaciones SQL pasan a clasificar por `c.type` en lugar de por el signo
+-- del `amount`.
+
+-- 1. DROP de dependencias (referencian las columnas a eliminar)
+DROP MATERIALIZED VIEW IF EXISTS transactions_monthly_summary;
+DROP FUNCTION IF EXISTS mark_internal_transfers(UUID);
+DROP FUNCTION IF EXISTS get_period_data(UUID, DATE, DATE);
+
+-- 2. Eliminar las columnas
+ALTER TABLE transactions DROP COLUMN IF EXISTS is_computable;
+ALTER TABLE transactions DROP COLUMN IF EXISTS is_internal_transfer;
+
+-- 3. Recrear vista materializada: agrega por `categories.type`.
+--    INNER JOIN excluye automáticamente transacciones sin categoría.
+--    Filtra `non_computable` a nivel de vista para mantener la semántica de
+--    "totales de Análisis" (ingresos/gastos comparables).
+CREATE MATERIALIZED VIEW transactions_monthly_summary AS
+SELECT
+  t.user_id,
+  t.account_id,
+  DATE_TRUNC('month', t.date)::date                                  AS month,
+  COALESCE(t.category_manual, t.category)                            AS effective_category,
+  SUM(CASE WHEN c.type = 'income'  THEN t.amount ELSE 0 END)         AS ingresos,
+  SUM(CASE WHEN c.type = 'expense' THEN t.amount ELSE 0 END)         AS gastos,
+  COUNT(*)                                                            AS tx_count
+FROM   transactions t
+JOIN   categories  c ON c.id = COALESCE(t.category_manual, t.category)
+WHERE  c.type IN ('income', 'expense')
+GROUP  BY t.user_id, t.account_id, DATE_TRUNC('month', t.date), COALESCE(t.category_manual, t.category);
+
+-- Índice único requerido para REFRESH MATERIALIZED VIEW CONCURRENTLY.
+-- effective_category aquí nunca es NULL (INNER JOIN), pero mantenemos
+-- NULLS NOT DISTINCT por consistencia con la versión anterior.
+CREATE UNIQUE INDEX idx_monthly_unique
+  ON transactions_monthly_summary(user_id, account_id, month, effective_category)
+  NULLS NOT DISTINCT;
+
+CREATE INDEX idx_monthly_user_month
+  ON transactions_monthly_summary(user_id, month DESC);
+
+-- 4. Recrear get_period_data: KPIs y breakdown clasifican por `c.type`.
+--    LEFT JOIN para poder distinguir "sin categoría" (cat_type IS NULL); estas
+--    transacciones se excluyen de ingresos/gastos hasta que el usuario las
+--    categorice.
+CREATE OR REPLACE FUNCTION get_period_data(
+  p_user_id    UUID,
+  p_start_date DATE,
+  p_end_date   DATE
+) RETURNS TABLE (
+  ingresos    DECIMAL,
+  gastos      DECIMAL,
+  ahorro      DECIMAL,
+  by_category JSONB
+) LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH txs AS (
+    SELECT t.amount,
+           COALESCE(t.category_manual, t.category) AS cat,
+           c.type                                  AS cat_type
+    FROM   transactions t
+    LEFT   JOIN categories c
+           ON c.id = COALESCE(t.category_manual, t.category)
+    WHERE  t.user_id = p_user_id
+      AND  t.date BETWEEN p_start_date AND p_end_date
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(amount) FILTER (WHERE cat_type = 'income'),       0) AS inc,
+      COALESCE(ABS(SUM(amount) FILTER (WHERE cat_type = 'expense')), 0) AS exp
+    FROM txs
+  ),
+  cats AS (
+    SELECT cat, SUM(amount) AS total
+    FROM   txs
+    WHERE  cat_type IN ('income', 'expense')
+    GROUP  BY cat
+  )
+  SELECT
+    totals.inc,
+    totals.exp,
+    totals.inc - totals.exp AS sav,
+    COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object('category', cat, 'amount', total)) FROM cats),
+      '[]'::jsonb
+    )
+  FROM totals;
+END;
+$$;

--- a/types/index.ts
+++ b/types/index.ts
@@ -78,8 +78,6 @@ export interface Transaction {
   category_manual: string | null
   source: DataSource
   external_id: string | null
-  is_computable: boolean
-  is_internal_transfer: boolean
   notes: string | null
   created_at: string
 }


### PR DESCRIPTION
Closes #63

## Resumen

La clasificación ingreso/gasto/no-computable de una transacción pasa a depender exclusivamente de `categories.type` de su categoría efectiva (`COALESCE(category_manual, category)`). El signo del `amount` deja de usarse para clasificar tipo; sólo se mantiene en la presentación visual del importe.

## Cambios

**Migración SQL** (`supabase/migrations/20260516000000_*`):
- Drop de las columnas `is_computable` e `is_internal_transfer` de `transactions`.
- Drop de `mark_internal_transfers()` y de la versión antigua de `get_period_data`.
- Recrear `transactions_monthly_summary` con `INNER JOIN categories` agregando por `c.type` (no por signo); excluye sin categoría y `non_computable`.
- Recrear `get_period_data` con `LEFT JOIN categories`: KPIs = `SUM(amount) FILTER (WHERE cat_type='income'|'expense')`; `by_category` filtra `type IN ('income','expense')`.

**Código**:
- `types/index.ts`: quitar los dos campos del interface `Transaction`.
- API: `app/api/transactions` (POST y GET — el filtro por type ahora vive sólo en el cliente), `app/api/edenred`, `app/api/sync/enablebanking` (quitar también la llamada a `mark_internal_transfers`).
- `lib/dashboard.ts`: la reconstrucción patrimonial deja de filtrar — todas las transacciones afectan al balance histórico.
- `components/transactions/MovimientosClient.tsx`: pill "No Computable" sólo se basa en `category.type='non_computable'`.
- `components/analytics/CategoryBreakdownSection.tsx`: las categorías nulas se excluyen del donut.

**Docs**: `CLAUDE.md`, `docs/finanzas-spec.md` (§3.3, §5.4, §5.6, nota 10), `docs/claude-code-plan.md`.

## Verificación

- [x] `pnpm build` pasa.
- [ ] Aplicar manualmente la migración en el panel SQL de Supabase.
- [ ] Análisis > Ingresos: aparecen "Reembolso" (2 tx) y "Nómina" (RECARGA Edenred).
- [ ] Análisis > Gastos: aparecen los consumos de Edenred como "Restaurantes".
- [ ] Análisis: el donut no muestra "Sin categoría".
- [ ] Test de signo: tx con `category='income'` y `amount=-50` debe restar 50 € del KPI Ingresos del período.
- [ ] Dashboard: balance y reconstrucción patrimonial siguen consistentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)