### PR TITLE
feat(theme): exponer ThemeToggle en el sheet de usuario (#66)

### DIFF
--- a/components/dashboard/UserMenuTrigger.tsx
+++ b/components/dashboard/UserMenuTrigger.tsx
@@ -11,6 +11,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { signOut } from '@/app/actions/auth'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 type Props = { email: string }
 
@@ -49,6 +50,7 @@ export function UserMenuTrigger({ email }: Props) {
         </SheetHeader>
 
         <div className="flex flex-col gap-1 px-2 pb-2">
+          <ThemeToggle />
           <form action={signOut}>
             <button
               type="submit"

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,20 +1,55 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
-import { Sun, Moon } from 'lucide-react'
+import { Moon, Sun } from 'lucide-react'
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  const isDark = mounted && resolvedTheme === 'dark'
 
   return (
-    <button
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-      className="flex items-center justify-center w-9.5 h-9.5 rounded-xl cursor-pointer
-                 bg-secondary border border-border text-muted-foreground transition-colors"
-      aria-label="Cambiar tema"
-    >
-      <Sun className="size-4 hidden dark:block" />
-      <Moon className="size-4 block dark:hidden" />
-    </button>
+    <div className="flex w-full items-center justify-between rounded-xl px-3 py-3 text-sm font-medium text-foreground">
+      <span className="flex items-center gap-3">
+        <Moon className="size-4.5" strokeWidth={2} />
+        Tema
+      </span>
+      <span
+        role="group"
+        aria-label="Seleccionar tema"
+        className="flex items-center gap-1 rounded-lg bg-muted p-0.5"
+      >
+        <button
+          type="button"
+          onClick={() => setTheme('light')}
+          aria-label="Tema claro"
+          aria-pressed={mounted ? !isDark : undefined}
+          className={`grid size-7 place-items-center rounded-md transition-colors ${
+            mounted && !isDark
+              ? 'bg-card text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Sun className="size-4" strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setTheme('dark')}
+          aria-label="Tema oscuro"
+          aria-pressed={mounted ? isDark : undefined}
+          className={`grid size-7 place-items-center rounded-md transition-colors ${
+            isDark
+              ? 'bg-card text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <Moon className="size-4" strokeWidth={2} />
+        </button>
+      </span>
+    </div>
   )
 }


### PR DESCRIPTION
Closes #66

## Resumen

- Refactoriza `components/theme-toggle.tsx` como **fila** apta para listas de preferencias: icono + label "Tema" + mini-segmented Sun/Moon a la derecha, con el modo activo resaltado.
- Añade guard de montaje (`useEffect` + `mounted` flag) y usa `resolvedTheme` para evitar mismatch de hidratación cuando el `defaultTheme` es `system`.
- Engancha `<ThemeToggle />` en el bottom sheet de `components/dashboard/UserMenuTrigger.tsx`, justo encima de "Cerrar sesión".

## Decisiones

- **Binario claro/oscuro** (sin opción "Sistema" explícita) — coherente con el prototipo `docs/finanzas-app.jsx:479-485`. El `defaultTheme="system"` del `ThemeProvider` sigue siendo el estado inicial hasta la primera interacción.
- **Sin `shadcn/Switch`** — no había otros usos en el repo; el mini-segmented con Tailwind puro cubre el caso.

## Test plan

- [ ] `pnpm dev` → abrir Dashboard → tocar avatar → aparece fila "Tema" sobre "Cerrar sesión".
- [ ] Con el SO en claro, el Sun aparece activo; con el SO en oscuro, el Moon.
- [ ] Tocar el icono inactivo cambia el tema en toda la app inmediatamente.
- [ ] Recargar mantiene la elección (`next-themes` persiste en `localStorage`).
- [ ] `pnpm build` sin warnings de hidratación. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)