### PR TITLE
feat(enablebanking): cron diario vía GitHub Actions + endpoint con bearer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,12 +6,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Enable Banking
 ENABLEBANKING_APP_ID=
 ENABLEBANKING_SECRET_KEY=
+ENABLEBANKING_WEBHOOK_SECRET=  # genera con: openssl rand -hex 32 — mismo valor en GitHub Secrets y en Vercel
 
-# Edenred scraper (GitHub Actions → webhook)
+# Edenred scraper (launchd local → webhook)
 EDENRED_WEBHOOK_SECRET=    # genera con: openssl rand -hex 32
 EDENRED_USER=              # solo para regenerar storage-state localmente
 EDENRED_PASS=              # solo para regenerar storage-state localmente
-APP_URL=http://localhost:3000   # destino del webhook al ejecutar scrape:edenred
+APP_URL=http://localhost:3000   # destino del webhook (lo usan scrape:edenred y el workflow de Enable Banking)
 
 # App
 NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app

--- a/.github/workflows/enablebanking-sync.yml
+++ b/.github/workflows/enablebanking-sync.yml
@@ -1,8 +1,6 @@
 name: Enable Banking sync
 
 on:
-  push:
-    branches: [feature/enablebanking-cron-bearer]   # TEMPORAL: validar el workflow antes del merge
   schedule:
     - cron: '0 5 * * *'   # 06:00 Europe/Madrid (UTC+1) — antes de la franja de Edenred 07:00 local
   workflow_dispatch:
@@ -14,7 +12,7 @@ jobs:
       - name: Trigger sync
         env:
           SECRET: ${{ secrets.ENABLEBANKING_WEBHOOK_SECRET }}
-          APP_URL: https://fin-4zjqrcggt-mrclits-projects.vercel.app   # TEMPORAL: preview URL en vez de secrets.APP_URL
+          APP_URL: ${{ secrets.APP_URL }}
         run: |
           curl --fail-with-body -sS -X POST \
             -H "Authorization: Bearer $SECRET" \

--- a/.github/workflows/enablebanking-sync.yml
+++ b/.github/workflows/enablebanking-sync.yml
@@ -1,0 +1,19 @@
+name: Enable Banking sync
+
+on:
+  schedule:
+    - cron: '0 5 * * *'   # 06:00 Europe/Madrid (UTC+1) — antes de la franja de Edenred 07:00 local
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync
+        env:
+          SECRET: ${{ secrets.ENABLEBANKING_WEBHOOK_SECRET }}
+          APP_URL: ${{ secrets.APP_URL }}
+        run: |
+          curl --fail-with-body -sS -X POST \
+            -H "Authorization: Bearer $SECRET" \
+            "$APP_URL/api/sync/enablebanking/cron"

--- a/.github/workflows/enablebanking-sync.yml
+++ b/.github/workflows/enablebanking-sync.yml
@@ -1,6 +1,8 @@
 name: Enable Banking sync
 
 on:
+  push:
+    branches: [feature/enablebanking-cron-bearer]   # TEMPORAL: validar el workflow antes del merge
   schedule:
     - cron: '0 5 * * *'   # 06:00 Europe/Madrid (UTC+1) — antes de la franja de Edenred 07:00 local
   workflow_dispatch:
@@ -12,7 +14,7 @@ jobs:
       - name: Trigger sync
         env:
           SECRET: ${{ secrets.ENABLEBANKING_WEBHOOK_SECRET }}
-          APP_URL: ${{ secrets.APP_URL }}
+          APP_URL: https://fin-4zjqrcggt-mrclits-projects.vercel.app   # TEMPORAL: preview URL en vez de secrets.APP_URL
         run: |
           curl --fail-with-body -sS -X POST \
             -H "Authorization: Bearer $SECRET" \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ pnpm scrape:edenred:login   # abre Chromium, completas 2FA, ENTER al final
 ./scripts/install-edenred-launchd.sh --uninstall
 ```
 
+## Cron de Enable Banking
+
+El sync de Enable Banking se ejecuta **cada día a las 06:00 Europe/Madrid** mediante GitHub Actions ([.github/workflows/enablebanking-sync.yml](.github/workflows/enablebanking-sync.yml)).
+
+> **¿Por qué GitHub Actions y no launchd local como Edenred?** Enable Banking es una API PSD2 oficial: los tokens OAuth viven en `accounts.session_id` y la llamada saliente desde el servidor a `api.enablebanking.com` no depende de la IP de origen (a diferencia de Edenred). GitHub Actions corre 24/7 sin depender de que el Mac esté encendido, lo cual importa porque el consentimiento PSD2 caduca a 90 días.
+
+### Secrets requeridos
+
+| GitHub Secret | Valor |
+|---|---|
+| `ENABLEBANKING_WEBHOOK_SECRET` | mismo valor que en Vercel (generado con `openssl rand -hex 32`) |
+| `APP_URL` | URL del deploy donde vive el endpoint (`https://<...>.vercel.app`, sin barra final). Reutilizable con el de Edenred. |
+
+Además, el endpoint vive en Vercel y necesita `ENABLEBANKING_WEBHOOK_SECRET` configurado como env var en Vercel (mismo valor que en GitHub).
+
+### Disparar manualmente
+
+Desde la pestaña Actions del repo → "Enable Banking sync" → "Run workflow". O por CLI:
+
+```bash
+gh workflow run enablebanking-sync.yml
+```
+
+### Verificar y operar
+
+Los logs de cada run están en la pestaña Actions del repo. Una ejecución correcta devuelve `{ synced, accounts, failed }`:
+- `synced`: nº de transacciones upserteadas.
+- `accounts`: nº total de cuentas EB activas procesadas.
+- `failed`: cuentas con error parcial (consentimiento caducado, token expirado, etc.). El run sigue siendo HTTP 200 — los errores parciales no abortan el cron, pero quedan logueados.
+
+El run falla con código HTTP no-2xx solo si el endpoint devuelve 5xx (DB inalcanzable, secret mal configurado).
+
 ## Comandos
 
 - `pnpm dev` — desarrollo local

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server'
+import { timingSafeEqual } from 'node:crypto'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getAccountTransactions } from '@/lib/enablebanking'
+import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
+
+function safeBearerMatch(header: string | null, secret: string): boolean {
+  if (!header) return false
+  const expected = `Bearer ${secret}`
+  const a = Buffer.from(header)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export async function POST(req: Request) {
+  const secret = process.env.ENABLEBANKING_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[sync/eb/cron] ENABLEBANKING_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  const db = createServiceClient()
+
+  const { data: accounts, error: accountsError } = await db
+    .from('accounts')
+    .select('id, user_id, external_id, session_id, last_synced')
+    .eq('source', 'enablebanking')
+    .eq('is_active', true)
+
+  if (accountsError) {
+    console.error('[sync/eb/cron] fetch accounts:', accountsError)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  if (!accounts || accounts.length === 0) {
+    return NextResponse.json({ synced: 0, accounts: 0, failed: [] })
+  }
+
+  const userIds = Array.from(new Set(accounts.map(a => a.user_id as string)))
+  const { data: rulesData, error: rulesError } = await db
+    .from('categorization_rules')
+    .select('user_id, pattern, field, category_id')
+    .in('user_id', userIds)
+    .eq('is_active', true)
+    .order('priority', { ascending: false })
+
+  if (rulesError) {
+    console.error('[sync/eb/cron] fetch rules:', rulesError)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  const rulesByUser = new Map<string, DbCategorizationRule[]>()
+  for (const row of rulesData ?? []) {
+    const userId = (row as { user_id: string }).user_id
+    const rule: DbCategorizationRule = {
+      pattern: (row as { pattern: string }).pattern,
+      field: (row as { field: DbCategorizationRule['field'] }).field,
+      category_id: (row as { category_id: string }).category_id,
+    }
+    const list = rulesByUser.get(userId)
+    if (list) list.push(rule)
+    else rulesByUser.set(userId, [rule])
+  }
+
+  let totalSynced = 0
+  const failed: { account_id: string; error: string }[] = []
+
+  for (const account of accounts) {
+    if (!account.external_id || !account.session_id) continue
+
+    const userId = account.user_id as string
+    const dbRules = rulesByUser.get(userId) ?? []
+    const dateFrom = account.last_synced
+      ? (account.last_synced as string).slice(0, 10)
+      : undefined
+
+    let ebTransactions
+    try {
+      ebTransactions = await getAccountTransactions(
+        account.external_id,
+        account.session_id,
+        dateFrom
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`[sync/eb/cron] getTransactions ${account.external_id}:`, message)
+      failed.push({ account_id: account.id as string, error: message })
+      continue
+    }
+
+    if (ebTransactions.length > 0) {
+      const rows = ebTransactions.map(tx => {
+        const externalId = tx.entry_reference ?? tx.transaction_id
+        const description =
+          tx.remittance_information?.[0]?.trim() ||
+          tx.creditor?.name ||
+          tx.debtor?.name ||
+          'Sin descripción'
+        const merchant = tx.creditor?.name ?? tx.debtor?.name ?? undefined
+        const sign = tx.credit_debit_indicator === 'DBIT' ? -1 : 1
+        const amount = parseFloat(tx.transaction_amount.amount) * sign
+
+        return {
+          user_id:     userId,
+          account_id:  account.id,
+          date:        tx.booking_date,
+          amount,
+          description,
+          category:    categorizeWithRules(dbRules, description, merchant ?? undefined),
+          source:      'enablebanking' as const,
+          external_id: externalId,
+        }
+      })
+
+      const { error: upsertError } = await db
+        .from('transactions')
+        .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: true })
+
+      if (upsertError) {
+        console.error(`[sync/eb/cron] upsert ${account.external_id}:`, upsertError)
+        failed.push({ account_id: account.id as string, error: upsertError.message })
+        continue
+      }
+
+      totalSynced += rows.length
+    }
+
+    const lastTx = ebTransactions.at(-1)
+    const balance = lastTx?.balance_after_transaction
+      ? parseFloat(lastTx.balance_after_transaction.amount)
+      : null
+    await db
+      .from('accounts')
+      .update({ ...(balance !== null && { balance }), last_synced: new Date().toISOString() })
+      .eq('id', account.id)
+  }
+
+  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
+  if (refreshError) console.error('[sync/eb/cron] refresh_monthly_summary:', refreshError)
+
+  return NextResponse.json({
+    synced: totalSynced,
+    accounts: accounts.length,
+    failed,
+  })
+}

--- a/docs/finanzas-spec.md
+++ b/docs/finanzas-spec.md
@@ -262,7 +262,7 @@ El signo del `amount` no determina nunca el tipo (income / expense / non_computa
 | Base de datos | **Supabase** (PostgreSQL) | Auth incluida, tiempo real, SDK TypeScript |
 | Agregación bancaria | **Enable Banking** | PSD2, tier gratuito para developers, buena cobertura España |
 | Scraping Edenred | **Playwright + Node.js** | Headless Chromium para la web de Edenred |
-| Automatización | **GitHub Actions** | Cron job gratuito para el scraper diario |
+| Automatización | **GitHub Actions** (Enable Banking) + **launchd local** (Edenred) | EB es API PSD2 → cron en GitHub. Edenred bindea la sesión por IP residencial → cron local en el Mac del usuario. |
 | Deploy | **Vercel** | Free tier, integración Next.js nativa |
 | Estilos | **Tailwind CSS v4** | Consistencia con el sistema de diseño del prototipo |
 
@@ -386,9 +386,12 @@ finanzas-app/
 │   ├── useTransactions.ts          → SWR/React Query para transacciones
 │   ├── useAccounts.ts              → SWR para cuentas y saldos
 │   └── useAnalytics.ts             → Datos agregados para la pantalla de análisis
-└── .github/
-    └── workflows/
-        └── edenred-scraper.yml     → Cron job diario 07:00 (Europe/Madrid)
+├── .github/
+│   └── workflows/
+│       └── enablebanking-sync.yml → Cron diario 06:00 (Europe/Madrid) → POST /api/sync/enablebanking/cron
+└── scripts/
+    ├── scrape-edenred.mjs         → Scraper Edenred (lanzado por launchd local 07:00)
+    └── install-edenred-launchd.sh → Instala el agente launchd en ~/Library/LaunchAgents
 ```
 
 ### 4.4 Flujo de sincronización bancaria (Enable Banking)
@@ -399,27 +402,38 @@ finanzas-app/
 3. Enable Banking redirige al usuario al banco (OAuth/PSD2 del banco)
 4. Usuario autoriza en su banco y vuelve a la app
 5. Enable Banking callback → Next.js guarda el session_id en Supabase
-6. Cron semanal (o manual) llama a GET /accounts/{id}/transactions
-7. Se normalizan y guardan en tabla transactions (external_id evita duplicados)
+6. Cron diario (o manual) llama a POST /api/sync/enablebanking/cron
+7. El endpoint itera todas las cuentas EB activas y normaliza/guarda transacciones (external_id evita duplicados)
 8. Se actualiza el saldo en tabla accounts
 ```
+
+El cron se dispara desde GitHub Actions (`.github/workflows/enablebanking-sync.yml`, cron `0 5 * * *` UTC = 06:00 Europe/Madrid) haciendo un `curl -H "Authorization: Bearer $ENABLEBANKING_WEBHOOK_SECRET"` contra el endpoint. El endpoint **cookie** (`POST /api/sync/enablebanking`) se mantiene para el botón "Sincronizar ahora" desde la UI. Los errores parciales por cuenta (consentimiento caducado, token expirado) loguean pero no abortan el cron.
 
 **Variables de entorno necesarias:**
 ```
 ENABLEBANKING_APP_ID=
 ENABLEBANKING_SECRET_KEY=
+ENABLEBANKING_WEBHOOK_SECRET=   # autentica al cron contra /api/sync/enablebanking/cron
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
-EDENRED_WEBHOOK_SECRET=      # para autenticar llamadas del scraper
+EDENRED_WEBHOOK_SECRET=         # autentica al scraper de Edenred contra /api/edenred
 ```
 
-### 4.5 Flujo Edenred (scraping vía GitHub Actions)
+**GitHub Secrets necesarios para el workflow EB:**
+```
+ENABLEBANKING_WEBHOOK_SECRET=   # mismo valor que en Vercel
+APP_URL=                        # URL de producción en Vercel
+```
+
+### 4.5 Flujo Edenred (scraping vía launchd local)
+
+> **Por qué no GitHub Actions:** Edenred valida la IP de origen de la sesión. Una sesión generada desde una IP residencial española queda invalidada al usarla desde el datacenter de GitHub. Probado y descartado. El cron pasa a ejecutarse en el Mac del usuario, donde la IP coincide con la que generó la sesión.
 
 ```
-GitHub Actions (cron: 0 7 * * * Europe/Madrid)
-  └── Node.js script con Playwright
-        ├── Login en edenred.es con credenciales (GitHub Secrets)
+launchd (StartCalendarInterval: 07:00 hora local)
+  └── pnpm scrape:edenred (Playwright headless, sesión en scripts/storage-state.json)
+        ├── Carga storage-state.json y entra en edenred.es
         ├── Extrae saldo actual y últimos movimientos
         └── POST a /api/edenred con Authorization: Bearer {EDENRED_WEBHOOK_SECRET}
               └── Next.js guarda en transactions con source='scraper'
@@ -427,39 +441,17 @@ GitHub Actions (cron: 0 7 * * * Europe/Madrid)
                   y actualiza balance en accounts
 ```
 
-**GitHub Secrets necesarios para el workflow:**
+El agente se instala con `./scripts/install-edenred-launchd.sh` y se desinstala con la misma orden + `--uninstall`. Si la sesión caduca, el script sale con exit code 2 y se regenera con `pnpm scrape:edenred:login`.
+
+**Variables en `.env.local` del Mac:**
 ```
 EDENRED_USER=
 EDENRED_PASS=
-APP_URL=                     # URL de producción en Vercel
+APP_URL=                        # URL de producción en Vercel
 EDENRED_WEBHOOK_SECRET=
 ```
 
-**Archivo `.github/workflows/edenred-scraper.yml`:**
-```yaml
-name: Edenred Scraper
-on:
-  schedule:
-    - cron: '0 6 * * *'   # 07:00 Europe/Madrid (UTC+1)
-  workflow_dispatch:         # Permite ejecución manual
-
-jobs:
-  scrape:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - run: npm ci
-      - run: npx playwright install chromium --with-deps
-      - run: node scripts/scrape-edenred.js
-        env:
-          EDENRED_USER: ${{ secrets.EDENRED_USER }}
-          EDENRED_PASS: ${{ secrets.EDENRED_PASS }}
-          APP_URL: ${{ secrets.APP_URL }}
-          EDENRED_WEBHOOK_SECRET: ${{ secrets.EDENRED_WEBHOOK_SECRET }}
-```
+**Instalación del agente launchd:** detalles operativos en el README (sección "Cron de Edenred").
 
 ---
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,8 +2,13 @@ import { createServerClient } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
   // Webhooks públicos con auth Bearer: saltar el chequeo de sesión.
-  if (request.nextUrl.pathname.startsWith('/api/edenred')) {
+  if (
+    pathname.startsWith('/api/edenred') ||
+    pathname === '/api/sync/enablebanking/cron'
+  ) {
     return NextResponse.next({ request })
   }
 
@@ -28,8 +33,6 @@ export async function proxy(request: NextRequest) {
 
   // Refreshes the session and gets the current user
   const { data: { user } } = await supabase.auth.getUser()
-
-  const { pathname } = request.nextUrl
 
   if (!user && pathname !== '/login' && !pathname.startsWith('/auth/')) {
     return NextResponse.redirect(new URL('/login', request.url))


### PR DESCRIPTION
Closes #67

## Resumen

- Nuevo endpoint `POST /api/sync/enablebanking/cron` con bearer auth (`ENABLEBANKING_WEBHOOK_SECRET`).
- Itera todas las cuentas EB activas y agrupa `categorization_rules` por `user_id` (soporta multi-user aunque hoy haya uno solo).
- Reutiliza la lógica de normalización, upsert (`onConflict: 'user_id,external_id'`) y `refresh_monthly_summary` del endpoint con cookie. Errores parciales por cuenta no abortan el cron — se devuelven en el campo `failed`.
- El endpoint actual con cookie (`POST /api/sync/enablebanking`) se mantiene intacto para "Sincronizar ahora" desde la UI.
- Nuevo workflow `.github/workflows/enablebanking-sync.yml` con cron diario `0 5 * * *` UTC (06:00 Europe/Madrid) y `workflow_dispatch`.

## Decisión arquitectónica (vs. Edenred)

La issue original sugería replicar el patrón Edenred (GitHub Actions), pero ese patrón ya no existe: en #70 Edenred migró a launchd local **porque su sesión está bindeada a IP residencial**. Enable Banking no tiene ese problema (es API PSD2 con tokens OAuth en DB), así que GitHub Actions sigue siendo la mejor opción para EB: 24/7 sin depender del Mac, importante porque el consentimiento PSD2 caduca a 90 días.

## Cambios en docs

- `.env.example`: añade `ENABLEBANKING_WEBHOOK_SECRET` y aclara que `APP_URL` lo usan ambos crons.
- `README.md`: nueva sección "Cron de Enable Banking" con secrets, disparo manual y observabilidad.
- `docs/finanzas-spec.md`: §3 (tabla decisiones), §4.3 (estructura), §4.4 (flujo EB) y §4.5 (flujo Edenred) actualizados para reflejar la distinción entre ambos crons.

## Test plan

- [x] `pnpm build` ✅ (`/api/sync/enablebanking/cron` aparece en la lista de rutas)
- [x] `pnpm lint` (errores preexistentes en prototipo y archivos no tocados; el código nuevo está limpio)
- [ ] Antes de merge: añadir `ENABLEBANKING_WEBHOOK_SECRET` a GitHub Secrets y a Vercel env vars
- [ ] Curl manual desde local: 401 con bearer incorrecto, 200 con bearer correcto
- [ ] Verificar en Supabase que `transactions` se upsertean y `accounts.balance` / `accounts.last_synced` se actualizan
- [ ] Tras merge a `main`: disparo manual desde Actions → confirmar HTTP 200 y datos en DB
- [ ] Comprobar que el endpoint con cookie (`/api/sync/enablebanking`) sigue funcionando sin regresión

🤖 Generated with [Claude Code](https://claude.com/claude-code)