### PR TITLE
refactor(movimientos): partir MovimientosClient en hooks y componentes (#65)

### DIFF
--- a/components/transactions/AddTxFab.tsx
+++ b/components/transactions/AddTxFab.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+
+interface AddTxFabProps {
+  onClick: () => void
+}
+
+export function AddTxFab({ onClick }: AddTxFabProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        position: 'fixed',
+        bottom: 'calc(max(env(safe-area-inset-bottom), 1.5rem) + 84px)',
+        right: 'max(20px, calc(50vw - 190px))',
+        width: 56,
+        height: 56,
+        borderRadius: '50%',
+        background: '#6366f1',
+        border: 'none',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        boxShadow: '0 4px 16px rgba(99,102,241,0.4)',
+        zIndex: 110,
+      }}
+    >
+      <Plus size={24} color="white" strokeWidth={2.5} />
+    </button>
+  )
+}

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -1,24 +1,17 @@
 'use client'
 
-import { useState } from 'react'
-import { Search, X, ChevronDown, Box, Plus } from 'lucide-react'
-import { TxRow } from './TxRow'
+import { useMemo, useState } from 'react'
 import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
 import { CategoryPicker } from './CategoryPicker'
 import { AddTxModal } from './AddTxModal'
-import { CATEGORY_META } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
-import type { Account, CategoryId, TransactionWithAccount } from '@/types'
-
-type TypeFilter = 'todos' | 'ingresos' | 'gastos' | 'no-computable'
-
-const TYPE_PILLS: { key: TypeFilter; label: string }[] = [
-  { key: 'todos', label: 'Todos' },
-  { key: 'ingresos', label: 'Ingresos' },
-  { key: 'gastos', label: 'Gastos' },
-  { key: 'no-computable', label: 'No Computable' },
-]
+import { MovimientosToolbar } from './MovimientosToolbar'
+import { MovimientosList } from './MovimientosList'
+import { AddTxFab } from './AddTxFab'
+import { useMovimientosFilters } from './useMovimientosFilters'
+import { useTxMutations } from './useTxMutations'
+import { groupTxByDate } from '@/lib/transactions'
+import type { Account, TransactionWithAccount } from '@/types'
 
 interface MovimientosClientProps {
   initialTransactions: TransactionWithAccount[]
@@ -26,23 +19,10 @@ interface MovimientosClientProps {
   manualAccountId: string
 }
 
-function formatDayLabel(dateStr: string): string {
-  const today = new Date().toISOString().slice(0, 10)
-  const yest = new Date()
-  yest.setDate(yest.getDate() - 1)
-  const yesterdayStr = yest.toISOString().slice(0, 10)
-  if (dateStr === today) return 'Hoy'
-  if (dateStr === yesterdayStr) return 'Ayer'
-  const [y, m, d] = dateStr.split('-').map(Number)
-  const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
-  return `${d} ${MONTHS[m - 1]} ${y}`
-}
-
 export function MovimientosClient({ initialTransactions, accounts, manualAccountId }: MovimientosClientProps) {
-  const [transactions, setTransactions] = useState(initialTransactions)
-  const [searchQuery, setSearchQuery] = useState('')
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
-  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
+  const { transactions, addTx, deleteTx, recategorize } = useTxMutations(initialTransactions)
+  const filters = useMovimientosFilters(transactions)
+
   const [showAccountFilter, setShowAccountFilter] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)
   const [swipedTxId, setSwipedTxId] = useState<string | null>(null)
@@ -50,13 +30,7 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
   const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
-
-  const accountLabel =
-    selectedAccountIds.length === 0
-      ? 'Todas las cuentas'
-      : selectedAccountIds.length === 1
-        ? (accounts.find(a => a.id === selectedAccountIds[0])?.name ?? '1 cuenta')
-        : `${selectedAccountIds.length} cuentas`
+  const groups = useMemo(() => groupTxByDate(filters.filtered), [filters.filtered])
 
   function handleTxTap(tx: TransactionWithAccount) {
     setSelectedTxId(tx.id)
@@ -70,198 +44,39 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
 
   async function handleDelete(txId: string) {
     setSelectedTxId(null)
-    setTransactions(prev => prev.filter(t => t.id !== txId))
-    const res = await fetch(`/api/transactions/${txId}`, { method: 'DELETE' })
-    if (!res.ok) {
-      setTransactions(initialTransactions)
-      console.error('[handleDelete] Error eliminando:', await res.text())
-    }
+    await deleteTx(txId)
   }
-
-  async function handleSelect(txId: string, category: CategoryId) {
-    setTransactions(prev => prev.map(t =>
-      t.id === txId ? { ...t, category_manual: category } : t
-    ))
-    const res = await fetch(`/api/transactions/${txId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ category_manual: category }),
-    })
-    if (!res.ok) {
-      setTransactions(initialTransactions)
-      console.error('[handleSelect] Error recategorizando:', await res.text())
-    }
-  }
-
-  // Client-side filtering
-  let filtered = transactions
-
-  if (selectedAccountIds.length > 0) {
-    filtered = filtered.filter(tx => selectedAccountIds.includes(tx.account_id))
-  }
-
-  if (typeFilter !== 'todos') {
-    filtered = filtered.filter(tx => {
-      const catId = (tx.category_manual ?? tx.category) as CategoryId | null
-      if (catId === null) return false
-      const catType = CATEGORY_META[catId]?.type
-      if (typeFilter === 'ingresos')       return catType === 'income'
-      if (typeFilter === 'gastos')         return catType === 'expense'
-      if (typeFilter === 'no-computable')  return catType === 'non_computable'
-      return true
-    })
-  }
-
-  if (searchQuery.trim()) {
-    const q = searchQuery.trim().toLowerCase()
-    filtered = filtered.filter(tx => {
-      if (tx.description.toLowerCase().includes(q)) return true
-      const cat = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
-      const label = CATEGORY_META[cat]?.label ?? ''
-      return label.toLowerCase().includes(q)
-    })
-  }
-
-  // Group by date
-  const groups = new Map<string, { transactions: TransactionWithAccount[]; net: number }>()
-  for (const tx of filtered) {
-    const existing = groups.get(tx.date)
-    if (existing) {
-      existing.transactions.push(tx)
-      existing.net += tx.amount
-    } else {
-      groups.set(tx.date, { transactions: [tx], net: tx.amount })
-    }
-  }
-
-  const sortedDates = Array.from(groups.keys()).sort((a, b) => b.localeCompare(a))
 
   return (
     <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
       <h1 className="text-xl font-bold text-foreground">Movimientos</h1>
 
-      {/* Search */}
-      <div
-        className="flex items-center gap-2 px-3.5 py-2.5 rounded-[14px] bg-muted"
-        style={{ border: '1px solid var(--border)' }}
-      >
-        <Search size={16} className="text-muted-foreground shrink-0" />
-        <input
-          type="text"
-          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
-          placeholder="Buscar por descripción o categoría…"
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-        />
-        {searchQuery && (
-          <button onClick={() => setSearchQuery('')} className="text-muted-foreground hover:text-foreground shrink-0">
-            <X size={14} />
-          </button>
-        )}
-      </div>
+      <MovimientosToolbar
+        searchQuery={filters.searchQuery}
+        onSearchChange={filters.setSearchQuery}
+        typeFilter={filters.typeFilter}
+        onTypeFilterChange={filters.setTypeFilter}
+        selectedAccountIds={filters.selectedAccountIds}
+        accounts={accounts}
+        onOpenAccountFilter={() => setShowAccountFilter(true)}
+      />
 
-      {/* Account filter button — full width */}
-      <button
-        className="w-full flex items-center justify-between px-3.5 py-2.5 rounded-[14px] transition-colors"
-        style={{
-          background: selectedAccountIds.length > 0 ? 'rgba(99,102,241,0.1)' : 'var(--muted)',
-          border: selectedAccountIds.length > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border)',
-        }}
-        onClick={() => setShowAccountFilter(true)}
-      >
-        <div className="flex items-center gap-2">
-          <Box size={14} style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }} strokeWidth={2} />
-          <span
-            className="text-sm font-semibold"
-            style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }}
-          >
-            {accountLabel}
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          {selectedAccountIds.length > 0 && (
-            <span
-              className="rounded-full text-[10px] font-bold px-1.5 py-0.5 leading-none"
-              style={{ background: '#6366f1', color: 'white' }}
-            >
-              {selectedAccountIds.length}
-            </span>
-          )}
-          <ChevronDown size={12} className="text-muted-foreground" />
-        </div>
-      </button>
+      <MovimientosList
+        groups={groups}
+        swipedTxId={swipedTxId}
+        onSwipe={setSwipedTxId}
+        onRecategorize={handleRecategorize}
+        onTap={handleTxTap}
+      />
 
-      {/* Type pills */}
-      <div className="flex items-center gap-2 overflow-x-auto pb-0.5">
-        {TYPE_PILLS.map(pill => (
-          <button
-            key={pill.key}
-            className="px-3.5 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0"
-            style={{
-              background: typeFilter === pill.key ? '#6366f1' : 'var(--muted)',
-              color: typeFilter === pill.key ? 'white' : 'var(--muted-foreground)',
-            }}
-            onClick={() => setTypeFilter(pill.key)}
-          >
-            {pill.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Transaction list */}
-      {sortedDates.length === 0 ? (
-        <div className="flex items-center justify-center py-16">
-          <p className="text-sm text-muted-foreground text-center">No hay movimientos con estos filtros</p>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-4">
-          {sortedDates.map(date => {
-            const group = groups.get(date)!
-            const net = group.net
-            const netStr = (net >= 0 ? '+' : '') + fmt(net, 2) + ' €'
-            const netColor = net >= 0 ? '#22c55e' : 'var(--foreground)'
-
-            return (
-              <div key={date} className="flex flex-col gap-0.5">
-                {/* Day header */}
-                <div className="flex items-center justify-between px-3 pb-1">
-                  <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
-                    {formatDayLabel(date)}
-                  </span>
-                  <span className="text-xs font-bold" style={{ color: netColor }}>
-                    {netStr}
-                  </span>
-                </div>
-
-                {/* Transactions */}
-                <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
-                  {group.transactions.map(tx => (
-                    <TxRow
-                      key={tx.id}
-                      tx={tx}
-                      swipedId={swipedTxId}
-                      onSwipe={setSwipedTxId}
-                      onRecategorize={handleRecategorize}
-                      onTap={handleTxTap}
-                    />
-                  ))}
-                </div>
-              </div>
-            )
-          })}
-        </div>
-      )}
-
-      {/* Account filter bottom sheet */}
       <AccountFilter
         open={showAccountFilter}
         onOpenChange={setShowAccountFilter}
         accounts={accounts}
-        selectedIds={selectedAccountIds}
-        onSelectionChange={setSelectedAccountIds}
+        selectedIds={filters.selectedAccountIds}
+        onSelectionChange={filters.setSelectedAccountIds}
       />
 
-      {/* Transaction detail bottom sheet */}
       {selectedTx && (
         <TxModal
           tx={selectedTx}
@@ -272,46 +87,23 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
         />
       )}
 
-      {/* Category picker bottom sheet (se apila sobre TxModal) */}
       {catPickerTx && (
         <CategoryPicker
           tx={catPickerTx}
           open
           onOpenChange={o => { if (!o) setCatPickerTx(null) }}
-          onSelect={handleSelect}
+          onSelect={recategorize}
         />
       )}
 
-      {/* Add transaction bottom sheet */}
       <AddTxModal
         open={showAddModal}
         onOpenChange={setShowAddModal}
         manualAccountId={manualAccountId}
-        onSave={tx => setTransactions(prev => [tx, ...prev])}
+        onSave={addTx}
       />
 
-      {/* FAB */}
-      <button
-        onClick={() => setShowAddModal(true)}
-        style={{
-          position: 'fixed',
-          bottom: 'calc(max(env(safe-area-inset-bottom), 1.5rem) + 84px)',
-          right: 'max(20px, calc(50vw - 190px))',
-          width: 56,
-          height: 56,
-          borderRadius: '50%',
-          background: '#6366f1',
-          border: 'none',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          boxShadow: '0 4px 16px rgba(99,102,241,0.4)',
-          zIndex: 110,
-        }}
-      >
-        <Plus size={24} color="white" strokeWidth={2.5} />
-      </button>
+      <AddTxFab onClick={() => setShowAddModal(true)} />
     </div>
   )
 }

--- a/components/transactions/MovimientosList.tsx
+++ b/components/transactions/MovimientosList.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { TxRow } from './TxRow'
+import { fmt } from '@/lib/formatting'
+import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
+import type { TransactionWithAccount } from '@/types'
+
+interface MovimientosListProps {
+  groups: TxDayGroup[]
+  swipedTxId: string | null
+  onSwipe: (id: string | null) => void
+  onRecategorize: (tx: TransactionWithAccount) => void
+  onTap: (tx: TransactionWithAccount) => void
+}
+
+export function MovimientosList({ groups, swipedTxId, onSwipe, onRecategorize, onTap }: MovimientosListProps) {
+  if (groups.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <p className="text-sm text-muted-foreground text-center">No hay movimientos con estos filtros</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {groups.map(group => {
+        const netStr = (group.net >= 0 ? '+' : '') + fmt(group.net, 2) + ' €'
+        const netColor = group.net >= 0 ? '#22c55e' : 'var(--foreground)'
+
+        return (
+          <div key={group.date} className="flex flex-col gap-0.5">
+            <div className="flex items-center justify-between px-3 pb-1">
+              <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
+                {formatDayLabel(group.date)}
+              </span>
+              <span className="text-xs font-bold" style={{ color: netColor }}>
+                {netStr}
+              </span>
+            </div>
+
+            <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+              {group.transactions.map(tx => (
+                <TxRow
+                  key={tx.id}
+                  tx={tx}
+                  swipedId={swipedTxId}
+                  onSwipe={onSwipe}
+                  onRecategorize={onRecategorize}
+                  onTap={onTap}
+                />
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/transactions/MovimientosToolbar.tsx
+++ b/components/transactions/MovimientosToolbar.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { Search, X, ChevronDown, Box } from 'lucide-react'
+import type { Account } from '@/types'
+import { TYPE_PILLS, type TypeFilter } from './useMovimientosFilters'
+
+interface MovimientosToolbarProps {
+  searchQuery: string
+  onSearchChange: (q: string) => void
+  typeFilter: TypeFilter
+  onTypeFilterChange: (t: TypeFilter) => void
+  selectedAccountIds: string[]
+  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
+  onOpenAccountFilter: () => void
+}
+
+export function MovimientosToolbar({
+  searchQuery,
+  onSearchChange,
+  typeFilter,
+  onTypeFilterChange,
+  selectedAccountIds,
+  accounts,
+  onOpenAccountFilter,
+}: MovimientosToolbarProps) {
+  const accountLabel =
+    selectedAccountIds.length === 0
+      ? 'Todas las cuentas'
+      : selectedAccountIds.length === 1
+        ? (accounts.find(a => a.id === selectedAccountIds[0])?.name ?? '1 cuenta')
+        : `${selectedAccountIds.length} cuentas`
+
+  return (
+    <>
+      {/* Search */}
+      <div
+        className="flex items-center gap-2 px-3.5 py-2.5 rounded-[14px] bg-muted"
+        style={{ border: '1px solid var(--border)' }}
+      >
+        <Search size={16} className="text-muted-foreground shrink-0" />
+        <input
+          type="text"
+          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+          placeholder="Buscar por descripción o categoría…"
+          value={searchQuery}
+          onChange={e => onSearchChange(e.target.value)}
+        />
+        {searchQuery && (
+          <button onClick={() => onSearchChange('')} className="text-muted-foreground hover:text-foreground shrink-0">
+            <X size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* Account filter button — full width */}
+      <button
+        className="w-full flex items-center justify-between px-3.5 py-2.5 rounded-[14px] transition-colors"
+        style={{
+          background: selectedAccountIds.length > 0 ? 'rgba(99,102,241,0.1)' : 'var(--muted)',
+          border: selectedAccountIds.length > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border)',
+        }}
+        onClick={onOpenAccountFilter}
+      >
+        <div className="flex items-center gap-2">
+          <Box size={14} style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }} strokeWidth={2} />
+          <span
+            className="text-sm font-semibold"
+            style={{ color: selectedAccountIds.length > 0 ? '#6366f1' : 'var(--muted-foreground)' }}
+          >
+            {accountLabel}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {selectedAccountIds.length > 0 && (
+            <span
+              className="rounded-full text-[10px] font-bold px-1.5 py-0.5 leading-none"
+              style={{ background: '#6366f1', color: 'white' }}
+            >
+              {selectedAccountIds.length}
+            </span>
+          )}
+          <ChevronDown size={12} className="text-muted-foreground" />
+        </div>
+      </button>
+
+      {/* Type pills */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-0.5">
+        {TYPE_PILLS.map(pill => (
+          <button
+            key={pill.key}
+            className="px-3.5 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0"
+            style={{
+              background: typeFilter === pill.key ? '#6366f1' : 'var(--muted)',
+              color: typeFilter === pill.key ? 'white' : 'var(--muted-foreground)',
+            }}
+            onClick={() => onTypeFilterChange(pill.key)}
+          >
+            {pill.label}
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/components/transactions/useMovimientosFilters.ts
+++ b/components/transactions/useMovimientosFilters.ts
@@ -1,0 +1,62 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CATEGORY_META } from '@/lib/theme'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+export type TypeFilter = 'todos' | 'ingresos' | 'gastos' | 'no-computable'
+
+export const TYPE_PILLS: { key: TypeFilter; label: string }[] = [
+  { key: 'todos', label: 'Todos' },
+  { key: 'ingresos', label: 'Ingresos' },
+  { key: 'gastos', label: 'Gastos' },
+  { key: 'no-computable', label: 'No Computable' },
+]
+
+export function useMovimientosFilters(transactions: TransactionWithAccount[]) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
+
+  const filtered = useMemo(() => {
+    let result = transactions
+
+    if (selectedAccountIds.length > 0) {
+      result = result.filter(tx => selectedAccountIds.includes(tx.account_id))
+    }
+
+    if (typeFilter !== 'todos') {
+      result = result.filter(tx => {
+        const catId = (tx.category_manual ?? tx.category) as CategoryId | null
+        if (catId === null) return false
+        const catType = CATEGORY_META[catId]?.type
+        if (typeFilter === 'ingresos')      return catType === 'income'
+        if (typeFilter === 'gastos')        return catType === 'expense'
+        if (typeFilter === 'no-computable') return catType === 'non_computable'
+        return true
+      })
+    }
+
+    const q = searchQuery.trim().toLowerCase()
+    if (q) {
+      result = result.filter(tx => {
+        if (tx.description.toLowerCase().includes(q)) return true
+        const cat = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
+        const label = CATEGORY_META[cat]?.label ?? ''
+        return label.toLowerCase().includes(q)
+      })
+    }
+
+    return result
+  }, [transactions, searchQuery, typeFilter, selectedAccountIds])
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    typeFilter,
+    setTypeFilter,
+    selectedAccountIds,
+    setSelectedAccountIds,
+    filtered,
+  }
+}

--- a/components/transactions/useTxMutations.ts
+++ b/components/transactions/useTxMutations.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import type { CategoryId, TransactionWithAccount } from '@/types'
+
+export function useTxMutations(initial: TransactionWithAccount[]) {
+  const [transactions, setTransactions] = useState(initial)
+
+  const addTx = useCallback((tx: TransactionWithAccount) => {
+    setTransactions(prev => [tx, ...prev])
+  }, [])
+
+  const deleteTx = useCallback(async (id: string) => {
+    setTransactions(prev => prev.filter(t => t.id !== id))
+    const res = await fetch(`/api/transactions/${id}`, { method: 'DELETE' })
+    if (!res.ok) {
+      setTransactions(initial)
+      console.error('[useTxMutations.deleteTx] Error eliminando:', await res.text())
+    }
+  }, [initial])
+
+  const recategorize = useCallback(async (id: string, category: CategoryId) => {
+    setTransactions(prev => prev.map(t =>
+      t.id === id ? { ...t, category_manual: category } : t
+    ))
+    const res = await fetch(`/api/transactions/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category_manual: category }),
+    })
+    if (!res.ok) {
+      setTransactions(initial)
+      console.error('[useTxMutations.recategorize] Error recategorizando:', await res.text())
+    }
+  }, [initial])
+
+  return { transactions, addTx, deleteTx, recategorize }
+}

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -1,0 +1,34 @@
+import type { TransactionWithAccount } from '@/types'
+
+export interface TxDayGroup {
+  date: string
+  transactions: TransactionWithAccount[]
+  net: number
+}
+
+export function groupTxByDate(txs: TransactionWithAccount[]): TxDayGroup[] {
+  const map = new Map<string, TxDayGroup>()
+  for (const tx of txs) {
+    const existing = map.get(tx.date)
+    if (existing) {
+      existing.transactions.push(tx)
+      existing.net += tx.amount
+    } else {
+      map.set(tx.date, { date: tx.date, transactions: [tx], net: tx.amount })
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => b.date.localeCompare(a.date))
+}
+
+const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
+export function formatDayLabel(dateStr: string): string {
+  const today = new Date().toISOString().slice(0, 10)
+  const yest = new Date()
+  yest.setDate(yest.getDate() - 1)
+  const yesterdayStr = yest.toISOString().slice(0, 10)
+  if (dateStr === today) return 'Hoy'
+  if (dateStr === yesterdayStr) return 'Ayer'
+  const [y, m, d] = dateStr.split('-').map(Number)
+  return `${d} ${MONTHS[m - 1]} ${y}`
+}


### PR DESCRIPTION
Cierra #65.

## Resumen

`MovimientosClient.tsx` baja de **317 → 109 líneas** y queda como orquestador puro. La descomposición evita estrenar `hooks/` en raíz: los hooks específicos de la pantalla quedan colocados junto al cliente; el agrupado por fecha se incorpora al patrón existente `lib/<dominio>.ts`.

## Cambios

| Archivo | Responsabilidad |
|---|---|
| `lib/transactions.ts` (nuevo) | `groupTxByDate` + `formatDayLabel` puras (sin React) |
| `components/transactions/useMovimientosFilters.ts` (nuevo) | Estado de filtros (search / type / cuentas) + `filtered` memoizado |
| `components/transactions/useTxMutations.ts` (nuevo) | `addTx` / `deleteTx` / `recategorize` con rollback optimista |
| `components/transactions/MovimientosToolbar.tsx` (nuevo) | Search + botón filtro cuenta + pills de tipo |
| `components/transactions/MovimientosList.tsx` (nuevo) | Lista agrupada por día con cabeceras y neto |
| `components/transactions/AddTxFab.tsx` (nuevo) | Botón flotante de añadir |
| `components/transactions/MovimientosClient.tsx` | Solo composición de hooks + modales |

**Sin cambio funcional ni visual.** API pública (`MovimientosClientProps`) intacta; `app/(app)/movimientos/page.tsx` no se toca.

## Test plan

- [x] `pnpm build` pasa
- [ ] `/movimientos` renderiza idéntico (toolbar, pills, lista agrupada con "Hoy"/"Ayer"/fecha + neto)
- [ ] Filtros: búsqueda (descripción y categoría), pill de tipo, cuenta (1 / varias / todas) y combinación
- [ ] Tap en tx → abre `TxModal`
- [ ] Swipe + recategorizar → `CategoryPicker` apilado; al elegir, la fila se actualiza optimistamente y persiste tras refrescar
- [ ] Borrar desde `TxModal` → desaparece y persiste tras refrescar
- [ ] FAB → `AddTxModal`; al guardar, nueva tx aparece en la lista
- [ ] Empty state ("No hay movimientos con estos filtros")

🤖 Generated with [Claude Code](https://claude.com/claude-code)