### PR TITLE
fix(movimientos): pulir UX de modales (descripción completa, buscador, badge EDITADA)

### DIFF
--- a/components/transactions/CategoryPicker.tsx
+++ b/components/transactions/CategoryPicker.tsx
@@ -9,7 +9,7 @@ import type { CategoryId, CategoryType, TransactionWithAccount } from '@/types'
 const norm = (s: string) => s.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '')
 
 interface CategoryPickerProps {
-  tx: TransactionWithAccount
+  tx: TransactionWithAccount | null
   open: boolean
   onOpenChange: (open: boolean) => void
   onSelect: (txId: string, category: CategoryId) => void
@@ -30,9 +30,22 @@ function initialTab(tx: TransactionWithAccount): CategoryType {
 }
 
 export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPickerProps) {
-  const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
-  const [activeType, setActiveType] = useState<CategoryType>(() => initialTab(tx))
+  const [cachedTx, setCachedTx] = useState<TransactionWithAccount | null>(tx)
+  const [activeType, setActiveType] = useState<CategoryType>(() =>
+    tx ? initialTab(tx) : 'expense'
+  )
   const [query, setQuery] = useState('')
+
+  if (tx && tx !== cachedTx) {
+    setCachedTx(tx)
+    setActiveType(initialTab(tx))
+    setQuery('')
+  }
+
+  const renderTx = tx ?? cachedTx
+  if (!renderTx) return null
+
+  const effectiveCategory = (renderTx.category_manual ?? renderTx.category ?? 'other') as CategoryId
 
   const visibleCategories = ENTRIES.filter(([, meta]) => meta.type === activeType)
   const q = norm(query.trim())
@@ -46,12 +59,12 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
         side="bottom"
         showCloseButton={false}
         className="mx-auto flex w-full max-w-105 flex-col rounded-t-[28px] bg-popover px-5 pt-5 pb-[max(env(safe-area-inset-bottom),2.5rem)]"
-        style={{ maxHeight: '82dvh' }}
+        style={{ height: '82dvh' }}
       >
         <SheetTitle className="sr-only">Cambiar categoría</SheetTitle>
         <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-border" />
         <p className="text-base font-bold text-foreground mb-1">Cambiar categoría</p>
-        <p className="text-xs leading-relaxed text-muted-foreground mb-4 wrap-break-word">{tx.description}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground mb-4 wrap-break-word">{renderTx.description}</p>
 
         {/* Selector de tipo */}
         <div
@@ -113,7 +126,7 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
               return (
                 <button
                   key={id}
-                  onClick={() => { onSelect(tx.id, id); onOpenChange(false) }}
+                  onClick={() => { onSelect(renderTx.id, id); onOpenChange(false) }}
                   style={{
                     padding: '12px 4px',
                     borderRadius: 14,

--- a/components/transactions/CategoryPicker.tsx
+++ b/components/transactions/CategoryPicker.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { useState } from 'react'
+import { Search, X } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { CATEGORY_META } from '@/lib/theme'
 import type { CategoryId, CategoryType, TransactionWithAccount } from '@/types'
+
+const norm = (s: string) => s.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '')
 
 interface CategoryPickerProps {
   tx: TransactionWithAccount
@@ -29,8 +32,13 @@ function initialTab(tx: TransactionWithAccount): CategoryType {
 export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPickerProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category ?? 'other') as CategoryId
   const [activeType, setActiveType] = useState<CategoryType>(() => initialTab(tx))
+  const [query, setQuery] = useState('')
 
   const visibleCategories = ENTRIES.filter(([, meta]) => meta.type === activeType)
+  const q = norm(query.trim())
+  const filteredCategories = q
+    ? visibleCategories.filter(([, meta]) => norm(meta.label).includes(q))
+    : visibleCategories
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -43,7 +51,7 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
         <SheetTitle className="sr-only">Cambiar categoría</SheetTitle>
         <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-border" />
         <p className="text-base font-bold text-foreground mb-1">Cambiar categoría</p>
-        <p className="text-xs text-muted-foreground mb-4 truncate">{tx.description}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground mb-4 wrap-break-word">{tx.description}</p>
 
         {/* Selector de tipo */}
         <div
@@ -53,7 +61,7 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
           {(Object.keys(TYPE_LABELS) as CategoryType[]).map(type => (
             <button
               key={type}
-              onClick={() => setActiveType(type)}
+              onClick={() => { setActiveType(type); setQuery('') }}
               style={{
                 flex: 1,
                 padding: '7px 4px',
@@ -73,10 +81,33 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
           ))}
         </div>
 
+        {/* Buscador de categorías */}
+        <div
+          className="flex items-center gap-2 px-3.5 py-2.5 rounded-[14px] bg-muted mb-3"
+          style={{ border: '1px solid var(--border)' }}
+        >
+          <Search size={16} className="text-muted-foreground shrink-0" />
+          <input
+            type="text"
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+            placeholder="Buscar categoría…"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+          {query && (
+            <button onClick={() => setQuery('')} className="text-muted-foreground hover:text-foreground shrink-0">
+              <X size={14} />
+            </button>
+          )}
+        </div>
+
         {/* Grid de categorías scrollable */}
         <div style={{ overflowY: 'auto', flex: 1 }}>
+          {filteredCategories.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-6">Sin resultados</p>
+          ) : (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
-            {visibleCategories.map(([id, meta]) => {
+            {filteredCategories.map(([id, meta]) => {
               const Icon = meta.Icon
               const isCurrent = effectiveCategory === id
               return (
@@ -110,6 +141,7 @@ export function CategoryPicker({ tx, open, onOpenChange, onSelect }: CategoryPic
               )
             })}
           </div>
+          )}
         </div>
       </SheetContent>
     </Sheet>

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -77,24 +77,20 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
         onSelectionChange={filters.setSelectedAccountIds}
       />
 
-      {selectedTx && (
-        <TxModal
-          tx={selectedTx}
-          open
-          onOpenChange={o => { if (!o) setSelectedTxId(null) }}
-          onRecategorize={handleRecategorize}
-          onDelete={handleDelete}
-        />
-      )}
+      <TxModal
+        tx={selectedTx}
+        open={!!selectedTx}
+        onOpenChange={o => { if (!o) setSelectedTxId(null) }}
+        onRecategorize={handleRecategorize}
+        onDelete={handleDelete}
+      />
 
-      {catPickerTx && (
-        <CategoryPicker
-          tx={catPickerTx}
-          open
-          onOpenChange={o => { if (!o) setCatPickerTx(null) }}
-          onSelect={recategorize}
-        />
-      )}
+      <CategoryPicker
+        tx={catPickerTx}
+        open={!!catPickerTx}
+        onOpenChange={o => { if (!o) setCatPickerTx(null) }}
+        onSelect={recategorize}
+      />
 
       <AddTxModal
         open={showAddModal}

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -8,7 +8,7 @@ import { fmt } from '@/lib/formatting'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
 interface TxModalProps {
-  tx: TransactionWithAccount
+  tx: TransactionWithAccount | null
   open: boolean
   onOpenChange: (open: boolean) => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -71,14 +71,21 @@ function FieldRow({ label, icon, children, onClick, chevron }: FieldRowProps) {
 }
 
 export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: TxModalProps) {
+  const [cachedTx, setCachedTx] = useState<TransactionWithAccount | null>(tx)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  if (tx && tx !== cachedTx) {
+    setCachedTx(tx)
+    setConfirmDelete(false)
+  }
+  const renderTx = tx ?? cachedTx
+  if (!renderTx) return null
 
-  const effectiveCategory = (tx.category_manual ?? tx.category) as CategoryId | null
+  const effectiveCategory = (renderTx.category_manual ?? renderTx.category) as CategoryId | null
   const meta = effectiveCategory ? (CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other) : SIN_CATEGORIA
   const Icon = meta.Icon
 
   const dateStr = (() => {
-    const [y, m, d] = tx.date.split('-').map(Number)
+    const [y, m, d] = renderTx.date.split('-').map(Number)
     return new Date(y, m - 1, d).toLocaleDateString('es-ES', {
       weekday: 'long',
       day: 'numeric',
@@ -87,9 +94,9 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
     })
   })()
 
-  const absAmount = fmt(Math.abs(tx.amount), 2)
-  const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
-  const amountColor = tx.amount > 0 ? '#22c55e' : 'var(--foreground)'
+  const absAmount = fmt(Math.abs(renderTx.amount), 2)
+  const amountStr = (renderTx.amount > 0 ? '+' : '-') + absAmount + ' €'
+  const amountColor = renderTx.amount > 0 ? '#22c55e' : 'var(--foreground)'
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -98,7 +105,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
         showCloseButton={false}
         className="mx-auto w-full max-w-105 rounded-t-[28px] bg-popover px-5 pt-5 pb-[max(env(safe-area-inset-bottom),2.5rem)]"
       >
-        <SheetTitle className="sr-only">{tx.description}</SheetTitle>
+        <SheetTitle className="sr-only">{renderTx.description}</SheetTitle>
         <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-border" />
 
         {/* Importe prominente */}
@@ -115,7 +122,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
           }}>
             <Icon size={26} style={{ color: meta.color }} strokeWidth={2} />
           </div>
-          <div className="text-sm font-bold text-foreground mb-1 line-clamp-3 px-4">{tx.description}</div>
+          <div className="text-sm font-bold text-foreground mb-1 line-clamp-3 px-4">{renderTx.description}</div>
           <div style={{
             fontSize: 44,
             fontWeight: 800,
@@ -140,13 +147,13 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
             label="Cuenta"
             icon={<CreditCard size={16} className="text-muted-foreground" />}
           >
-            <span className="text-sm font-semibold text-foreground">{tx.account?.name ?? '—'}</span>
+            <span className="text-sm font-semibold text-foreground">{renderTx.account?.name ?? '—'}</span>
           </FieldRow>
 
           <FieldRow
             label="Categoría"
             chevron
-            onClick={() => onRecategorize(tx)}
+            onClick={() => onRecategorize(renderTx)}
             icon={
               <div style={{
                 width: 34,
@@ -166,7 +173,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
         </div>
 
         {/* Eliminar */}
-        {tx.source === 'manual' ? (
+        {renderTx.source === 'manual' ? (
           !confirmDelete ? (
             <button
               onClick={() => setConfirmDelete(true)}
@@ -212,7 +219,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
                   Cancelar
                 </button>
                 <button
-                  onClick={() => onDelete(tx.id)}
+                  onClick={() => onDelete(renderTx.id)}
                   style={{
                     flex: 1,
                     background: '#ef4444',

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -115,7 +115,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
           }}>
             <Icon size={26} style={{ color: meta.color }} strokeWidth={2} />
           </div>
-          <div className="text-sm font-bold text-foreground mb-1 truncate px-4">{tx.description}</div>
+          <div className="text-sm font-bold text-foreground mb-1 line-clamp-3 px-4">{tx.description}</div>
           <div style={{
             fontSize: 44,
             fontWeight: 800,
@@ -161,17 +161,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
               </div>
             }
           >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span className="text-sm font-semibold text-foreground">{meta.label}</span>
-              {tx.category_manual && (
-                <span
-                  className="rounded-full text-[9px] font-bold px-1.5 py-0.5 leading-none shrink-0"
-                  style={{ background: '#6366f1', color: 'white' }}
-                >
-                  EDITADA
-                </span>
-              )}
-            </div>
+            <span className="text-sm font-semibold text-foreground">{meta.label}</span>
           </FieldRow>
         </div>
 

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -134,17 +134,7 @@ export function TxRow({ tx, swipedId, onSwipe, onRecategorize, onTap }: TxRowPro
           </div>
 
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5 min-w-0">
-              <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
-              {tx.category_manual && (
-                <span
-                  className="rounded-full text-[9px] font-bold px-1.5 py-0.5 leading-none shrink-0"
-                  style={{ background: '#6366f1', color: 'white' }}
-                >
-                  EDITADA
-                </span>
-              )}
-            </div>
+            <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
             <div className="flex items-center gap-1 mt-0.5">
               <span className="rounded-full shrink-0" style={{ width: 7, height: 7, background: meta.color }} />
               <span className="text-[11px] text-muted-foreground truncate">{meta.label}</span>


### PR DESCRIPTION
## Resumen

Cierra #73. Tres ajustes de UX en los modales de Movimientos para hacer más fluido el flujo de "ver tx y asignar categoría":

- **TxModal**: descripción a `line-clamp-3` (antes `truncate`) → se ven completas las descripciones largas.
- **TxModal**: eliminado el badge "EDITADA" del campo Categoría — no aportaba al usuario.
- **CategoryPicker**: descripción sin recorte (wrap libre con `wrap-break-word` + `leading-relaxed`) — el `line-clamp` recortaba descendientes en `text-xs` y dejaba la última línea visualmente cortada.
- **CategoryPicker**: añadido buscador con icono `Search` y botón `X` para limpiar, filtrando `meta.label` dentro del tab activo, insensible a case y acentos (`String.normalize('NFD')`). Reset del query al cambiar de tab. Empty state "Sin resultados".

## Test plan

- [x] `pnpm build` pasa.
- [x] Descripción larga en `TxModal` se ve en hasta 3 líneas centradas.
- [x] Descripción larga en `CategoryPicker` se ve completa sin recorte vertical.
- [x] Badge "EDITADA" ya no aparece en `TxModal`.
- [x] Buscar "super" en Gastos deja sólo "Supermercado".
- [x] Cambiar de tab limpia el query.
- [x] Botón X limpia el texto y restaura el grid.
- [x] Sin regresión en recategorizar ni eliminar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)