### PR TITLE
chore(lint): resolver todos los warnings/errores de ESLint

### DIFF
--- a/components/analytics/DonutChart.tsx
+++ b/components/analytics/DonutChart.tsx
@@ -34,10 +34,8 @@ const degToRad = (d: number) => (d * Math.PI) / 180
 export default function DonutChart({ items, selectedIdx, accentColor, onSelect }: DonutChartProps) {
   const total = items.reduce((s, i) => s + i.amount, 0)
 
-  let cumPct = 0
   const segments = items.map((item, i) => {
-    const startPct = cumPct
-    cumPct += item.pct
+    const startPct = items.slice(0, i).reduce((s, it) => s + it.pct, 0)
     const midDeg = -90 + (startPct + item.pct / 2) * 3.6
     const offset = CIRC - (startPct / 100) * CIRC
     const dash = (item.pct / 100) * CIRC

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
 import { Moon, Sun } from 'lucide-react'
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => setMounted(true), [])
-
-  const isDark = mounted && resolvedTheme === 'dark'
+  // next-themes devuelve `resolvedTheme === undefined` durante SSR / pre-hidratación.
+  // Lo usamos como flag de "mounted" sin necesidad de useEffect+useState.
+  const mounted = resolvedTheme !== undefined
+  const isDark = resolvedTheme === 'dark'
 
   return (
     <div className="flex w-full items-center justify-between rounded-xl px-3 py-3 text-sm font-medium text-foreground">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,10 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Node scripts ejecutados fuera del bundle de Next.
     "scripts/**",
+    // Prototipo visual de referencia (no producción) — ver CLAUDE.md.
+    "docs/**",
+    // Templates de skills de Claude Code (no se compilan con la app).
+    ".agents/**",
   ]),
 ]);
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,6 +1,6 @@
 import {
-  ShoppingCart, UtensilsCrossed, Car, Home, Gamepad2, ShoppingBag,
-  HeartPulse, TrendingUp, MoreHorizontal, CircleHelp, Fuel, ParkingCircle, Wrench,
+  ShoppingCart, UtensilsCrossed, Home, Gamepad2, ShoppingBag,
+  TrendingUp, MoreHorizontal, CircleHelp, Fuel, ParkingCircle, Wrench,
   Building2, Users, Zap, Flame, Droplets, Wifi, Shirt, Laptop,
   Stethoscope, Pill, Dumbbell, Repeat2, Plane, BookOpen, Shield,
   Sparkles, Gift, Heart, Users2, Receipt, CreditCard, Banknote,


### PR DESCRIPTION
`pnpm lint` pasaba con 12 errores y 17 warnings. Esta PR los deja todos a cero.

## Summary

- **`eslint.config.mjs`** — añadidos a `globalIgnores`:
  - `docs/**`: prototipo visual de referencia (no se compila con la app — ver `CLAUDE.md`). Concentraba la mayoría del ruido (`react-hooks/static-components`, etc. en `finanzas-app.jsx`).
  - `.agents/**`: templates de skills de Claude Code, fuera del bundle de Next.
- **`lib/theme.ts`** — quitados imports no usados (`Car`, `HeartPulse`).
- **`components/analytics/DonutChart.tsx`** — `let cumPct` reasignado dentro de `.map()` sustituido por cálculo funcional `items.slice(0, i).reduce(...)`. Mismo resultado visual, sin reasignación post-render.
- **`components/theme-toggle.tsx`** — eliminado el patrón `useState(false) + useEffect(() => setMounted(true), [])`. `next-themes` ya expone `resolvedTheme === undefined` durante SSR/pre-hidratación, así que sirve como flag de "mounted" sin tocar React state desde un effect.

## Test plan

- [x] `pnpm lint` → ✅ 0 problemas
- [x] `pnpm build` → ✅ compila sin errores
- [ ] Verificar manualmente que el toggle de tema sigue funcionando sin flash de hidratación (cambio sutil de patrón)
- [ ] Verificar que el donut chart sigue pintando los segmentos en las mismas posiciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)