### PR TITLE
docs(claude.md): exigir pnpm test/lint/build antes de abrir PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ gh project field-list 2 --owner MrClit --format json  # → field-id y option-id
 | Al aceptar el plan e iniciar implementación | Si el plan difiere significativamente de la descripción original de la issue, actualizarla con `mcp__github__update_issue` antes de empezar |
 | Al aceptar el plan e iniciar implementación | Mover a **In progress** |
 | Al aceptar el plan e iniciar implementación | Crear rama `feature/<issue-slug>` o `fix/<issue-slug>` desde `develop` y trabajar en ella |
+| Antes de abrir PR | Ejecutar **siempre** `pnpm test`, `pnpm lint` y `pnpm build`. Si alguno falla, arreglarlo antes de pushear. No usar `--no-verify` ni saltarse hooks. |
 | Al terminar implementación y validaciones | Hacer push de la rama y abrir PR hacia `develop` con `mcp__github__create_pull_request` |
 | Al terminar implementación y validaciones | Mover a **Review** |
 | Al cerrar la issue | Mover a **Done** + comentar resumen con `mcp__github__add_issue_comment` |


### PR DESCRIPTION
## Summary

Añade un paso explícito al flujo obligatorio de issues en `CLAUDE.md`: ejecutar `pnpm test`, `pnpm lint` y `pnpm build` antes de pushear y abrir PR.

Motivación: ya nos pasó en #61 que el lint del repo arrastraba 12 errores no relacionados; tenerlo en el flujo lo deja claro como pre-requisito, no como afterthought.

```diff
 | Al aceptar el plan e iniciar implementación | Crear rama `feature/<issue-slug>` ...
+| Antes de abrir PR | Ejecutar **siempre** `pnpm test`, `pnpm lint` y `pnpm build`. Si alguno falla, arreglarlo antes de pushear. No usar `--no-verify` ni saltarse hooks.
 | Al terminar implementación y validaciones | Hacer push de la rama ...
```

## Test plan

- [x] Cambio de doc puro, sin código
- [x] `pnpm test` / `pnpm lint` / `pnpm build` siguen verdes (no aplica, no hay cambio de código — comprobado igualmente en local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)