### PR TITLE
feat(sync): banners de estado, toast de errores y cooldown de sync

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { AppHeader } from '@/components/app-header'
 import { BottomNav } from '@/components/bottom-nav'
+import { SyncStatusProvider } from '@/components/sync/SyncStatusProvider'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient()
@@ -10,11 +11,13 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="relative mx-auto w-full max-w-105 min-h-screen overflow-clip bg-background">
-      <AppHeader email={user.email ?? ''} />
-      <main className="pb-22.5 animate-fade-in">
-        {children}
-      </main>
-      <BottomNav />
+      <SyncStatusProvider>
+        <AppHeader email={user.email ?? ''} />
+        <main className="pb-22.5 animate-fade-in">
+          {children}
+        </main>
+        <BottomNav />
+      </SyncStatusProvider>
     </div>
   )
 }

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
+import { SYNC_COOLDOWN_MS } from '@/lib/sync'
 
 export async function POST() {
   // Auth: verify user via cookie client
@@ -40,6 +41,21 @@ export async function POST() {
 
   if (!accounts || accounts.length === 0) {
     return NextResponse.json({ synced: 0, accounts: 0 })
+  }
+
+  // Rate limit: EB permite 4 syncs/día. Se exige un cooldown de 6h desde la
+  // última sincronización (manual o cron — ambas escriben last_synced).
+  const lastSyncedMs = accounts
+    .map(a => (a.last_synced ? new Date(a.last_synced as string).getTime() : 0))
+    .filter(t => t > 0)
+  if (lastSyncedMs.length > 0) {
+    const availableAt = Math.max(...lastSyncedMs) + SYNC_COOLDOWN_MS
+    if (availableAt > Date.now()) {
+      return NextResponse.json(
+        { error: 'cooldown', availableAt: new Date(availableAt).toISOString() },
+        { status: 429 }
+      )
+    }
   }
 
   let totalSynced = 0

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,5 +1,6 @@
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
+import { SyncButton } from './SyncButton'
 import type { Account } from '@/types'
 
 function getSyncStatus(iso: string | null): { label: string; color: string; Icon: typeof Check } {
@@ -79,9 +80,14 @@ export function AccountCard({ account }: { account: Account }) {
         </div>
       </div>
 
-      <div className="mt-3.5 pt-3.5 border-t border-border text-[11px] text-muted-foreground flex items-center gap-1.5">
-        <SyncIcon className="size-3 shrink-0" style={{ color: syncColor }} />
-        <span style={{ color: syncColor }}>{syncLabel}</span>
+      <div className="mt-3.5 pt-3.5 border-t border-border flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <SyncIcon className="size-3 shrink-0" style={{ color: syncColor }} />
+          <span style={{ color: syncColor }}>{syncLabel}</span>
+        </div>
+        {account.source === 'enablebanking' && (
+          <SyncButton lastSynced={account.last_synced} />
+        )}
       </div>
     </div>
   )

--- a/components/accounts/SyncButton.tsx
+++ b/components/accounts/SyncButton.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { RefreshCw } from 'lucide-react'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
+import { syncAvailableAt } from '@/lib/sync'
+
+/**
+ * Botón de sincronización manual para la card de cuenta.
+ * El endpoint /api/sync/enablebanking recorre todas las cuentas Enable Banking,
+ * así que un único botón sincroniza toda la conexión.
+ * Se deshabilita durante el cooldown de 6h (rate limit de EB, ver lib/sync.ts).
+ */
+export function SyncButton({ lastSynced }: { lastSynced: string | null }) {
+  const { runSync, isSyncing, isOffline } = useSyncStatus()
+  // El contador del cooldown se refresca cada 30s mientras el botón está montado.
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000)
+    return () => clearInterval(id)
+  }, [])
+
+  const availableAt = syncAvailableAt(lastSynced)
+  const inCooldown = availableAt !== null && availableAt > now
+
+  const label = isSyncing
+    ? 'Sincronizando…'
+    : inCooldown
+      ? `Disponible en ${formatRemaining(availableAt - now)}`
+      : 'Sincronizar'
+
+  return (
+    <button
+      type="button"
+      onClick={() => runSync()}
+      disabled={isSyncing || isOffline || inCooldown}
+      className="flex shrink-0 items-center gap-1.5 rounded-[10px] px-3 py-1.5 text-[11px] font-semibold transition-opacity disabled:opacity-40"
+      style={{ background: '#6366f115', color: '#6366f1' }}
+    >
+      <RefreshCw className={`size-3 ${isSyncing ? 'animate-spin' : ''}`} />
+      {label}
+    </button>
+  )
+}
+
+function formatRemaining(ms: number): string {
+  const totalMin = Math.ceil(ms / 60_000)
+  if (totalMin >= 60) {
+    const h = Math.floor(totalMin / 60)
+    const m = totalMin % 60
+    return m > 0 ? `${h}h ${m}min` : `${h}h`
+  }
+  return `${totalMin}min`
+}

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation'
 import { Bell } from 'lucide-react'
 import { UserMenuTrigger } from './dashboard/UserMenuTrigger'
+import { StatusBanner } from './sync/StatusBanner'
 
 type Props = { email: string }
 
@@ -23,6 +24,7 @@ export function AppHeader({ email }: Props) {
           <Bell className="size-4.5" strokeWidth={2} />
         </button>
       </div>
+      <StatusBanner />
     </header>
   )
 }

--- a/components/sync/StatusBanner.tsx
+++ b/components/sync/StatusBanner.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { AlertTriangle, RefreshCw, WifiOff } from 'lucide-react'
+import { useSyncStatus } from './SyncStatusProvider'
+
+/**
+ * Banner superior de estado de sync/conexión. Solo se muestra uno a la vez,
+ * con precedencia: offline > error de sync > sincronizando (spec §8.1/§8.2).
+ * Se renderiza dentro del <header> sticky, justo debajo de la barra global.
+ */
+export function StatusBanner() {
+  const { isOffline, isSyncing, syncError, runSync } = useSyncStatus()
+
+  if (isOffline) {
+    return (
+      <Banner color="#64748b">
+        <WifiOff className="size-3.5 shrink-0" />
+        <span>Sin conexión. Mostrando datos guardados</span>
+      </Banner>
+    )
+  }
+
+  if (syncError) {
+    return (
+      <Banner color="#f59e0b">
+        <AlertTriangle className="size-3.5 shrink-0" />
+        <span>No pudimos sincronizar.</span>
+        <button
+          type="button"
+          onClick={() => runSync()}
+          className="ml-auto shrink-0 font-bold underline underline-offset-2"
+        >
+          Reintentar →
+        </button>
+      </Banner>
+    )
+  }
+
+  if (isSyncing) {
+    return (
+      <Banner color="#3b82f6">
+        <RefreshCw className="size-3.5 shrink-0 animate-spin" />
+        <span>Sincronizando…</span>
+      </Banner>
+    )
+  }
+
+  return null
+}
+
+function Banner({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 px-4 py-2 text-[13px] font-medium animate-fade-in"
+      style={{ background: color + '1f', color, borderTop: `1px solid ${color}26` }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/sync/SyncStatusProvider.tsx
+++ b/components/sync/SyncStatusProvider.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useRouter } from 'next/navigation'
+import { Toast } from '@/components/ui/toast'
+
+interface ToastState {
+  message: string
+  onRetry?: () => void
+}
+
+interface SyncStatusValue {
+  /** Sin conexión a internet (navigator.onLine). */
+  isOffline: boolean
+  /** Hay una sincronización manual en curso. */
+  isSyncing: boolean
+  /** La última sincronización falló o superó el timeout. */
+  syncError: boolean
+  /** Lanza una sincronización manual contra /api/sync/enablebanking. */
+  runSync: () => Promise<void>
+  /** Muestra el toast genérico de error con un Reintentar opcional. */
+  showToast: (message: string, onRetry?: () => void) => void
+}
+
+const SyncStatusContext = createContext<SyncStatusValue | null>(null)
+
+/** Timeout de la sincronización manual (spec §8.2). */
+const SYNC_TIMEOUT_MS = 10_000
+
+export function SyncStatusProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const [isOffline, setIsOffline] = useState(false)
+  const [isSyncing, setIsSyncing] = useState(false)
+  const [syncError, setSyncError] = useState(false)
+  const [toast, setToast] = useState<ToastState | null>(null)
+  // Evita relanzar una sync mientras otra está en curso (sin esperar al re-render).
+  const syncingRef = useRef(false)
+
+  // Detección de conexión. El estado inicial es false en SSR y se corrige aquí
+  // tras el montaje para no provocar un mismatch de hidratación.
+  useEffect(() => {
+    const update = () => setIsOffline(!navigator.onLine)
+    update()
+    window.addEventListener('online', update)
+    window.addEventListener('offline', update)
+    return () => {
+      window.removeEventListener('online', update)
+      window.removeEventListener('offline', update)
+    }
+  }, [])
+
+  const showToast = useCallback((message: string, onRetry?: () => void) => {
+    setToast({ message, onRetry })
+  }, [])
+
+  const dismissToast = useCallback(() => setToast(null), [])
+
+  const runSync = useCallback(async () => {
+    if (syncingRef.current) return
+    syncingRef.current = true
+    setIsSyncing(true)
+    setSyncError(false)
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), SYNC_TIMEOUT_MS)
+
+    try {
+      const res = await fetch('/api/sync/enablebanking', {
+        method: 'POST',
+        signal: controller.signal,
+      })
+      // 429 = cooldown: no es un fallo de sync; aviso suave sin banner ámbar.
+      if (res.status === 429) {
+        showToast('Has alcanzado el límite de sincronizaciones. Inténtalo más tarde.')
+        return
+      }
+      if (!res.ok) throw new Error(`sync failed: ${res.status}`)
+      // Refresca los Server Components para traer saldos y last_synced nuevos.
+      router.refresh()
+    } catch (err) {
+      console.error('[SyncStatusProvider.runSync]', err)
+      setSyncError(true)
+    } finally {
+      clearTimeout(timeout)
+      syncingRef.current = false
+      setIsSyncing(false)
+    }
+  }, [router, showToast])
+
+  const value = useMemo<SyncStatusValue>(
+    () => ({ isOffline, isSyncing, syncError, runSync, showToast }),
+    [isOffline, isSyncing, syncError, runSync, showToast]
+  )
+
+  return (
+    <SyncStatusContext.Provider value={value}>
+      {children}
+      {toast && (
+        <Toast message={toast.message} onRetry={toast.onRetry} onDismiss={dismissToast} />
+      )}
+    </SyncStatusContext.Provider>
+  )
+}
+
+export function useSyncStatus(): SyncStatusValue {
+  const ctx = useContext(SyncStatusContext)
+  if (!ctx) throw new Error('useSyncStatus debe usarse dentro de <SyncStatusProvider>')
+  return ctx
+}

--- a/components/transactions/AddTxModal.tsx
+++ b/components/transactions/AddTxModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { FileText, Calendar, CreditCard } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
 import { CATEGORY_META } from '@/lib/theme'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
@@ -79,6 +80,7 @@ export function AddTxModal({ open, onOpenChange, manualAccountId, onSave }: AddT
   const [category, setCategory] = useState<CategoryId>('other')
   const [showCatGrid, setShowCatGrid] = useState(false)
   const [saving, setSaving] = useState(false)
+  const { showToast } = useSyncStatus()
 
   const accentColor = type === 'gasto' ? EXPENSE_COLOR : INCOME_COLOR
   const parsedAmount = parseFloat(amount)
@@ -113,6 +115,7 @@ export function AddTxModal({ open, onOpenChange, manualAccountId, onSave }: AddT
       onOpenChange(false)
     } catch (err) {
       console.error('[AddTxModal] Error guardando:', err)
+      showToast('No se pudo guardar el movimiento', handleSave)
     } finally {
       setSaving(false)
     }

--- a/components/transactions/useTxMutations.ts
+++ b/components/transactions/useTxMutations.ts
@@ -1,38 +1,53 @@
 'use client'
 
 import { useCallback, useState } from 'react'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
 export function useTxMutations(initial: TransactionWithAccount[]) {
   const [transactions, setTransactions] = useState(initial)
+  const { showToast } = useSyncStatus()
 
   const addTx = useCallback((tx: TransactionWithAccount) => {
     setTransactions(prev => [tx, ...prev])
   }, [])
 
-  const deleteTx = useCallback(async (id: string) => {
-    setTransactions(prev => prev.filter(t => t.id !== id))
-    const res = await fetch(`/api/transactions/${id}`, { method: 'DELETE' })
-    if (!res.ok) {
-      setTransactions(initial)
-      console.error('[useTxMutations.deleteTx] Error eliminando:', await res.text())
-    }
-  }, [initial])
+  // El callback de Reintentar del toast re-ejecuta la propia operación. Se usa
+  // una función con nombre (`attempt`) para poder referenciarla recursivamente
+  // sin acceder a la variable del useCallback antes de declararla.
+  const deleteTx = useCallback((id: string) => {
+    return (async function attempt() {
+      setTransactions(prev => prev.filter(t => t.id !== id))
+      try {
+        const res = await fetch(`/api/transactions/${id}`, { method: 'DELETE' })
+        if (!res.ok) throw new Error(await res.text())
+      } catch (err) {
+        setTransactions(initial)
+        console.error('[useTxMutations.deleteTx] Error eliminando:', err)
+        showToast('No se pudo eliminar el movimiento', () => { void attempt() })
+      }
+    })()
+  }, [initial, showToast])
 
-  const recategorize = useCallback(async (id: string, category: CategoryId) => {
-    setTransactions(prev => prev.map(t =>
-      t.id === id ? { ...t, category_manual: category } : t
-    ))
-    const res = await fetch(`/api/transactions/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ category_manual: category }),
-    })
-    if (!res.ok) {
-      setTransactions(initial)
-      console.error('[useTxMutations.recategorize] Error recategorizando:', await res.text())
-    }
-  }, [initial])
+  const recategorize = useCallback((id: string, category: CategoryId) => {
+    return (async function attempt() {
+      setTransactions(prev => prev.map(t =>
+        t.id === id ? { ...t, category_manual: category } : t
+      ))
+      try {
+        const res = await fetch(`/api/transactions/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ category_manual: category }),
+        })
+        if (!res.ok) throw new Error(await res.text())
+      } catch (err) {
+        setTransactions(initial)
+        console.error('[useTxMutations.recategorize] Error recategorizando:', err)
+        showToast('No se pudo recategorizar el movimiento', () => { void attempt() })
+      }
+    })()
+  }, [initial, showToast])
 
   return { transactions, addTx, deleteTx, recategorize }
 }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { X } from 'lucide-react'
+
+interface ToastProps {
+  message: string
+  onRetry?: () => void
+  onDismiss: () => void
+}
+
+/**
+ * Toast genérico y persistente para errores inesperados.
+ * No se auto-cierra: el usuario lo descarta con la X o pulsando Reintentar.
+ * El estado vive en SyncStatusProvider; este componente es presentacional.
+ */
+export function Toast({ message, onRetry, onDismiss }: ToastProps) {
+  return (
+    <div
+      role="alert"
+      className="fixed left-1/2 z-[120] w-full max-w-105 -translate-x-1/2 px-4 animate-fade-in"
+      style={{ bottom: 'calc(max(env(safe-area-inset-bottom), 1.5rem) + 84px)' }}
+    >
+      <div className="flex items-center gap-3 rounded-2xl bg-foreground px-4 py-3 text-background shadow-lg">
+        <span className="flex-1 text-sm font-medium">{message}</span>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={() => {
+              onRetry()
+              onDismiss()
+            }}
+            className="shrink-0 text-sm font-bold underline underline-offset-2"
+          >
+            Reintentar
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label="Cerrar"
+          onClick={onDismiss}
+          className="grid size-5 shrink-0 place-items-center opacity-60"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -1,0 +1,21 @@
+/**
+ * Cooldown mínimo entre sincronizaciones con Enable Banking.
+ *
+ * EB permite 4 syncs/día por consentimiento. Con un cooldown de 6h entre
+ * sincronizaciones (manual o cron, ambas actualizan `accounts.last_synced`)
+ * no se puede superar ese límite. Se enforza en el servidor; el cliente lo
+ * usa solo para mostrar el estado del botón.
+ */
+export const SYNC_COOLDOWN_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Devuelve el instante (ms epoch) en que el sync volverá a estar disponible,
+ * o `null` si ya se puede sincronizar.
+ */
+export function syncAvailableAt(lastSynced: string | number | null): number | null {
+  if (!lastSynced) return null
+  const last = typeof lastSynced === 'number' ? lastSynced : new Date(lastSynced).getTime()
+  if (Number.isNaN(last)) return null
+  const availableAt = last + SYNC_COOLDOWN_MS
+  return availableAt > Date.now() ? availableAt : null
+}


### PR DESCRIPTION
Closes #77

## Resumen

Sistema de comunicación de estado de sync/conexión (spec §8.1/§8.2). La app ya sincronizaba con Enable Banking pero no comunicaba nada al usuario.

## Cambios

**Banner superior (`StatusBanner`)** — un único banner a la vez, precedencia **offline > error > sincronizando**:
- 🔵 Info: "Sincronizando…" con spinner durante una sync manual.
- 🟠 Warning: "No pudimos sincronizar." + Reintentar (fallo o timeout de 10s).
- ⚪ Offline: "Sin conexión. Mostrando datos guardados".

Vive dentro del `<header>` sticky, justo debajo de la barra global.

**`SyncStatusProvider`** — contexto cliente que envuelve el layout: listeners `online`/`offline`, `runSync()` (`AbortController` + timeout 10s) y estado del toast.

**Toast genérico (`components/ui/toast.tsx`)** — un único toast persistente `{ message, onRetry? }` para errores inesperados. Cableado en `useTxMutations` (eliminar / recategorizar) y `AddTxModal`, sustituyendo los `console.error` silenciosos.

**Sync manual** — no existía ningún disparador: se añade `SyncButton` en la card de cuenta Enable Banking (decisión: solo hay una cuenta y el endpoint ya recorre todas).

**Rate limit (extra acordado)** — EB permite 4 syncs/día y el cron ya consume 1 a las 06:00. Se añade un **cooldown de 6h** enforced en servidor (`/api/sync/enablebanking` → `429`); el botón se deshabilita y muestra "Disponible en Xh". Sin migración de BD: se deriva de `accounts.last_synced`.

## Fuera de alcance
Banners PSD2 (§9), skeletons de carga y service worker offline — issues propias.

## Validación
- `pnpm lint` ✅ · `pnpm test` ✅ (13/13) · `pnpm build` ✅

## Notas de revisión
- El cooldown solo cubre el sync manual; el cron mantiene su disparo diario. En el peor caso adversarial (sync manual al máximo + solape con el cron) el total teórico podría llegar a 5/día; un 5.º intento real lo rechazaría el propio EB y se mostraría el banner ámbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)