### PR TITLE
feat(ui): skeletons de carga en Dashboard, Movimientos y Cuentas (#76)

### DIFF
--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -1,11 +1,25 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { Check, Landmark } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { AccountCard } from '@/components/accounts/AccountCard'
 import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
+import { CuentasSkeleton } from '@/components/accounts/CuentasSkeleton'
 import type { Account } from '@/types'
 
-export default async function CuentasPage({
+export default function CuentasPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ connected?: string; error?: string }>
+}) {
+  return (
+    <Suspense fallback={<CuentasSkeleton />}>
+      <CuentasContent searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function CuentasContent({
   searchParams,
 }: {
   searchParams: Promise<{ connected?: string; error?: string }>

--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -1,9 +1,19 @@
+import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { MovimientosClient } from '@/components/transactions/MovimientosClient'
+import { MovimientosSkeleton } from '@/components/transactions/MovimientosSkeleton'
 import type { TransactionWithAccount } from '@/types'
 
-export default async function MovimientosPage() {
+export default function MovimientosPage() {
+  return (
+    <Suspense fallback={<MovimientosSkeleton />}>
+      <MovimientosContent />
+    </Suspense>
+  )
+}
+
+async function MovimientosContent() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,9 +1,19 @@
+import { Suspense } from 'react'
 import { getDashboardData } from '@/lib/dashboard'
 import { DashboardBalanceCard } from '@/components/dashboard/DashboardBalanceCard'
 import { DashboardAccountGrid } from '@/components/dashboard/DashboardAccountGrid'
 import { PatrimonioChart } from '@/components/dashboard/PatrimonioChart'
+import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton'
 
-export default async function HomePage() {
+export default function HomePage() {
+  return (
+    <Suspense fallback={<DashboardSkeleton />}>
+      <DashboardContent />
+    </Suspense>
+  )
+}
+
+async function DashboardContent() {
   const { balance, weeklyDelta, dailyBalances, accounts, patrimonioData, annualDelta } = await getDashboardData()
 
   return (

--- a/components/accounts/CuentasSkeleton.tsx
+++ b/components/accounts/CuentasSkeleton.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function CuentasSkeleton() {
+  return (
+    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+      {/* Título */}
+      <Skeleton className="mb-2 h-7 w-28" />
+      {/* Tarjetas de cuenta */}
+      {[0, 1, 2].map(i => (
+        <Skeleton key={i} className="h-47.5 rounded-[20px]" />
+      ))}
+      {/* Botón conectar banco */}
+      <Skeleton className="h-12 rounded-2xl" />
+    </div>
+  )
+}

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -9,6 +9,7 @@ import SavingsCard from './SavingsCard'
 import KpiCard from './KpiCard'
 import DualBarChart from './DualBarChart'
 import CategoryBreakdownSection from './CategoryBreakdownSection'
+import { Skeleton } from '@/components/ui/skeleton'
 
 const DELTA_REF: Record<Granularity, string> = {
   week:    'vs sem. anterior',
@@ -40,12 +41,7 @@ function CalendarIcon() {
 }
 
 function CardSkeleton({ height = 120 }: { height?: number }) {
-  return (
-    <div
-      className="animate-pulse"
-      style={{ background: 'var(--secondary)', borderRadius: 20, height }}
-    />
-  )
+  return <Skeleton className="rounded-[20px]" style={{ height }} />
 }
 
 interface PageState {

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -12,6 +12,7 @@ import { TxModal } from '@/components/transactions/TxModal'
 import { CategoryPicker } from '@/components/transactions/CategoryPicker'
 import GranPicker from './GranPicker'
 import CategoryBarChart from './CategoryBarChart'
+import { Skeleton } from '@/components/ui/skeleton'
 
 const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
 
@@ -220,7 +221,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
           {/* KPI */}
           <div className="mb-4">
             {loadingPeriods ? (
-              <div className="h-9 w-32 animate-pulse rounded-lg" style={{ background: 'var(--muted)' }} />
+              <Skeleton className="h-9 w-32 rounded-lg" />
             ) : (
               <>
                 <span style={{ fontSize: 32, fontWeight: 800, color, letterSpacing: -1 }}>
@@ -237,7 +238,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
 
           {/* Bar chart */}
           {loadingPeriods ? (
-            <div className="h-27.5 animate-pulse rounded-lg" style={{ background: 'var(--muted)' }} />
+            <Skeleton className="h-27.5 rounded-lg" />
           ) : periods.length > 0 ? (
             <CategoryBarChart
               periods={periods}
@@ -256,7 +257,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
         {loadingTxs ? (
           <div className="flex flex-col gap-2">
             {[1, 2, 3].map(i => (
-              <div key={i} className="h-14 animate-pulse rounded-2xl" style={{ background: 'var(--secondary)' }} />
+              <Skeleton key={i} className="h-14 rounded-2xl" />
             ))}
           </div>
         ) : sortedDates.length === 0 ? (

--- a/components/dashboard/DashboardSkeleton.tsx
+++ b/components/dashboard/DashboardSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function DashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 px-4 pt-3 pb-6">
+      {/* Balance card */}
+      <Skeleton className="h-47.5 rounded-3xl" />
+      {/* Patrimonio chart */}
+      <Skeleton className="h-45 rounded-3xl" />
+      {/* Account grid */}
+      <div>
+        <Skeleton className="mb-3 h-4 w-24" />
+        <div className="grid grid-cols-2 gap-3">
+          {[0, 1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-26.25 rounded-2xl" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/transactions/MovimientosSkeleton.tsx
+++ b/components/transactions/MovimientosSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function MovimientosSkeleton() {
+  return (
+    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+      {/* Título */}
+      <Skeleton className="h-7 w-40" />
+      {/* Toolbar (búsqueda + filtros) */}
+      <Skeleton className="h-10 rounded-xl" />
+      {/* 5 filas con la misma altura que TxRow */}
+      <div className="flex flex-col gap-2">
+        {[0, 1, 2, 3, 4].map(i => (
+          <Skeleton key={i} className="h-15.5 rounded-2xl" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Resumen

Cierra el patrón de skeletons de carga (spec §8.1). Hoy sólo `AnalyticsClient` mostraba skeleton; el resto de pantallas se quedaban en blanco hasta que el server component resolvía sus datos. Ahora el primer paint es siempre coherente.

Closes #76

## Cambios

- **`components/ui/skeleton.tsx`** — nuevo componente base `Skeleton` (patrón shadcn: `cn` + `animate-pulse` + `bg-muted`, server-compatible).
- **Dashboard, Cuentas y Movimientos** — server components async; su contenido se envuelve en `<Suspense>` con un fallback de skeleton **acotado a cada ruta** (Suspense por página en vez de `loading.tsx` de grupo, para no contaminar las rutas de `analisis`).
- **`DashboardSkeleton`, `CuentasSkeleton`, `MovimientosSkeleton`** — replican el wrapper y las alturas/radios reales de cada pantalla para evitar layout shift (bloques sólidos, alineados con el `CardSkeleton` existente).
- **`CategoryDetailClient` y `AnalyticsClient`** — los skeletons inline pasan a usar el componente base compartido.

## Detalle de categoría

Ya tenía skeletons inline (KPI, gráfica de barras, lista) — sólo se refactorizan para usar el componente base. La cabecera es estática (`CATEGORY_META`), se pinta al instante y no necesita skeleton.

## Criterios de aceptación

- [x] Las 4 pantallas muestran skeleton durante la primera carga, sin layout shift.
- [x] El skeleton respeta dark/light mode (`bg-muted` vía tokens).
- [x] `pnpm test` (13/13), `pnpm lint` y `pnpm build` pasan sin errores.

## Verificación manual sugerida

`pnpm dev` + throttling lento en DevTools → recargar `/`, `/cuentas`, `/movimientos` y comprobar el skeleton en el primer paint y la transición sin salto. Alternar dark/light con el skeleton visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)