### PR TITLE
feat(psd2): avisos in-app de caducidad del consentimiento (#78)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -3,16 +3,26 @@ import { createClient } from '@/lib/supabase/server'
 import { AppHeader } from '@/components/app-header'
 import { BottomNav } from '@/components/bottom-nav'
 import { SyncStatusProvider } from '@/components/sync/SyncStatusProvider'
+import { getConsentBannerData } from '@/lib/accounts'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
+  // Estado de caducidad PSD2 para el banner global (spec §9.2). Consulta
+  // ligera; se reejecuta al montar el grupo (app) y tras router.refresh().
+  const { data: ebAccounts } = await supabase
+    .from('accounts')
+    .select('name, source, consent_expires_at')
+    .eq('source', 'enablebanking')
+    .eq('is_active', true)
+  const consentBanner = getConsentBannerData(ebAccounts ?? [])
+
   return (
     <div className="relative mx-auto w-full max-w-105 min-h-screen overflow-clip bg-background">
       <SyncStatusProvider>
-        <AppHeader email={user.email ?? ''} />
+        <AppHeader email={user.email ?? ''} consentBanner={consentBanner} />
         <main className="pb-22.5 animate-fade-in">
           {children}
         </main>

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
 
   const { data: accounts, error: accountsError } = await db
     .from('accounts')
-    .select('id, user_id, external_id, session_id, last_synced')
+    .select('id, user_id, external_id, session_id, last_synced, consent_expires_at')
     .eq('source', 'enablebanking')
     .eq('is_active', true)
 
@@ -38,10 +38,25 @@ export async function POST(req: Request) {
   }
 
   if (!accounts || accounts.length === 0) {
-    return NextResponse.json({ synced: 0, accounts: 0, failed: [] })
+    return NextResponse.json({ synced: 0, accounts: 0, skipped: [], failed: [] })
   }
 
-  const userIds = Array.from(new Set(accounts.map(a => a.user_id as string)))
+  // Caducidad PSD2: se saltan las conexiones caducadas (o sin fecha) y se
+  // refleja el motivo en la respuesta del cron (issue #78).
+  const nowMs = Date.now()
+  const skipped: { account_id: string; reason: string }[] = []
+  const syncable = accounts.filter(account => {
+    const expiry = account.consent_expires_at
+      ? new Date(account.consent_expires_at as string).getTime()
+      : 0
+    if (!expiry || expiry <= nowMs) {
+      skipped.push({ account_id: account.id as string, reason: 'consent_expired' })
+      return false
+    }
+    return true
+  })
+
+  const userIds = Array.from(new Set(syncable.map(a => a.user_id as string)))
   const { data: rulesData, error: rulesError } = await db
     .from('categorization_rules')
     .select('user_id, pattern, field, category_id')
@@ -70,7 +85,7 @@ export async function POST(req: Request) {
   let totalSynced = 0
   const failed: { account_id: string; error: string }[] = []
 
-  for (const account of accounts) {
+  for (const account of syncable) {
     if (!account.external_id || !account.session_id) continue
 
     const userId = account.user_id as string
@@ -145,7 +160,8 @@ export async function POST(req: Request) {
 
   return NextResponse.json({
     synced: totalSynced,
-    accounts: accounts.length,
+    accounts: syncable.length,
+    skipped,
     failed,
   })
 }

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -22,7 +22,10 @@ export async function POST() {
       .select('id, external_id, session_id, last_synced')
       .eq('user_id', user.id)
       .eq('source', 'enablebanking')
-      .eq('is_active', true),
+      .eq('is_active', true)
+      // Caducidad PSD2: no se sincronizan conexiones caducadas (issue #78).
+      // `.gt` también descarta las filas con consent_expires_at NULL.
+      .gt('consent_expires_at', new Date().toISOString()),
     db
       .from('categorization_rules')
       .select('pattern, field, category_id')

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,5 +1,6 @@
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
+import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
 import { SyncButton } from './SyncButton'
 import type { Account } from '@/types'
 
@@ -34,14 +35,45 @@ function SourceBadge({ source }: { source: Account['source'] }) {
   )
 }
 
+/**
+ * Badge de caducidad PSD2 (spec §9.2). Solo se muestra en `warning` (7-14 días)
+ * y `expired`; en `critical` el aviso lo da el banner global, no la card.
+ */
+function ConsentBadge({ consent }: { consent: ConsentInfo }) {
+  if (consent.status === 'warning') {
+    return (
+      <span
+        className="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+        style={{ background: '#f59e0b22', color: '#f59e0b' }}
+      >
+        Caduca en {consent.daysLeft} {consent.daysLeft === 1 ? 'día' : 'días'}
+      </span>
+    )
+  }
+  if (consent.status === 'expired') {
+    return (
+      <span
+        className="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+        style={{ background: '#ef444422', color: '#ef4444' }}
+      >
+        Conexión caducada
+      </span>
+    )
+  }
+  return null
+}
+
 export function AccountCard({ account }: { account: Account }) {
   const color = account.color ?? '#6366f1'
   const isNegative = (account.balance ?? 0) < 0
   const { label: syncLabel, color: syncColor, Icon: SyncIcon } = getSyncStatus(account.last_synced)
+  const consent =
+    account.source === 'enablebanking' ? getConsentStatus(account.consent_expires_at) : null
+  const isExpired = consent?.status === 'expired'
 
   return (
     <div className="bg-card rounded-[20px] p-5 border border-border">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <div
             className="size-11 rounded-[14px] flex items-center justify-center"
@@ -59,7 +91,10 @@ export function AccountCard({ account }: { account: Account }) {
           </div>
         </div>
 
-        <SourceBadge source={account.source} />
+        <div className="flex flex-col items-end gap-1.5">
+          <SourceBadge source={account.source} />
+          {consent && <ConsentBadge consent={consent} />}
+        </div>
       </div>
 
       <div className="flex items-end justify-between">
@@ -67,7 +102,13 @@ export function AccountCard({ account }: { account: Account }) {
           <div className="text-xs text-muted-foreground mb-1">Saldo actual</div>
           <div
             className="text-[26px] font-extrabold tracking-tight leading-none"
-            style={{ color: isNegative ? '#ef4444' : undefined }}
+            style={{
+              color: isExpired
+                ? 'var(--muted-foreground)'
+                : isNegative
+                  ? '#ef4444'
+                  : undefined,
+            }}
           >
             {account.balance !== null ? `${fmt(account.balance, 2)} €` : '—'}
           </div>
@@ -85,7 +126,7 @@ export function AccountCard({ account }: { account: Account }) {
           <SyncIcon className="size-3 shrink-0" style={{ color: syncColor }} />
           <span style={{ color: syncColor }}>{syncLabel}</span>
         </div>
-        {account.source === 'enablebanking' && (
+        {account.source === 'enablebanking' && !isExpired && (
           <SyncButton lastSynced={account.last_synced} />
         )}
       </div>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -4,10 +4,11 @@ import { usePathname } from 'next/navigation'
 import { Bell } from 'lucide-react'
 import { UserMenuTrigger } from './dashboard/UserMenuTrigger'
 import { StatusBanner } from './sync/StatusBanner'
+import type { ConsentBannerData } from '@/lib/accounts'
 
-type Props = { email: string }
+type Props = { email: string; consentBanner: ConsentBannerData | null }
 
-export function AppHeader({ email }: Props) {
+export function AppHeader({ email, consentBanner }: Props) {
   const pathname = usePathname()
   if (pathname.startsWith('/analisis/categoria/')) return null
 
@@ -24,7 +25,7 @@ export function AppHeader({ email }: Props) {
           <Bell className="size-4.5" strokeWidth={2} />
         </button>
       </div>
-      <StatusBanner />
+      <StatusBanner consent={consentBanner} />
     </header>
   )
 }

--- a/components/sync/StatusBanner.tsx
+++ b/components/sync/StatusBanner.tsx
@@ -1,15 +1,34 @@
 'use client'
 
-import { AlertTriangle, RefreshCw, WifiOff } from 'lucide-react'
+import Link from 'next/link'
+import { AlertTriangle, RefreshCw, ShieldAlert, WifiOff } from 'lucide-react'
 import { useSyncStatus } from './SyncStatusProvider'
+import type { ConsentBannerData } from '@/lib/accounts'
 
 /**
- * Banner superior de estado de sync/conexión. Solo se muestra uno a la vez,
- * con precedencia: offline > error de sync > sincronizando (spec §8.1/§8.2).
+ * Banner superior de estado. Solo se muestra uno a la vez, con precedencia:
+ * caducidad PSD2 > offline > error de sync > sincronizando (spec §8.1/§8.2/§9.2).
+ * El aviso de caducidad es persistente y de acción requerida, así que tiene
+ * prioridad sobre los estados transitorios de sync.
  * Se renderiza dentro del <header> sticky, justo debajo de la barra global.
  */
-export function StatusBanner() {
+export function StatusBanner({ consent }: { consent: ConsentBannerData | null }) {
   const { isOffline, isSyncing, syncError, runSync } = useSyncStatus()
+
+  if (consent) {
+    return (
+      <Banner color="#ef4444">
+        <ShieldAlert className="size-3.5 shrink-0" />
+        <span>{consentMessage(consent)}</span>
+        <Link
+          href="/cuentas"
+          className="ml-auto shrink-0 font-bold underline underline-offset-2"
+        >
+          Renovar →
+        </Link>
+      </Banner>
+    )
+  }
 
   if (isOffline) {
     return (
@@ -46,6 +65,23 @@ export function StatusBanner() {
   }
 
   return null
+}
+
+/** Texto del banner de caducidad PSD2 (spec §9.2). */
+function consentMessage(consent: ConsentBannerData): string {
+  if (consent.count > 1 || !consent.only) {
+    return `Tienes ${consent.count} conexiones por renovar.`
+  }
+  const { name, status, expiresAt } = consent.only
+  if (status === 'expired') {
+    return `Tu conexión con ${name} ha caducado.`
+  }
+  return `Tu conexión con ${name} caduca el ${formatExpiry(expiresAt)}.`
+}
+
+function formatExpiry(iso: string | null): string {
+  if (!iso) return 'pronto'
+  return new Date(iso).toLocaleDateString('es-ES', { day: 'numeric', month: 'long' })
 }
 
 function Banner({ color, children }: { color: string; children: React.ReactNode }) {

--- a/lib/accounts.test.ts
+++ b/lib/accounts.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getConsentStatus, getConsentBannerData } from './accounts'
+import type { Account } from '@/types'
+
+const DAY_MS = 86_400_000
+const NOW = new Date('2026-05-21T12:00:00.000Z')
+
+/** ISO de una fecha situada a `days` días de NOW (negativo = en el pasado). */
+function isoInDays(days: number): string {
+  return new Date(NOW.getTime() + days * DAY_MS).toISOString()
+}
+
+type ConsentAccount = Pick<Account, 'name' | 'source' | 'consent_expires_at'>
+
+function account(over: Partial<ConsentAccount> = {}): ConsentAccount {
+  return {
+    name: 'Cuenta Corriente',
+    source: 'enablebanking',
+    consent_expires_at: isoInDays(30),
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('getConsentStatus', () => {
+  it('clasifica como ok cuando faltan más de 14 días', () => {
+    expect(getConsentStatus(isoInDays(30))).toEqual({ status: 'ok', daysLeft: 30 })
+    expect(getConsentStatus(isoInDays(15)).status).toBe('ok')
+  })
+
+  it('clasifica como warning entre 7 y 14 días (ambos inclusive)', () => {
+    expect(getConsentStatus(isoInDays(14))).toEqual({ status: 'warning', daysLeft: 14 })
+    expect(getConsentStatus(isoInDays(10))).toEqual({ status: 'warning', daysLeft: 10 })
+    expect(getConsentStatus(isoInDays(7))).toEqual({ status: 'warning', daysLeft: 7 })
+  })
+
+  it('clasifica como critical con menos de 7 días', () => {
+    expect(getConsentStatus(isoInDays(6))).toEqual({ status: 'critical', daysLeft: 6 })
+    expect(getConsentStatus(isoInDays(1))).toEqual({ status: 'critical', daysLeft: 1 })
+  })
+
+  it('clasifica como expired una fecha pasada', () => {
+    expect(getConsentStatus(isoInDays(-1))).toEqual({ status: 'expired', daysLeft: 0 })
+  })
+
+  it('clasifica como expired cuando no hay fecha o es inválida', () => {
+    expect(getConsentStatus(null)).toEqual({ status: 'expired', daysLeft: 0 })
+    expect(getConsentStatus('no-es-una-fecha')).toEqual({ status: 'expired', daysLeft: 0 })
+  })
+})
+
+describe('getConsentBannerData', () => {
+  it('devuelve null cuando ninguna conexión está en riesgo', () => {
+    expect(getConsentBannerData([])).toBeNull()
+    expect(
+      getConsentBannerData([
+        account({ consent_expires_at: isoInDays(30) }),
+        account({ consent_expires_at: isoInDays(10) }), // warning, no cuenta
+      ])
+    ).toBeNull()
+  })
+
+  it('resume una única conexión critical con sus datos', () => {
+    const result = getConsentBannerData([
+      account({ name: 'Mi Banco', consent_expires_at: isoInDays(3) }),
+    ])
+    expect(result).toEqual({
+      count: 1,
+      only: { name: 'Mi Banco', status: 'critical', expiresAt: isoInDays(3) },
+    })
+  })
+
+  it('resume una única conexión expired', () => {
+    const result = getConsentBannerData([
+      account({ name: 'Mi Banco', consent_expires_at: isoInDays(-2) }),
+    ])
+    expect(result).toEqual({
+      count: 1,
+      only: { name: 'Mi Banco', status: 'expired', expiresAt: isoInDays(-2) },
+    })
+  })
+
+  it('agrupa varias conexiones en riesgo sin detalle individual', () => {
+    const result = getConsentBannerData([
+      account({ consent_expires_at: isoInDays(3) }),
+      account({ consent_expires_at: isoInDays(-2) }),
+      account({ consent_expires_at: isoInDays(30) }), // ok, no cuenta
+    ])
+    expect(result).toEqual({ count: 2, only: null })
+  })
+
+  it('ignora cuentas que no son de Enable Banking', () => {
+    expect(
+      getConsentBannerData([
+        account({ source: 'manual', consent_expires_at: null }),
+        account({ source: 'scraper', consent_expires_at: null }),
+      ])
+    ).toBeNull()
+  })
+})

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,0 +1,73 @@
+import type { Account } from '@/types'
+
+/**
+ * Estado de caducidad del consentimiento PSD2 de una cuenta (spec §9.2).
+ * - `ok`       — más de 14 días para caducar
+ * - `warning`  — entre 7 y 14 días
+ * - `critical` — menos de 7 días
+ * - `expired`  — ya caducada o sin fecha de caducidad
+ */
+export type ConsentStatus = 'ok' | 'warning' | 'critical' | 'expired'
+
+export interface ConsentInfo {
+  status: ConsentStatus
+  /** Días enteros restantes (redondeo al alza). 0 si caducada o sin fecha. */
+  daysLeft: number
+}
+
+const DAY_MS = 86_400_000
+
+/**
+ * Clasifica la caducidad del consentimiento PSD2 a partir de `consent_expires_at`.
+ * Una fecha ausente o inválida se trata como `expired` (spec §9.2).
+ */
+export function getConsentStatus(consentExpiresAt: string | null): ConsentInfo {
+  if (!consentExpiresAt) return { status: 'expired', daysLeft: 0 }
+  const expiry = new Date(consentExpiresAt).getTime()
+  if (Number.isNaN(expiry)) return { status: 'expired', daysLeft: 0 }
+
+  const msLeft = expiry - Date.now()
+  if (msLeft <= 0) return { status: 'expired', daysLeft: 0 }
+
+  const daysLeft = Math.ceil(msLeft / DAY_MS)
+  if (daysLeft > 14) return { status: 'ok', daysLeft }
+  if (daysLeft >= 7) return { status: 'warning', daysLeft }
+  return { status: 'critical', daysLeft }
+}
+
+export interface ConsentBannerData {
+  /** Nº de conexiones PSD2 en estado `critical` o `expired`. */
+  count: number
+  /** Datos de la única conexión afectada; solo poblado cuando `count === 1`. */
+  only: { name: string; status: 'critical' | 'expired'; expiresAt: string | null } | null
+}
+
+type ConsentAccount = Pick<Account, 'name' | 'source' | 'consent_expires_at'>
+
+/**
+ * Resume las conexiones PSD2 que requieren acción (caducan pronto o ya
+ * caducaron) para el banner global. Solo considera cuentas `enablebanking`.
+ * Devuelve `null` cuando no hay nada que avisar.
+ */
+export function getConsentBannerData(accounts: ConsentAccount[]): ConsentBannerData | null {
+  const atRisk = accounts
+    .filter(a => a.source === 'enablebanking')
+    .map(a => ({ account: a, consent: getConsentStatus(a.consent_expires_at) }))
+    .filter(({ consent }) => consent.status === 'critical' || consent.status === 'expired')
+
+  if (atRisk.length === 0) return null
+
+  if (atRisk.length === 1) {
+    const { account, consent } = atRisk[0]
+    return {
+      count: 1,
+      only: {
+        name: account.name,
+        status: consent.status as 'critical' | 'expired',
+        expiresAt: account.consent_expires_at,
+      },
+    }
+  }
+
+  return { count: atRisk.length, only: null }
+}


### PR DESCRIPTION
## Resumen

Implementa los avisos in-app de caducidad del consentimiento PSD2 (spec §9.1/§9.2). Hasta ahora `accounts.consent_expires_at` se guardaba pero no se usaba en ninguna pantalla; el usuario no se enteraba de que su conexión iba a caducar hasta que la sincronización fallaba en silencio.

Closes #78

## Cambios

- **`lib/accounts.ts`** (nuevo): `getConsentStatus` clasifica la caducidad en `ok` (>14d) / `warning` (7-14d) / `critical` (<7d) / `expired` (caducada o sin fecha); `getConsentBannerData` resume las conexiones en riesgo para el banner global.
- **`AccountCard`**: badge ámbar discreto «Caduca en X días» en estado `warning`; en estado `expired`, saldo en gris, etiqueta «Conexión caducada» y sin botón de sincronizar.
- **`StatusBanner`**: nuevo banner rojo persistente con **máxima precedencia** (por encima de offline/sync) para conexiones `critical`/`expired`. CTA «Renovar →» hacia Cuentas. Una sola línea agrupada («Tienes N conexiones por renovar») cuando hay varias.
- **`layout (app)`**: calcula el estado de caducidad en servidor y lo pasa al header.
- **Endpoints de sync**: el manual (`/api/sync/enablebanking`) filtra `consent_expires_at > now()`; el cron salta las conexiones caducadas y refleja el motivo en `skipped` de la respuesta.

## Decisiones

- El banner usa `account.name` para identificar la conexión (la tabla `accounts` no guarda el nombre del ASPSP; no se amplía el esquema).
- El banner de caducidad tiene precedencia sobre el `StatusBanner` de sync — se mantiene el principio de «un solo banner a la vez».
- En `/analisis/categoria/*` el header (y el banner) sigue oculto, como hasta ahora.

## Fuera de alcance

- Flujo de renovación (re-OAuth) — issue aparte.
- Notificaciones externas (email/Telegram) — descartado para el MVP.

## Verificación

- `pnpm test` ✓ (23 tests, incluye cobertura nueva de `getConsentStatus` / `getConsentBannerData`)
- `pnpm lint` ✓
- `pnpm build` ✓

### Criterios de aceptación

- [x] Cuenta a 10 días → badge ámbar en `AccountCard`.
- [x] Cuenta a 5 días → banner rojo persistente en cualquier pantalla.
- [x] Cuenta caducada → saldo gris, «Conexión caducada», sin intento de sync.
- [x] El cron diario salta cuentas caducadas y lo refleja en su respuesta (`skipped`).
- [x] Sin cuentas en `warning`/`critical`/`expired`, no se muestra nada extra.
- [x] `pnpm build` pasa sin errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)