### PR TITLE
feat(psd2): flujo de renovación del consentimiento desde Cuentas

### DIFF
--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -4,13 +4,16 @@ import { Check, Landmark } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { AccountCard } from '@/components/accounts/AccountCard'
 import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
+import { RenewedSyncTrigger } from '@/components/accounts/RenewedSyncTrigger'
 import { CuentasSkeleton } from '@/components/accounts/CuentasSkeleton'
 import type { Account } from '@/types'
+
+type CuentasSearchParams = { connected?: string; error?: string; renewed?: string }
 
 export default function CuentasPage({
   searchParams,
 }: {
-  searchParams: Promise<{ connected?: string; error?: string }>
+  searchParams: Promise<CuentasSearchParams>
 }) {
   return (
     <Suspense fallback={<CuentasSkeleton />}>
@@ -22,7 +25,7 @@ export default function CuentasPage({
 async function CuentasContent({
   searchParams,
 }: {
-  searchParams: Promise<{ connected?: string; error?: string }>
+  searchParams: Promise<CuentasSearchParams>
 }) {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -52,6 +55,23 @@ async function CuentasContent({
           <Check className="size-4 shrink-0" />
           Banco conectado correctamente
         </div>
+      )}
+
+      {params.renewed && (
+        <>
+          <div
+            className="rounded-2xl px-4 py-3 text-sm font-medium flex items-center gap-2"
+            style={{
+              background: '#22c55e15',
+              border: '1px solid #22c55e30',
+              color: '#22c55e',
+            }}
+          >
+            <Check className="size-4 shrink-0" />
+            Conexión renovada correctamente
+          </div>
+          <RenewedSyncTrigger accountId={params.renewed} />
+        </>
       )}
 
       {params.error && (

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { createSessionFromCode } from '@/lib/enablebanking'
+import { createSessionFromCode, decodeBankingState } from '@/lib/enablebanking'
+
+/** Normaliza un IBAN para comparar (sin espacios, mayúsculas). */
+function normalizeIban(iban: string | null | undefined): string | null {
+  return iban ? iban.replace(/\s/g, '').toUpperCase() : null
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const appUrl = process.env.NEXT_PUBLIC_APP_URL
   const code = searchParams.get('code')
   const error = searchParams.get('error')
+  const state = decodeBankingState(searchParams.get('state'))
 
   if (error || !code) {
     return NextResponse.redirect(`${appUrl}/cuentas?error=bank_auth_cancelled`)
@@ -26,6 +32,42 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${appUrl}/cuentas?error=session_fetch_failed`)
   }
 
+  // Modo renovación: actualiza la cuenta existente, no crea filas nuevas (issue #79).
+  if (state?.accountId) {
+    const { data: target } = await supabase
+      .from('accounts')
+      .select('id, iban')
+      .eq('id', state.accountId)
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    if (!target) {
+      return NextResponse.redirect(`${appUrl}/cuentas?error=renew_account_not_found`)
+    }
+
+    // El uid de la cuenta EB puede cambiar entre sesiones; se empareja por IBAN.
+    const ebAcc = target.iban
+      ? session.accounts.find(
+          a => normalizeIban(a.account_id?.iban) === normalizeIban(target.iban)
+        )
+      : session.accounts[0]
+
+    await supabase
+      .from('accounts')
+      .update({
+        session_id: session.session_id,
+        consent_expires_at: session.access.valid_until,
+        ...(ebAcc && { external_id: ebAcc.uid }),
+        aspsp_name: state.aspspName,
+        aspsp_country: state.aspspCountry,
+        is_active: true,
+      })
+      .eq('id', target.id)
+
+    return NextResponse.redirect(`${appUrl}/cuentas?renewed=${target.id}`)
+  }
+
+  // Modo conexión: alta o actualización de cuentas de la sesión.
   for (const acc of session.accounts) {
     const iban = acc.account_id?.iban ?? null
     const lastFour = iban ? iban.replace(/\s/g, '').slice(-4) : null
@@ -41,6 +83,8 @@ export async function GET(request: NextRequest) {
       external_id: acc.uid,
       session_id: session.session_id,
       consent_expires_at: session.access.valid_until,
+      aspsp_name: state?.aspspName ?? null,
+      aspsp_country: state?.aspspCountry ?? null,
       is_active: true,
     }
 

--- a/app/api/banking/connect/route.ts
+++ b/app/api/banking/connect/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { initiateAuth } from '@/lib/enablebanking'
+import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
@@ -15,9 +15,10 @@ export async function POST(request: NextRequest) {
   }
 
   const redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/banking/callback`
+  const state = encodeBankingState({ aspspName, aspspCountry })
 
   try {
-    const auth = await initiateAuth(redirectUrl, { name: aspspName, country: aspspCountry })
+    const auth = await initiateAuth(redirectUrl, { name: aspspName, country: aspspCountry }, state)
     return NextResponse.json({ url: auth.url })
   } catch (err) {
     console.error('[EB connect]', err)

--- a/app/api/banking/renew/route.ts
+++ b/app/api/banking/renew/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
+
+/**
+ * Renovación del consentimiento PSD2 de una cuenta existente (issue #79, spec §9.4).
+ * Crea una nueva sesión de autorización en Enable Banking reutilizando el banco
+ * (ASPSP) guardado en la cuenta y devuelve la URL de autorización. El callback
+ * detecta `accountId` en el `state` y actualiza la fila en vez de duplicarla.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { accountId } = await request.json()
+  if (!accountId) {
+    return NextResponse.json({ error: 'accountId es obligatorio' }, { status: 400 })
+  }
+
+  const { data: account } = await supabase
+    .from('accounts')
+    .select('id, source, aspsp_name, aspsp_country')
+    .eq('id', accountId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (!account || account.source !== 'enablebanking') {
+    return NextResponse.json({ error: 'Cuenta no encontrada' }, { status: 404 })
+  }
+
+  // Cuenta heredada, conectada antes de que se guardara el ASPSP: no se puede
+  // renovar de un clic. El cliente redirige al flujo de conexión manual.
+  if (!account.aspsp_name || !account.aspsp_country) {
+    return NextResponse.json({ error: 'aspsp_unknown' }, { status: 422 })
+  }
+
+  const redirectUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/banking/callback`
+  const state = encodeBankingState({
+    aspspName: account.aspsp_name,
+    aspspCountry: account.aspsp_country,
+    accountId: account.id,
+  })
+
+  try {
+    const auth = await initiateAuth(
+      redirectUrl,
+      { name: account.aspsp_name, country: account.aspsp_country },
+      state
+    )
+    return NextResponse.json({ url: auth.url })
+  } catch (err) {
+    console.error('[EB renew]', err)
+    return NextResponse.json(
+      { error: 'No se pudo iniciar la renovación bancaria' },
+      { status: 502 }
+    )
+  }
+}

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -5,7 +5,7 @@ import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 import { SYNC_COOLDOWN_MS } from '@/lib/sync'
 
-export async function POST() {
+export async function POST(request: Request) {
   // Auth: verify user via cookie client
   const supabase = await createClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -13,19 +13,32 @@ export async function POST() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  // Body opcional: `{ accountId }` limita la sync a una sola cuenta (issue #79,
+  // sync inmediata tras renovar). Sin body, se sincronizan todas.
+  let accountId: string | undefined
+  try {
+    const body = await request.json()
+    accountId = typeof body?.accountId === 'string' ? body.accountId : undefined
+  } catch {
+    accountId = undefined
+  }
+
   // All DB writes via service client (bypasses RLS)
   const db = createServiceClient()
 
+  let accountsQuery = db
+    .from('accounts')
+    .select('id, external_id, session_id, last_synced')
+    .eq('user_id', user.id)
+    .eq('source', 'enablebanking')
+    .eq('is_active', true)
+    // Caducidad PSD2: no se sincronizan conexiones caducadas (issue #78).
+    // `.gt` también descarta las filas con consent_expires_at NULL.
+    .gt('consent_expires_at', new Date().toISOString())
+  if (accountId) accountsQuery = accountsQuery.eq('id', accountId)
+
   const [accountsResult, rulesResult] = await Promise.all([
-    db
-      .from('accounts')
-      .select('id, external_id, session_id, last_synced')
-      .eq('user_id', user.id)
-      .eq('source', 'enablebanking')
-      .eq('is_active', true)
-      // Caducidad PSD2: no se sincronizan conexiones caducadas (issue #78).
-      // `.gt` también descarta las filas con consent_expires_at NULL.
-      .gt('consent_expires_at', new Date().toISOString()),
+    accountsQuery,
     db
       .from('categorization_rules')
       .select('pattern, field, category_id')

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -2,6 +2,7 @@ import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
 import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
 import { SyncButton } from './SyncButton'
+import { RenewBankButton } from './RenewBankButton'
 import type { Account } from '@/types'
 
 function getSyncStatus(iso: string | null): { label: string; color: string; Icon: typeof Check } {
@@ -70,6 +71,7 @@ export function AccountCard({ account }: { account: Account }) {
   const consent =
     account.source === 'enablebanking' ? getConsentStatus(account.consent_expires_at) : null
   const isExpired = consent?.status === 'expired'
+  const needsRenew = consent?.status === 'critical' || consent?.status === 'expired'
 
   return (
     <div className="bg-card rounded-[20px] p-5 border border-border">
@@ -126,9 +128,12 @@ export function AccountCard({ account }: { account: Account }) {
           <SyncIcon className="size-3 shrink-0" style={{ color: syncColor }} />
           <span style={{ color: syncColor }}>{syncLabel}</span>
         </div>
-        {account.source === 'enablebanking' && !isExpired && (
-          <SyncButton lastSynced={account.last_synced} />
-        )}
+        {account.source === 'enablebanking' &&
+          (needsRenew ? (
+            <RenewBankButton accountId={account.id} expired={isExpired} />
+          ) : (
+            <SyncButton lastSynced={account.last_synced} />
+          ))}
       </div>
     </div>
   )

--- a/components/accounts/RenewBankButton.tsx
+++ b/components/accounts/RenewBankButton.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { ShieldCheck } from 'lucide-react'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
+
+/**
+ * CTA de renovación del consentimiento PSD2 en la card de cuenta (issue #79).
+ * Se muestra cuando la conexión está `critical` o `expired`. Inicia el flujo
+ * OAuth de re-autorización contra /api/banking/renew.
+ */
+export function RenewBankButton({
+  accountId,
+  expired,
+}: {
+  accountId: string
+  expired: boolean
+}) {
+  const { showToast } = useSyncStatus()
+  const [loading, setLoading] = useState(false)
+
+  // Rojo si ya caducó; ámbar si está a punto de caducar.
+  const color = expired ? '#ef4444' : '#f59e0b'
+
+  async function handleRenew() {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/banking/renew', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId }),
+      })
+      if (res.status === 422) {
+        showToast(
+          'No identificamos el banco de esta cuenta. Renuévala desde «Conectar nueva cuenta».'
+        )
+        return
+      }
+      if (!res.ok) throw new Error(`renew failed: ${res.status}`)
+      const { url } = await res.json()
+      window.location.href = url
+    } catch (err) {
+      console.error('[RenewBankButton]', err)
+      showToast('No se pudo iniciar la renovación. Inténtalo de nuevo.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleRenew}
+      disabled={loading}
+      className="flex shrink-0 items-center gap-1.5 rounded-[10px] px-3 py-1.5 text-[11px] font-semibold transition-opacity disabled:opacity-40"
+      style={{ background: color + '22', color }}
+    >
+      <ShieldCheck className="size-3 shrink-0" />
+      {loading ? 'Abriendo…' : 'Renovar conexión'}
+    </button>
+  )
+}

--- a/components/accounts/RenewedSyncTrigger.tsx
+++ b/components/accounts/RenewedSyncTrigger.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
+
+/**
+ * Tras renovar el consentimiento PSD2 lanza una sync inmediata de la cuenta
+ * renovada para cubrir el hueco temporal de la caducidad (issue #79, spec §9.4).
+ * No renderiza nada. `router.refresh()` no remonta clientes, así que el guard
+ * `useRef` evita un segundo disparo.
+ */
+export function RenewedSyncTrigger({ accountId }: { accountId: string }) {
+  const { runSync } = useSyncStatus()
+  const fired = useRef(false)
+
+  useEffect(() => {
+    if (fired.current) return
+    fired.current = true
+    runSync(accountId)
+  }, [accountId, runSync])
+
+  return null
+}

--- a/components/sync/SyncStatusProvider.tsx
+++ b/components/sync/SyncStatusProvider.tsx
@@ -24,8 +24,11 @@ interface SyncStatusValue {
   isSyncing: boolean
   /** La última sincronización falló o superó el timeout. */
   syncError: boolean
-  /** Lanza una sincronización manual contra /api/sync/enablebanking. */
-  runSync: () => Promise<void>
+  /**
+   * Lanza una sincronización manual contra /api/sync/enablebanking.
+   * Con `accountId` la sync se limita a esa cuenta (renovación PSD2, issue #79).
+   */
+  runSync: (accountId?: string) => Promise<void>
   /** Muestra el toast genérico de error con un Reintentar opcional. */
   showToast: (message: string, onRetry?: () => void) => void
 }
@@ -63,7 +66,7 @@ export function SyncStatusProvider({ children }: { children: React.ReactNode }) 
 
   const dismissToast = useCallback(() => setToast(null), [])
 
-  const runSync = useCallback(async () => {
+  const runSync = useCallback(async (accountId?: string) => {
     if (syncingRef.current) return
     syncingRef.current = true
     setIsSyncing(true)
@@ -76,6 +79,10 @@ export function SyncStatusProvider({ children }: { children: React.ReactNode }) 
       const res = await fetch('/api/sync/enablebanking', {
         method: 'POST',
         signal: controller.signal,
+        ...(accountId && {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ accountId }),
+        }),
       })
       // 429 = cooldown: no es un fallo de sync; aviso suave sin banner ámbar.
       if (res.status === 429) {

--- a/lib/enablebanking.ts
+++ b/lib/enablebanking.ts
@@ -40,13 +40,39 @@ export interface EBaspsp {
   country: string
 }
 
+/**
+ * Payload que viaja en el parámetro `state` del flujo OAuth de Enable Banking.
+ * EB lo devuelve intacto en el redirect al callback. Si `accountId` está
+ * presente, el callback está en modo renovación (issue #79).
+ */
+export interface BankingState {
+  aspspName: string
+  aspspCountry: string
+  accountId?: string
+}
+
+/** Serializa el `state` a base64url para incrustarlo en el flujo OAuth. */
+export function encodeBankingState(state: BankingState): string {
+  return Buffer.from(JSON.stringify(state)).toString('base64url')
+}
+
+/** Deserializa el `state` recibido en el callback. Devuelve `null` si es inválido. */
+export function decodeBankingState(raw: string | null): BankingState | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as BankingState
+  } catch {
+    return null
+  }
+}
+
 export async function initiateAuth(
   redirectUrl: string,
-  aspsp: EBaspsp
+  aspsp: EBaspsp,
+  state: string
 ): Promise<EBAuthResponse> {
   const jwt = await signJWT()
   const validUntil = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
-  const state = crypto.randomUUID()
 
   const res = await fetch(`${BASE_URL}/auth`, {
     method: 'POST',

--- a/supabase/migrations/20260521000000_accounts_aspsp.sql
+++ b/supabase/migrations/20260521000000_accounts_aspsp.sql
@@ -1,0 +1,5 @@
+-- Banco (ASPSP) de origen de las cuentas Enable Banking.
+-- Se guarda para poder renovar el consentimiento PSD2 sin que el usuario
+-- vuelva a seleccionar el banco (issue #79, spec §9.4).
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS aspsp_name TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS aspsp_country TEXT;

--- a/types/index.ts
+++ b/types/index.ts
@@ -62,6 +62,8 @@ export interface Account {
   external_id: string | null
   session_id: string | null
   consent_expires_at: string | null
+  aspsp_name: string | null
+  aspsp_country: string | null
   last_synced: string | null
   is_active: boolean
   created_at: string


### PR DESCRIPTION
## Contexto

Cierra **#79**. Hoy se puede conectar un banco por primera vez pero no **renovar** la autorización PSD2 cuando caduca (cada 90–180 días por ley europea). Esta PR añade el flujo completo de re-OAuth + sync inmediata (spec §9.4).

**Hueco resuelto:** la tabla `accounts` no guardaba el banco (ASPSP), necesario para re-autorizar. Ahora se persiste y se propaga por el parámetro `state` del flujo OAuth.

## Cambios

- **Migración** `20260521000000_accounts_aspsp.sql`: columnas `aspsp_name` / `aspsp_country`.
- **`lib/enablebanking.ts`**: `initiateAuth` recibe un `state` controlado por el llamante; helpers `encodeBankingState` / `decodeBankingState` (JSON → base64url) que transportan `{ aspspName, aspspCountry, accountId? }`.
- **`POST /api/banking/renew`** (nuevo): re-autoriza el banco guardado en la cuenta y devuelve la URL del banco. `422 aspsp_unknown` para cuentas heredadas sin ASPSP.
- **`/api/banking/callback`**: si `state.accountId` está presente → modo renovación: actualiza la fila existente (`session_id`, `consent_expires_at`, `external_id` emparejado por IBAN) en vez de duplicarla. El modo conexión ahora persiste el ASPSP.
- **`/api/sync/enablebanking`**: acepta `{ accountId }` opcional para sincronizar solo la cuenta renovada y cubrir el hueco temporal; el cooldown queda acotado a esa cuenta.
- **UI**: botón "Renovar conexión" en `AccountCard` cuando la conexión está `critical`/`expired`; `RenewedSyncTrigger` lanza la sync inmediata al volver del banco; banner verde de confirmación en `/cuentas`.

## Criterios de aceptación

- [x] Una cuenta `critical`/`expired` muestra el botón "Renovar conexión".
- [x] Al pulsarlo redirige al banco; el callback vuelve a Cuentas con la cuenta actualizada.
- [x] La fila de `accounts` se actualiza, no se duplica.
- [x] Tras renovar se lanza una sync automática de esa cuenta.
- [x] `pnpm test`, `pnpm lint` y `pnpm build` pasan sin errores.

## Notas

- **Requiere aplicar la migración** `20260521000000_accounts_aspsp.sql` en Supabase.
- Las cuentas conectadas **antes** de esta feature no tienen ASPSP guardado: al renovarlas el endpoint devuelve `422` y la UI sugiere usar "Conectar nueva cuenta" (que ya renueva vía match por IBAN). Las cuentas nuevas guardan el ASPSP y se renuevan de un clic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)