### PR TITLE
test(analytics): unit tests de la lógica de agregación (#80)

### DIFF
--- a/app/api/analytics/categoria/route.test.ts
+++ b/app/api/analytics/categoria/route.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+const { GET } = await import('./route')
+
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+// Jueves 21 mayo 2026, 12:00 local
+const NOW = new Date(2026, 4, 21, 12, 0, 0, 0)
+
+interface RpcParams {
+  p_user_id: string
+  p_start_date: string
+  p_end_date: string
+}
+
+interface ByCat {
+  category: string | null
+  amount: number
+}
+
+interface PeriodRow {
+  ingresos: number
+  gastos: number
+  ahorro: number
+  by_category: ByCat[] | null
+}
+
+type RpcImpl = (
+  name: string,
+  params: RpcParams
+) => Promise<{ data: PeriodRow[] | null; error: unknown }>
+
+interface MockOpts {
+  user?: { id: string } | null
+  authError?: unknown
+  rpc?: RpcImpl
+}
+
+function buildSupabase(opts: MockOpts = {}) {
+  const rpcSpy = vi.fn<RpcImpl>(
+    opts.rpc ??
+      (async () => ({
+        data: [{ ingresos: 0, gastos: 0, ahorro: 0, by_category: [] }],
+        error: null,
+      }))
+  )
+  const supabase = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: opts.user === undefined ? { id: USER_ID } : opts.user },
+        error: opts.authError ?? null,
+      })),
+    },
+    rpc: rpcSpy,
+  }
+  return { supabase, rpcSpy }
+}
+
+function req(query: Record<string, string> = {}) {
+  const url = new URL('http://test/api/analytics/categoria')
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v)
+  return new NextRequest(url)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('GET /api/analytics/categoria — validación de params', () => {
+  it.each<[string, Record<string, string>]>([
+    ['gran ausente', { id: 'restaurant' }],
+    ['gran inválido', { gran: 'day', id: 'restaurant' }],
+    ['id ausente', { gran: 'month' }],
+    ['id desconocido (no existe en CATEGORY_META)', { gran: 'month', id: 'nope' }],
+  ])('devuelve 400 cuando %s', async (_label, query) => {
+    const { supabase } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req(query))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid params' })
+    expect(supabase.auth.getUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/analytics/categoria — autenticación', () => {
+  it('devuelve 401 si auth.getUser devuelve error', async () => {
+    const { supabase, rpcSpy } = buildSupabase({
+      user: null,
+      authError: { message: 'no session' },
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month', id: 'restaurant' }))
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+    expect(rpcSpy).not.toHaveBeenCalled()
+  })
+
+  it('devuelve 401 si no hay usuario', async () => {
+    const { supabase, rpcSpy } = buildSupabase({ user: null })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month', id: 'restaurant' }))
+    expect(res.status).toBe(401)
+    expect(rpcSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/analytics/categoria — ventana de drilldown', () => {
+  it('devuelve exactamente 6 períodos (recortado desde la ventana completa)', async () => {
+    const { supabase, rpcSpy } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month', id: 'restaurant' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.gran).toBe('month')
+    expect(body.categoryId).toBe('restaurant')
+    expect(body.periods).toHaveLength(6)
+    expect(rpcSpy).toHaveBeenCalledTimes(6)
+  })
+
+  it('los 6 períodos son los últimos de la ventana completa (mes actual = último)', async () => {
+    const { supabase } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const body = await (await GET(req({ gran: 'month', id: 'restaurant' }))).json()
+    // Mes actual = mayo 2026; ventana=12; últimos 6 = dic 2025..mayo 2026
+    expect(body.periods[0].start).toBe('2025-12-01')
+    expect(body.periods.at(-1).start).toBe('2026-05-01')
+    expect(body.periods.at(-1).end).toBe('2026-05-31')
+  })
+})
+
+describe('GET /api/analytics/categoria — drilldown por categoría', () => {
+  it('devuelve el valor absoluto del amount para la categoría pedida (gasto)', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({
+        data: [
+          {
+            ingresos: 0,
+            gastos: 320,
+            ahorro: -320,
+            by_category: [
+              { category: 'restaurant', amount: -120 },
+              { category: 'groceries', amount: -200 },
+            ],
+          },
+        ],
+        error: null,
+      }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const body = await (await GET(req({ gran: 'month', id: 'restaurant' }))).json()
+    expect(body.periods).toHaveLength(6)
+    for (const p of body.periods) {
+      expect(p.amount).toBe(120)
+    }
+  })
+
+  it('devuelve el amount sin signo cuando la categoría representa ingresos', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({
+        data: [
+          {
+            ingresos: 2000,
+            gastos: 0,
+            ahorro: 2000,
+            by_category: [{ category: 'income', amount: 2000 }],
+          },
+        ],
+        error: null,
+      }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const body = await (await GET(req({ gran: 'month', id: 'income' }))).json()
+    for (const p of body.periods) {
+      expect(p.amount).toBe(2000)
+    }
+  })
+
+  it('devuelve amount=0 cuando la categoría no aparece en by_category', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({
+        data: [
+          {
+            ingresos: 0,
+            gastos: 200,
+            ahorro: -200,
+            by_category: [{ category: 'groceries', amount: -200 }],
+          },
+        ],
+        error: null,
+      }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const body = await (await GET(req({ gran: 'month', id: 'restaurant' }))).json()
+    for (const p of body.periods) {
+      expect(p.amount).toBe(0)
+    }
+  })
+
+  it('devuelve amount=0 cuando el RPC trae data vacío o by_category null', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({ data: [], error: null }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const body = await (await GET(req({ gran: 'month', id: 'restaurant' }))).json()
+    for (const p of body.periods) expect(p.amount).toBe(0)
+  })
+
+  it('llama al RPC con p_user_id y fechas ISO por cada periodo', async () => {
+    const { supabase, rpcSpy } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    await GET(req({ gran: 'month', id: 'restaurant' }))
+    for (const [name, params] of rpcSpy.mock.calls) {
+      expect(name).toBe('get_period_data')
+      expect(params.p_user_id).toBe(USER_ID)
+      expect(params.p_start_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(params.p_end_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+  })
+})
+
+describe('GET /api/analytics/categoria — granularidades', () => {
+  it.each<[string]>([['week'], ['month'], ['quarter'], ['year']])(
+    'devuelve 6 períodos para gran=%s',
+    async (gran) => {
+      const { supabase } = buildSupabase()
+      vi.mocked(createClient).mockResolvedValue(
+        supabase as unknown as Awaited<ReturnType<typeof createClient>>
+      )
+
+      const body = await (await GET(req({ gran, id: 'restaurant' }))).json()
+      expect(body.periods).toHaveLength(6)
+    }
+  )
+})
+
+describe('GET /api/analytics/categoria — errores', () => {
+  it('devuelve 500 "DB error" si el RPC lanza', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => {
+        throw new Error('connection refused')
+      },
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await GET(req({ gran: 'month', id: 'restaurant' }))
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'DB error' })
+    errSpy.mockRestore()
+  })
+})

--- a/app/api/analytics/route.test.ts
+++ b/app/api/analytics/route.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getWindowPeriods, toISODate } from '@/lib/analytics'
+import type { Granularity } from '@/types'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+const { GET } = await import('./route')
+
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+// NOW = jueves 21 mayo 2026, 12:00 local. Mismo bedrock que lib/analytics.test.ts
+const NOW = new Date(2026, 4, 21, 12, 0, 0, 0)
+
+interface RpcParams {
+  p_user_id: string
+  p_start_date: string
+  p_end_date: string
+}
+
+interface PeriodRow {
+  ingresos: number
+  gastos: number
+  ahorro: number
+  by_category: { category: string | null; amount: number }[]
+}
+
+type RpcImpl = (
+  name: string,
+  params: RpcParams
+) => Promise<{ data: PeriodRow[] | null; error: unknown }>
+
+interface MockOpts {
+  user?: { id: string } | null
+  authError?: unknown
+  rpc?: RpcImpl
+}
+
+const emptyRow = (): PeriodRow => ({
+  ingresos: 0,
+  gastos: 0,
+  ahorro: 0,
+  by_category: [],
+})
+
+/**
+ * Devuelve el set de `p_start_date` ISO esperados para los períodos CUR de
+ * la ventana actual, dado `gran` y `offset`. Se usa para que un mock pueda
+ * distinguir RPCs CUR vs YoY sin asumir orden de llamada.
+ */
+function curStartSet(gran: Granularity, offset = 0): Set<string> {
+  return new Set(getWindowPeriods(gran, offset).map((r) => toISODate(r.start)))
+}
+
+/**
+ * Helper que crea una `rpc` mock devolviendo `cur` para los períodos actuales
+ * y `yoy` para los demás (asumidos YoY).
+ */
+function rpcByPeriod(
+  gran: Granularity,
+  cur: PeriodRow | null,
+  yoy: PeriodRow | null,
+  offset = 0
+): RpcImpl {
+  const curStarts = curStartSet(gran, offset)
+  return async (_, p) => {
+    const row = curStarts.has(p.p_start_date) ? cur : yoy
+    return { data: row === null ? [] : [row], error: null }
+  }
+}
+
+function buildSupabase(opts: MockOpts = {}) {
+  const rpcSpy = vi.fn<RpcImpl>(
+    opts.rpc ?? (async () => ({ data: [emptyRow()], error: null }))
+  )
+  const supabase = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: opts.user === undefined ? { id: USER_ID } : opts.user },
+        error: opts.authError ?? null,
+      })),
+    },
+    rpc: rpcSpy,
+  }
+  return { supabase, rpcSpy }
+}
+
+function req(query: Record<string, string> = {}) {
+  const url = new URL('http://test/api/analytics')
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v)
+  return new NextRequest(url)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('GET /api/analytics — validación de params', () => {
+  it.each<[string, Record<string, string>]>([
+    ['gran ausente', {}],
+    ['gran inválido', { gran: 'day' }],
+    ['offset negativo', { gran: 'month', offset: '-1' }],
+    ['offset no numérico', { gran: 'month', offset: 'abc' }],
+  ])('devuelve 400 cuando %s', async (_label, query) => {
+    const { supabase } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req(query))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid params' })
+    // No debe haber tocado la BD
+    expect(supabase.auth.getUser).not.toHaveBeenCalled()
+  })
+
+  it('acepta offset omitido (default 0)', async () => {
+    const { supabase } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('GET /api/analytics — autenticación', () => {
+  it('devuelve 401 si auth.getUser devuelve error', async () => {
+    const { supabase, rpcSpy } = buildSupabase({
+      user: null,
+      authError: { message: 'no session' },
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+    expect(rpcSpy).not.toHaveBeenCalled()
+  })
+
+  it('devuelve 401 si no hay usuario', async () => {
+    const { supabase, rpcSpy } = buildSupabase({ user: null })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    expect(res.status).toBe(401)
+    expect(rpcSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/analytics — shape de la respuesta', () => {
+  it('devuelve N períodos según granularidad (week=9, month=12, quarter=10, year=8)', async () => {
+    const expectedLengths: Record<string, number> = {
+      week: 9,
+      month: 12,
+      quarter: 10,
+      year: 8,
+    }
+
+    for (const [gran, expected] of Object.entries(expectedLengths)) {
+      const { supabase } = buildSupabase()
+      vi.mocked(createClient).mockResolvedValue(
+        supabase as unknown as Awaited<ReturnType<typeof createClient>>
+      )
+
+      const res = await GET(req({ gran }))
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.gran).toBe(gran)
+      expect(body.periods).toHaveLength(expected)
+    }
+  })
+
+  it('cada periodo tiene la forma documentada (label, fechas ISO, KPIs, byCategory, yoy*)', async () => {
+    const { supabase } = buildSupabase({
+      rpc: rpcByPeriod(
+        'month',
+        {
+          ingresos: 1000,
+          gastos: 750,
+          ahorro: 250,
+          by_category: [{ category: 'groceries', amount: -200 }],
+        },
+        {
+          ingresos: 800,
+          gastos: 600,
+          ahorro: 200,
+          by_category: [{ category: 'groceries', amount: -150 }],
+        }
+      ),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+
+    expect(body.periods).toHaveLength(12)
+    for (const p of body.periods) {
+      expect(p).toMatchObject({
+        label: expect.any(String),
+        start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        ingresos: 1000,
+        gastos: 750,
+        ahorro: 250,
+        yoyIngresos: 800,
+        yoyGastos: 600,
+      })
+      expect(p.byCategory).toEqual([{ category: 'groceries', amount: -200 }])
+    }
+
+    // El último periodo de la ventana debe ser el mes actual (mayo 2026)
+    const last = body.periods.at(-1)
+    expect(last.start).toBe('2026-05-01')
+    expect(last.end).toBe('2026-05-31')
+    expect(last.label).toBe('May')
+  })
+
+  it('llama a rpc("get_period_data", ...) dos veces por período (actual + YoY)', async () => {
+    const { supabase, rpcSpy } = buildSupabase()
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    await GET(req({ gran: 'month' }))
+    // 12 meses × 2 llamadas
+    expect(rpcSpy).toHaveBeenCalledTimes(24)
+    for (const [name, params] of rpcSpy.mock.calls) {
+      expect(name).toBe('get_period_data')
+      expect(params.p_user_id).toBe(USER_ID)
+      expect(params.p_start_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(params.p_end_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+  })
+})
+
+describe('GET /api/analytics — comparativa YoY (§5.7)', () => {
+  it('devuelve yoyIngresos/yoyGastos === null cuando el RPC del año anterior está vacío', async () => {
+    const { supabase } = buildSupabase({
+      rpc: rpcByPeriod(
+        'month',
+        { ingresos: 1000, gastos: 500, ahorro: 500, by_category: [] },
+        null
+      ),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+
+    for (const p of body.periods) {
+      expect(p.yoyIngresos).toBeNull()
+      expect(p.yoyGastos).toBeNull()
+    }
+  })
+
+  it('devuelve yoy* === null cuando el período anterior tiene ingresos=0 y gastos=0 (histórico insuficiente, no cero real)', async () => {
+    const { supabase } = buildSupabase({
+      rpc: rpcByPeriod(
+        'month',
+        { ingresos: 100, gastos: 50, ahorro: 50, by_category: [] },
+        { ingresos: 0, gastos: 0, ahorro: 0, by_category: [] }
+      ),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+    for (const p of body.periods) {
+      expect(p.yoyIngresos).toBeNull()
+      expect(p.yoyGastos).toBeNull()
+    }
+  })
+
+  it('devuelve los valores numéricos cuando hay histórico (al menos uno > 0)', async () => {
+    const { supabase } = buildSupabase({
+      rpc: rpcByPeriod(
+        'month',
+        { ingresos: 100, gastos: 50, ahorro: 50, by_category: [] },
+        { ingresos: 0, gastos: 200, ahorro: -200, by_category: [] }
+      ),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+    for (const p of body.periods) {
+      expect(p.yoyIngresos).toBe(0)
+      expect(p.yoyGastos).toBe(200)
+    }
+  })
+
+  it.todo(
+    'clasificación por categories.type: devolución de nómina (amount=-1500, type=income) suma a ingresos — bloqueado por #89 (RPC clasifica por signo)'
+  )
+})
+
+describe('GET /api/analytics — defensa frente a datos faltantes', () => {
+  it('si el RPC devuelve data vacío también en el período actual, los KPIs son 0 y byCategory []', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({ data: [], error: null }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+    for (const p of body.periods) {
+      expect(p.ingresos).toBe(0)
+      expect(p.gastos).toBe(0)
+      expect(p.ahorro).toBe(0)
+      expect(p.byCategory).toEqual([])
+      expect(p.yoyIngresos).toBeNull()
+      expect(p.yoyGastos).toBeNull()
+    }
+  })
+
+  it('si by_category llega null, se normaliza a []', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => ({
+        data: [
+          {
+            ingresos: 10,
+            gastos: 5,
+            ahorro: 5,
+            // @ts-expect-error – simulando respuesta del RPC con null
+            by_category: null,
+          },
+        ],
+        error: null,
+      }),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+    for (const p of body.periods) {
+      expect(p.byCategory).toEqual([])
+    }
+  })
+})
+
+describe('GET /api/analytics — errores', () => {
+  it('devuelve 500 "DB error" si el RPC lanza', async () => {
+    const { supabase } = buildSupabase({
+      rpc: async () => {
+        throw new Error('connection refused')
+      },
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    // Silenciar console.error para no contaminar la salida del test
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await GET(req({ gran: 'month' }))
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'DB error' })
+    errSpy.mockRestore()
+  })
+})

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PERIOD_LABELS,
+  getPeriodRange,
+  getWindowPeriods,
+  getYoYRange,
+  toISODate,
+  yoyDelta,
+  type PeriodRange,
+} from './analytics'
+
+// NOW = jueves 21 mayo 2026, 12:00 local. Suficientemente lejos de bordes
+// (semana lun 18 — dom 24, Q2, año 2026) para los casos felices.
+const NOW = new Date(2026, 4, 21, 12, 0, 0, 0)
+
+function setNow(d: Date) {
+  vi.setSystemTime(d)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('toISODate', () => {
+  it('formatea YYYY-MM-DD con padding de mes y día', () => {
+    expect(toISODate(new Date(2026, 0, 5))).toBe('2026-01-05')
+    expect(toISODate(new Date(2026, 8, 9))).toBe('2026-09-09')
+    expect(toISODate(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+
+  it('usa la fecha local (no UTC) — clave para evitar shift de timezone', () => {
+    // En zona +0200, new Date(2026, 0, 1, 23, ...) podría caer en 2026-01-02 si
+    // se serializara como ISO UTC. toISODate debe usar getFullYear/Month/Date.
+    expect(toISODate(new Date(2026, 0, 1, 23, 30, 0))).toBe('2026-01-01')
+  })
+})
+
+describe('yoyDelta', () => {
+  it('devuelve N/A cuando previous === 0', () => {
+    expect(yoyDelta(100, 0)).toBe('N/A')
+    expect(yoyDelta(0, 0)).toBe('N/A')
+    expect(yoyDelta(-50, 0)).toBe('N/A')
+  })
+
+  it('devuelve +X% si current crece sobre previous', () => {
+    expect(yoyDelta(150, 100)).toBe('+50%')
+    expect(yoyDelta(101, 100)).toBe('+1%')
+    expect(yoyDelta(200, 100)).toBe('+100%')
+  })
+
+  it('devuelve -X% si current cae respecto a previous', () => {
+    expect(yoyDelta(50, 100)).toBe('-50%')
+    expect(yoyDelta(0, 100)).toBe('-100%')
+  })
+
+  it('marca +0% (signo positivo) cuando current === previous', () => {
+    expect(yoyDelta(100, 100)).toBe('+0%')
+  })
+
+  it('redondea a 0 decimales', () => {
+    // (133-100)/100 = 33%
+    expect(yoyDelta(133, 100)).toBe('+33%')
+    // (134.7-100)/100 = 34.7%, toFixed(0) redondea a 35
+    expect(yoyDelta(134.7, 100)).toBe('+35%')
+  })
+})
+
+describe('getPeriodRange — week', () => {
+  it('devuelve lunes 00:00 a domingo 23:59:59.999 que contiene NOW', () => {
+    // NOW = jueves 21 mayo 2026 → semana 18–24 mayo
+    const r = getPeriodRange('week', 0)
+    expect(r.start.getFullYear()).toBe(2026)
+    expect(r.start.getMonth()).toBe(4)
+    expect(r.start.getDate()).toBe(18)
+    expect(r.start.getHours()).toBe(0)
+    expect(r.start.getMinutes()).toBe(0)
+    expect(r.end.getFullYear()).toBe(2026)
+    expect(r.end.getMonth()).toBe(4)
+    expect(r.end.getDate()).toBe(24)
+    expect(r.end.getHours()).toBe(23)
+    expect(r.end.getMinutes()).toBe(59)
+    expect(r.end.getSeconds()).toBe(59)
+    expect(r.label).toBe('18 May')
+  })
+
+  it('aplica el offset retrocediendo semanas completas', () => {
+    const r = getPeriodRange('week', 1)
+    // Semana anterior: 11–17 mayo 2026
+    expect(toISODate(r.start)).toBe('2026-05-11')
+    expect(toISODate(r.end)).toBe('2026-05-17')
+    expect(r.label).toBe('11 May')
+  })
+
+  it('cuando NOW cae en domingo, ese mismo domingo cierra la semana actual', () => {
+    // Domingo 24 mayo 2026
+    setNow(new Date(2026, 4, 24, 10, 0, 0))
+    const r = getPeriodRange('week', 0)
+    expect(toISODate(r.start)).toBe('2026-05-18')
+    expect(toISODate(r.end)).toBe('2026-05-24')
+  })
+
+  it('cuando NOW cae en lunes, la semana empieza ese día', () => {
+    setNow(new Date(2026, 4, 18, 8, 0, 0))
+    const r = getPeriodRange('week', 0)
+    expect(toISODate(r.start)).toBe('2026-05-18')
+    expect(toISODate(r.end)).toBe('2026-05-24')
+  })
+
+  it('cubre el cruce de año si la semana actual atraviesa diciembre/enero', () => {
+    // Viernes 1 enero 2027 → la semana ISO es lun 28 dic 2026 — dom 3 ene 2027
+    setNow(new Date(2027, 0, 1, 12, 0, 0))
+    const r = getPeriodRange('week', 0)
+    expect(toISODate(r.start)).toBe('2026-12-28')
+    expect(toISODate(r.end)).toBe('2027-01-03')
+  })
+})
+
+describe('getPeriodRange — month', () => {
+  it('devuelve el mes que contiene NOW, del 1 al último día', () => {
+    const r = getPeriodRange('month', 0)
+    expect(toISODate(r.start)).toBe('2026-05-01')
+    expect(toISODate(r.end)).toBe('2026-05-31')
+    expect(r.label).toBe('May')
+  })
+
+  it('aplica offset retrocediendo meses', () => {
+    const r = getPeriodRange('month', 1)
+    expect(toISODate(r.start)).toBe('2026-04-01')
+    expect(toISODate(r.end)).toBe('2026-04-30')
+    expect(r.label).toBe('Abr')
+  })
+
+  it('cruza año al retroceder lo suficiente', () => {
+    // NOW mayo 2026 (mes idx 4). Offset 5 → diciembre 2025.
+    const r = getPeriodRange('month', 5)
+    expect(toISODate(r.start)).toBe('2025-12-01')
+    expect(toISODate(r.end)).toBe('2025-12-31')
+    expect(r.label).toBe('Dic')
+  })
+
+  it('respeta el último día de un mes corto (febrero, abril)', () => {
+    // Febrero 2026 (no bisiesto) → 28 días
+    setNow(new Date(2026, 1, 15, 12, 0, 0))
+    const feb = getPeriodRange('month', 0)
+    expect(toISODate(feb.start)).toBe('2026-02-01')
+    expect(toISODate(feb.end)).toBe('2026-02-28')
+
+    // Abril → 30 días
+    setNow(new Date(2026, 3, 10, 12, 0, 0))
+    const abr = getPeriodRange('month', 0)
+    expect(toISODate(abr.end)).toBe('2026-04-30')
+  })
+
+  it('respeta febrero bisiesto (2028 es bisiesto)', () => {
+    setNow(new Date(2028, 1, 15, 12, 0, 0))
+    const r = getPeriodRange('month', 0)
+    expect(toISODate(r.end)).toBe('2028-02-29')
+  })
+})
+
+describe('getPeriodRange — quarter', () => {
+  it('devuelve el trimestre que contiene NOW', () => {
+    // NOW mayo (Q2) → abril–junio 2026
+    const r = getPeriodRange('quarter', 0)
+    expect(toISODate(r.start)).toBe('2026-04-01')
+    expect(toISODate(r.end)).toBe('2026-06-30')
+    expect(r.label).toBe('Q2 2026')
+  })
+
+  it('cubre Q1 cuando NOW es enero', () => {
+    setNow(new Date(2026, 0, 15, 12, 0, 0))
+    const r = getPeriodRange('quarter', 0)
+    expect(toISODate(r.start)).toBe('2026-01-01')
+    expect(toISODate(r.end)).toBe('2026-03-31')
+    expect(r.label).toBe('Q1 2026')
+  })
+
+  it('cubre Q4 cuando NOW es diciembre', () => {
+    setNow(new Date(2026, 11, 20, 12, 0, 0))
+    const r = getPeriodRange('quarter', 0)
+    expect(toISODate(r.start)).toBe('2026-10-01')
+    expect(toISODate(r.end)).toBe('2026-12-31')
+    expect(r.label).toBe('Q4 2026')
+  })
+
+  it('cruza año al retroceder trimestres', () => {
+    // NOW Q2 2026, offset 2 → Q4 2025
+    const r = getPeriodRange('quarter', 2)
+    expect(toISODate(r.start)).toBe('2025-10-01')
+    expect(toISODate(r.end)).toBe('2025-12-31')
+    expect(r.label).toBe('Q4 2025')
+  })
+})
+
+describe('getPeriodRange — year', () => {
+  it('devuelve 1 ene a 31 dic del año actual', () => {
+    const r = getPeriodRange('year', 0)
+    expect(toISODate(r.start)).toBe('2026-01-01')
+    expect(toISODate(r.end)).toBe('2026-12-31')
+    expect(r.label).toBe('2026')
+  })
+
+  it('aplica offset retrocediendo años', () => {
+    const r = getPeriodRange('year', 3)
+    expect(toISODate(r.start)).toBe('2023-01-01')
+    expect(toISODate(r.end)).toBe('2023-12-31')
+    expect(r.label).toBe('2023')
+  })
+})
+
+describe('getWindowPeriods', () => {
+  it('devuelve la longitud correcta por granularidad (§5.1)', () => {
+    expect(getWindowPeriods('week', 0)).toHaveLength(9)
+    expect(getWindowPeriods('month', 0)).toHaveLength(12)
+    expect(getWindowPeriods('quarter', 0)).toHaveLength(10)
+    expect(getWindowPeriods('year', 0)).toHaveLength(8)
+  })
+
+  it('ordena del más antiguo al más reciente; el último elemento es el período actual', () => {
+    const w = getWindowPeriods('month', 0)
+    // último = mes actual
+    expect(toISODate(w[w.length - 1].start)).toBe('2026-05-01')
+    // primero = 11 meses antes (mayo 2025)
+    expect(toISODate(w[0].start)).toBe('2025-06-01')
+    // monotonía estricta
+    for (let i = 1; i < w.length; i++) {
+      expect(w[i].start.getTime()).toBeGreaterThan(w[i - 1].start.getTime())
+    }
+  })
+
+  it('aplica offset desplazando la ventana entera hacia atrás', () => {
+    const w = getWindowPeriods('month', 3)
+    // Último elemento = mes actual - 3 = febrero 2026
+    expect(toISODate(w[w.length - 1].start)).toBe('2026-02-01')
+    // Primero = 11 meses antes = marzo 2025
+    expect(toISODate(w[0].start)).toBe('2025-03-01')
+  })
+})
+
+describe('getYoYRange', () => {
+  it('resta un año a ambos extremos del rango y preserva el label', () => {
+    const current: PeriodRange = {
+      start: new Date(2026, 4, 1),
+      end: new Date(2026, 4, 31, 23, 59, 59, 999),
+      label: 'May',
+    }
+    const yoy = getYoYRange(current)
+    expect(toISODate(yoy.start)).toBe('2025-05-01')
+    expect(toISODate(yoy.end)).toBe('2025-05-31')
+    expect(yoy.label).toBe('May')
+  })
+
+  it('no muta el rango de entrada', () => {
+    const current: PeriodRange = {
+      start: new Date(2026, 4, 1),
+      end: new Date(2026, 4, 31),
+      label: 'May',
+    }
+    getYoYRange(current)
+    expect(current.start.getFullYear()).toBe(2026)
+    expect(current.end.getFullYear()).toBe(2026)
+  })
+
+  it('caso 29-feb: restar un año a un febrero bisiesto cae en 1 marzo del año anterior (comportamiento nativo de setFullYear)', () => {
+    const current: PeriodRange = {
+      start: new Date(2028, 1, 29),
+      end: new Date(2028, 1, 29, 23, 59, 59, 999),
+      label: '29 Feb',
+    }
+    const yoy = getYoYRange(current)
+    // 2027 no es bisiesto → setFullYear desborda a 1 marzo
+    expect(toISODate(yoy.start)).toBe('2027-03-01')
+  })
+})
+
+describe('PERIOD_LABELS', () => {
+  it('expone una etiqueta legible para cada granularidad', () => {
+    expect(PERIOD_LABELS).toEqual({
+      week: 'Semana',
+      month: 'Mes',
+      quarter: 'Trimestre',
+      year: 'Año',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Tests puros de `lib/analytics.ts` (30 casos): `toISODate`, `yoyDelta`, `getPeriodRange` por las 4 granularidades con bordes (lunes/domingo, cruce de año en semana y mes, febrero bisiesto), `getWindowPeriods` con orden cronológico y offset, `getYoYRange` preservando label (caso 29-feb).
- Tests del handler `GET /api/analytics` (16 casos + 1 todo): validación de `gran`/`offset`, auth, shape, comparativa YoY con `null` cuando hay histórico insuficiente (§5.7), defensa frente a `data` vacío o `by_category` null, error de RPC → 500.
- Tests del handler `GET /api/analytics/categoria` (18 casos): validación, ventana reducida a 6 períodos, drilldown con valor absoluto, categoría sin datos, las 4 granularidades, error de RPC.

Mocks de Supabase con el patrón de [app/api/edenred/route.test.ts](app/api/edenred/route.test.ts) (`vi.mock('@/lib/supabase/server')` + dynamic import). Tiempo congelado con `vi.useFakeTimers()` + `vi.setSystemTime(NOW)` (mismo patrón que [lib/accounts.test.ts](lib/accounts.test.ts)). `NOW` se fija a jueves 21-mayo-2026 para evitar bordes ambiguos; los tests de cruce de año re-setean el reloj a fechas concretas.

## Hallazgo importante

El RPC `get_period_data` clasifica ingresos/gastos por **signo del `amount`**, no por `categories.type` como exige spec §13 nota 10 / §5.4. Una devolución de nómina (`amount<0`, `type='income'`) se contabiliza hoy como gasto.

El caso de la spec queda como `it.todo(...)` en `app/api/analytics/route.test.ts` referenciando **#89** ([bug] get_period_data), donde se arreglará el RPC y se convertirá en test real.

De paso, al revisar cobertura del repo abrí issues para otros módulos críticos sin tests: **#90** (`fmt`), **#91** (`groupTxByDate`), **#92** (`AUTO_RULES`), **#93** (sync cooldown), **#94** (patrimonio neto).

## Test plan

- [x] `pnpm test` → 87 passed | 1 todo
- [x] `pnpm lint` → sin errores
- [x] `pnpm build` → sin errores
- [x] Cobertura de criterios de aceptación de #80:
  - [x] Granularidades (semana, mes, trimestre, año) con bordes
  - [x] Comparativa con período anterior (deltas, `yoyDelta`)
  - [x] YoY con histórico insuficiente devuelve `null`, no `0` (§5.7)
  - [~] Clasificación por `type` — `it.todo` + #89
  - [x] Drilldown por categoría

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
