### PR TITLE
test(analytics): test de regresión para devolución de nómina (#89)

### DIFF
--- a/app/api/analytics/route.test.ts
+++ b/app/api/analytics/route.test.ts
@@ -311,9 +311,39 @@ describe('GET /api/analytics — comparativa YoY (§5.7)', () => {
     }
   })
 
-  it.todo(
-    'clasificación por categories.type: devolución de nómina (amount=-1500, type=income) suma a ingresos — bloqueado por #89 (RPC clasifica por signo)'
-  )
+  it('clasificación por categories.type (§13 nota 10): una devolución de nómina (amount=-1500, type=income) suma a ingresos, no a gastos', async () => {
+    // El RPC v2 (post-#63) clasifica por `categories.type`, no por signo del amount.
+    // Para una devolución de nómina (única transacción del período, amount=-1500,
+    // categoría con type='income') devuelve ingresos=-1500 / gastos=0 / ahorro=-1500
+    // y by_category con el amount negativo preservado. Este test es el guardián
+    // del contrato: si el route o alguna capa intermedia reintrodujese lógica
+    // basada en el signo (ingresos = solo amount > 0), aquí saltaría.
+    const { supabase } = buildSupabase({
+      rpc: rpcByPeriod(
+        'month',
+        {
+          ingresos: -1500,
+          gastos: 0,
+          ahorro: -1500,
+          by_category: [{ category: 'salary', amount: -1500 }],
+        },
+        null
+      ),
+    })
+    vi.mocked(createClient).mockResolvedValue(
+      supabase as unknown as Awaited<ReturnType<typeof createClient>>
+    )
+
+    const res = await GET(req({ gran: 'month' }))
+    const body = await res.json()
+
+    for (const p of body.periods) {
+      expect(p.ingresos).toBe(-1500)
+      expect(p.gastos).toBe(0)
+      expect(p.ahorro).toBe(-1500)
+      expect(p.byCategory).toEqual([{ category: 'salary', amount: -1500 }])
+    }
+  })
 })
 
 describe('GET /api/analytics — defensa frente a datos faltantes', () => {


### PR DESCRIPTION
Closes #89

## Resumen

Convierte el `it.todo` de "devolución de nómina" en [app/api/analytics/route.test.ts](app/api/analytics/route.test.ts) en un test de regresión real, ahora que el fix SQL ya está aplicado en la migración [20260516000000_drop_is_computable_and_internal_transfer.sql](supabase/migrations/20260516000000_drop_is_computable_and_internal_transfer.sql) (refactor #63), que dropea y recrea `get_period_data` clasificando por `categories.type` con `LEFT JOIN categories`.

## Por qué este test (y no una migración nueva)

Re-evaluando #89 durante la planificación:

- El bug SQL (clasificar por signo del `amount`) **ya está resuelto** a nivel de migración desde #63. No hace falta una nueva migración.
- Los "tests de integración SQL" que pedía el alcance original requerirían montar infraestructura inexistente en el repo (Supabase local, pgTAP). Quedan fuera de alcance.
- Lo único que faltaba era desbloquear el placeholder `it.todo` que documentaba el bug.

## El test

Simula lo que devuelve el RPC v2 (post-#63) ante una devolución de nómina (única transacción del período, `amount=-1500€`, categoría con `type='income'`):

- `ingresos: -1500`, `gastos: 0`, `ahorro: -1500`
- `by_category: [{ category: 'salary', amount: -1500 }]`

y verifica que el route handler los propaga sin reinterpretar signos. Si alguien reintrodujese lógica de "ingresos = sólo `amount > 0`" en el route handler o en alguna capa intermedia, este test la pillaría.

Referencia: spec §13 nota 10 («El signo del `amount` nunca se usa para clasificar tipo, sólo para presentación visual»).

## Test plan

- [x] `pnpm test` — 88/88 verde
- [x] `pnpm lint` — limpio
- [x] `pnpm build` — compila sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
