### PR TITLE
feat(accounts): cablear "Ver movimientos" de AccountCard (#88)

### DIFF
--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -5,15 +5,24 @@ import { MovimientosClient } from '@/components/transactions/MovimientosClient'
 import { MovimientosSkeleton } from '@/components/transactions/MovimientosSkeleton'
 import type { TransactionWithAccount } from '@/types'
 
-export default function MovimientosPage() {
+export default function MovimientosPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cuenta?: string }>
+}) {
   return (
     <Suspense fallback={<MovimientosSkeleton />}>
-      <MovimientosContent />
+      <MovimientosContent searchParams={searchParams} />
     </Suspense>
   )
 }
 
-async function MovimientosContent() {
+async function MovimientosContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ cuenta?: string }>
+}) {
+  const { cuenta } = await searchParams
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
@@ -56,11 +65,16 @@ async function MovimientosContent() {
     manualAccountId = created?.id
   }
 
+  const accountsList = accounts ?? []
+  const initialAccountIds =
+    cuenta && accountsList.some(a => a.id === cuenta) ? [cuenta] : []
+
   return (
     <MovimientosClient
       initialTransactions={(transactions ?? []) as TransactionWithAccount[]}
-      accounts={accounts ?? []}
+      accounts={accountsList}
       manualAccountId={manualAccountId ?? ''}
+      initialAccountIds={initialAccountIds}
     />
   )
 }

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
 import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
@@ -115,12 +116,13 @@ export function AccountCard({ account }: { account: Account }) {
             {account.balance !== null ? `${fmt(account.balance, 2)} €` : '—'}
           </div>
         </div>
-        <div
+        <Link
+          href={`/movimientos?cuenta=${account.id}`}
           className="text-xs font-semibold px-3 py-1.5 rounded-[10px]"
           style={{ background: '#6366f115', color: '#6366f1' }}
         >
           Ver movimientos
-        </div>
+        </Link>
       </div>
 
       <div className="mt-3.5 pt-3.5 border-t border-border flex items-center justify-between gap-2">

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
 import { CategoryPicker } from './CategoryPicker'
@@ -17,11 +17,22 @@ interface MovimientosClientProps {
   initialTransactions: TransactionWithAccount[]
   accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
   manualAccountId: string
+  initialAccountIds?: string[]
 }
 
-export function MovimientosClient({ initialTransactions, accounts, manualAccountId }: MovimientosClientProps) {
+export function MovimientosClient({ initialTransactions, accounts, manualAccountId, initialAccountIds }: MovimientosClientProps) {
   const { transactions, addTx, deleteTx, recategorize } = useTxMutations(initialTransactions)
-  const filters = useMovimientosFilters(transactions)
+  const filters = useMovimientosFilters(transactions, initialAccountIds)
+
+  // `?cuenta=` solo actúa como deep-link de entrada: lo consumimos en el server
+  // para inicializar el filtro y aquí limpiamos la URL para evitar que mienta
+  // cuando el usuario cambia el filtro desde el selector. `replaceState` no
+  // dispara navegación de Next, solo reescribe la URL del browser.
+  useEffect(() => {
+    if (initialAccountIds && initialAccountIds.length > 0) {
+      window.history.replaceState(null, '', '/movimientos')
+    }
+  }, [initialAccountIds])
 
   const [showAccountFilter, setShowAccountFilter] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)

--- a/components/transactions/useMovimientosFilters.ts
+++ b/components/transactions/useMovimientosFilters.ts
@@ -13,10 +13,13 @@ export const TYPE_PILLS: { key: TypeFilter; label: string }[] = [
   { key: 'no-computable', label: 'No Computable' },
 ]
 
-export function useMovimientosFilters(transactions: TransactionWithAccount[]) {
+export function useMovimientosFilters(
+  transactions: TransactionWithAccount[],
+  initialAccountIds: string[] = []
+) {
   const [searchQuery, setSearchQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos')
-  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>(initialAccountIds)
 
   const filtered = useMemo(() => {
     let result = transactions


### PR DESCRIPTION
Closes #88

## Resumen

- `AccountCard` convierte el `<div>` decorativo "Ver movimientos" en un `<Link href="/movimientos?cuenta=<id>">`, sin cambios visuales.
- `app/(app)/movimientos/page.tsx` lee `?cuenta=<id>` (server, `searchParams` como `Promise` en Next 16) y, después de cargar las cuentas activas del usuario, valida que el id pertenezca a la lista antes de inicializar `selectedAccountIds`. Si no matchea o no viene, no se aplica filtro.
- `useMovimientosFilters` acepta un segundo parámetro `initialAccountIds: string[] = []` que se usa como valor inicial del `useState`. Backwards-compatible.
- `MovimientosClient` recibe `initialAccountIds?` y lo propaga al hook. Además, tras el primer render con deep-link, limpia el query param con `window.history.replaceState('/movimientos')` para evitar que la URL mienta cuando el usuario cambia el filtro desde el selector (decisión de UX: `?cuenta=` actúa como deep-link de entrada, no de salida).

## Test plan

- [x] `pnpm test` → 88/88
- [x] `pnpm lint` → limpio
- [x] `pnpm build` → compila
- [ ] Manual: `/cuentas` → click "Ver movimientos" en una card → `/movimientos` con esa cuenta filtrada y URL limpia.
- [ ] Manual: cambiar el filtro desde el selector → el filtro se actualiza con normalidad (URL ya estaba limpia).
- [ ] Manual: `/movimientos?cuenta=xxxxx-invalido` → lista completa, sin error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
