### PR TITLE
test(transactions): unit tests de groupTxByDate y formatDayLabel

### DIFF
--- a/lib/transactions.test.ts
+++ b/lib/transactions.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatDayLabel, groupTxByDate } from './transactions'
+import type { TransactionWithAccount } from '@/types'
+
+const ORIG_TZ = process.env.TZ
+
+beforeAll(() => {
+  process.env.TZ = 'Europe/Madrid'
+})
+
+afterAll(() => {
+  process.env.TZ = ORIG_TZ
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+let nextId = 0
+function tx(over: Partial<TransactionWithAccount> = {}): TransactionWithAccount {
+  nextId += 1
+  return {
+    id: `tx-${nextId}`,
+    user_id: 'user-1',
+    account_id: 'acc-1',
+    date: '2026-05-21',
+    amount: 0,
+    description: 'Movimiento',
+    category: null,
+    category_manual: null,
+    source: 'manual',
+    external_id: null,
+    notes: null,
+    created_at: '2026-05-21T12:00:00.000Z',
+    account: { id: 'acc-1', name: 'Cuenta', color: null },
+    ...over,
+  }
+}
+
+describe('groupTxByDate', () => {
+  it('devuelve lista vacía cuando no hay transacciones', () => {
+    expect(groupTxByDate([])).toEqual([])
+  })
+
+  it('agrupa una única transacción con net = amount', () => {
+    const t = tx({ date: '2026-05-21', amount: 42.5 })
+    const result = groupTxByDate([t])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({ date: '2026-05-21', transactions: [t], net: 42.5 })
+  })
+
+  it('agrupa varias transacciones del mismo día sumando el neto', () => {
+    const a = tx({ date: '2026-05-21', amount: 100 })
+    const b = tx({ date: '2026-05-21', amount: -30 })
+    const c = tx({ date: '2026-05-21', amount: -10.5 })
+    const result = groupTxByDate([a, b, c])
+    expect(result).toHaveLength(1)
+    expect(result[0].date).toBe('2026-05-21')
+    expect(result[0].transactions).toEqual([a, b, c])
+    expect(result[0].net).toBeCloseTo(59.5, 2)
+  })
+
+  it('ordena los grupos por fecha descendente aunque la entrada no esté ordenada', () => {
+    const t1 = tx({ date: '2026-05-19', amount: 1 })
+    const t2 = tx({ date: '2026-05-21', amount: 2 })
+    const t3 = tx({ date: '2026-05-20', amount: 3 })
+    const result = groupTxByDate([t1, t2, t3])
+    expect(result.map(g => g.date)).toEqual(['2026-05-21', '2026-05-20', '2026-05-19'])
+  })
+
+  it('mantiene un único grupo aunque el día aparezca intercalado en la entrada', () => {
+    const a = tx({ date: '2026-05-21', amount: 10 })
+    const b = tx({ date: '2026-05-20', amount: 5 })
+    const c = tx({ date: '2026-05-21', amount: 20 })
+    const result = groupTxByDate([a, b, c])
+    expect(result).toHaveLength(2)
+    const may21 = result.find(g => g.date === '2026-05-21')!
+    expect(may21.transactions).toEqual([a, c])
+    expect(may21.net).toBe(30)
+  })
+})
+
+describe('formatDayLabel', () => {
+  it('devuelve "Hoy" cuando la fecha es la del sistema (mediodía local)', () => {
+    vi.setSystemTime(new Date('2026-05-21T12:00:00+02:00'))
+    expect(formatDayLabel('2026-05-21')).toBe('Hoy')
+  })
+
+  it('devuelve "Ayer" para el día anterior', () => {
+    vi.setSystemTime(new Date('2026-05-21T12:00:00+02:00'))
+    expect(formatDayLabel('2026-05-20')).toBe('Ayer')
+  })
+
+  it('devuelve fecha absoluta en español para fechas de hace 2+ días', () => {
+    vi.setSystemTime(new Date('2026-05-21T12:00:00+02:00'))
+    expect(formatDayLabel('2026-05-19')).toBe('19 May 2026')
+    expect(formatDayLabel('2025-12-31')).toBe('31 Dic 2025')
+    expect(formatDayLabel('2024-01-05')).toBe('5 Ene 2024')
+  })
+
+  it('usa hora local, no UTC, en el cruce de día (00:00 local en Europe/Madrid)', () => {
+    // 23:30 UTC del 21-may = 01:30 hora local del 22-may en CEST (UTC+2).
+    // Con el cálculo en UTC, "hoy" sería 21-may y el test fallaría: ése era el bug.
+    vi.setSystemTime(new Date('2026-05-21T23:30:00.000Z'))
+    expect(formatDayLabel('2026-05-22')).toBe('Hoy')
+    expect(formatDayLabel('2026-05-21')).toBe('Ayer')
+    expect(formatDayLabel('2026-05-20')).toBe('20 May 2026')
+  })
+})

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -22,11 +22,15 @@ export function groupTxByDate(txs: TransactionWithAccount[]): TxDayGroup[] {
 
 const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
 
+const toLocalISODate = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
 export function formatDayLabel(dateStr: string): string {
-  const today = new Date().toISOString().slice(0, 10)
-  const yest = new Date()
+  const now = new Date()
+  const today = toLocalISODate(now)
+  const yest = new Date(now)
   yest.setDate(yest.getDate() - 1)
-  const yesterdayStr = yest.toISOString().slice(0, 10)
+  const yesterdayStr = toLocalISODate(yest)
   if (dateStr === today) return 'Hoy'
   if (dateStr === yesterdayStr) return 'Ayer'
   const [y, m, d] = dateStr.split('-').map(Number)


### PR DESCRIPTION
## Resumen

Closes #91.

Añade `lib/transactions.test.ts` con cobertura de las dos funciones puras que alimentan la pantalla de Movimientos:

### `groupTxByDate`
- Lista vacía.
- Una sola transacción (net = amount).
- Múltiples transacciones del mismo día (net suma con signos, orden de inserción preservado).
- Días distintos desordenados → grupos en orden cronológico descendente.
- Mismo día intercalado en la entrada → un único grupo.

### `formatDayLabel`
- `"Hoy"`, `"Ayer"` y formato absoluto `"D MMM YYYY"` en español (verifica enero, mayo y diciembre del array `MONTHS`).
- **Caso de cruce de día en hora local** (`Europe/Madrid`, 01:30 CEST = 23:30 UTC del día anterior).

## Bug de timezone arreglado

El test del cruce de día destapó el bug que la propia issue mencionaba: `formatDayLabel` usaba `new Date().toISOString().slice(0, 10)`, que devuelve la fecha en **UTC**. En Madrid (UTC+1/+2), entre las 22:00 y 00:00 hora local la fecha UTC ya pertenece al día siguiente, así que las etiquetas `"Hoy"` y `"Ayer"` se corrían un día durante ese rango.

Sustituido por un helper que extrae componentes locales (`getFullYear`/`getMonth`/`getDate`). Sin cambios de firma ni de imports.

## Determinismo en CI

El test fija `process.env.TZ = 'Europe/Madrid'` en `beforeAll` y restaura el valor original en `afterAll`, así el caso de cruce de día no depende de la zona horaria del runner.

## Test plan

- [x] `pnpm test lib/transactions.test.ts` → 9/9 verde
- [x] `pnpm test` (suite completa) → verde
- [x] `pnpm lint` → verde
- [x] `pnpm build` → verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)