### PR TITLE
test(dashboard): cubre cálculo de patrimonio neto con tests unitarios

### DIFF
--- a/lib/dashboard.test.ts
+++ b/lib/dashboard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { calculateNetWorth } from './dashboard'
+import type { Account } from '@/types'
+
+type AccountSlice = Pick<Account, 'is_liability' | 'balance'>
+
+function asset(balance: number): AccountSlice {
+  return { is_liability: false, balance }
+}
+
+function liability(balance: number): AccountSlice {
+  return { is_liability: true, balance }
+}
+
+describe('calculateNetWorth', () => {
+  it('devuelve 0 con una lista vacía', () => {
+    expect(calculateNetWorth([])).toBe(0)
+  })
+
+  it('suma los saldos cuando solo hay activos', () => {
+    expect(calculateNetWorth([asset(1000), asset(500)])).toBe(1500)
+  })
+
+  it('resta el valor absoluto de un pasivo con saldo negativo', () => {
+    expect(calculateNetWorth([liability(-200)])).toBe(-200)
+  })
+
+  // Contrato actual: Math.abs() sobre la suma de pasivos hace que un crédito
+  // a favor aislado en un pasivo también reste del patrimonio. Documentado en
+  // spec §5.5; si en el futuro se considera incorrecto se abre issue aparte.
+  it('aplica Math.abs también cuando el único pasivo tiene saldo positivo', () => {
+    expect(calculateNetWorth([liability(50)])).toBe(-50)
+  })
+
+  it('mezcla activos y pasivos: activos − |Σ pasivos|', () => {
+    expect(calculateNetWorth([asset(1000), asset(500), liability(-200)])).toBe(1300)
+  })
+
+  it('un activo en descubierto resta del lado activo, no se mueve a pasivos', () => {
+    expect(calculateNetWorth([asset(1000), asset(-150), liability(-200)])).toBe(650)
+  })
+
+  it('un crédito a favor en una tarjeta reduce la deuda total ("resta menos")', () => {
+    // Σ pasivos = -200 + 50 = -150 → |-150| = 150 → 1000 - 150 = 850.
+    // Comparado con sólo liability(-200) (que restaría 200), el crédito
+    // hace que el patrimonio quede en 850 en lugar de 800.
+    expect(calculateNetWorth([asset(1000), liability(-200), liability(50)])).toBe(850)
+  })
+
+  it('caso mixto: activo en descubierto + pasivo con crédito a favor', () => {
+    // assets = 1000 + (-150) = 850
+    // Σ pasivos = -200 + 50 = -150 → |.| = 150
+    // patrimonio = 850 - 150 = 700
+    expect(
+      calculateNetWorth([asset(1000), asset(-150), liability(-200), liability(50)])
+    ).toBe(700)
+  })
+})

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -10,6 +10,15 @@ export interface DashboardData {
   annualDelta: number | null
 }
 
+// Patrimonio neto = activos − |Σ pasivos|. Ver spec §5.5.
+export function calculateNetWorth(
+  accounts: Pick<Account, 'is_liability' | 'balance'>[]
+): number {
+  const assets = accounts.filter(a => !a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
+  const liabs  = accounts.filter(a =>  a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
+  return assets - Math.abs(liabs)
+}
+
 export async function getDashboardData(): Promise<DashboardData> {
   const supabase = await createClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -24,9 +33,7 @@ export async function getDashboardData(): Promise<DashboardData> {
 
   if (accError || !accounts) throw new Error('Failed to fetch accounts')
 
-  const assets = accounts.filter(a => !a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
-  const liabs  = accounts.filter(a =>  a.is_liability).reduce((s, a) => s + (a.balance ?? 0), 0)
-  const balance = assets - Math.abs(liabs)
+  const balance = calculateNetWorth(accounts)
 
   const thirtyDaysAgo = new Date()
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 29)


### PR DESCRIPTION
## Resumen

Cierra #94 cubriendo con tests unitarios la fórmula del patrimonio neto del headline del Dashboard.

Para poder testearla de forma aislada (sin mockear Supabase, en línea con la convención del resto de `lib/*.test.ts`), se **extrae** la fórmula `assets − |Σ pasivos|` de `getDashboardData` a un helper puro exportado:

```ts
export function calculateNetWorth(
  accounts: Pick<Account, 'is_liability' | 'balance'>[]
): number
```

El contrato no cambia: `getDashboardData` ahora llama a `calculateNetWorth(accounts)` y devuelve exactamente el mismo número que antes. La fórmula coincide con la documentada en spec §5.5.

## Casos cubiertos (`lib/dashboard.test.ts`)

1. Lista vacía → `0`
2. Solo activos → suma de saldos
3. Solo pasivo con saldo negativo → resta el valor absoluto
4. Solo pasivo con saldo positivo → documenta el efecto de `Math.abs` aplicado a la suma (un crédito aislado en un pasivo resta del patrimonio según el contrato actual)
5. Mezcla activos + pasivos → `activos − |Σ pasivos|`
6. Activo en descubierto → resta del lado activo, no migra a pasivos
7. Pasivo con crédito a favor → "resta menos" del patrimonio
8. **Caso mixto** (activo en descubierto + pasivo con crédito a favor) — criterio de aceptación explícito de la issue

## Test plan

- [x] `pnpm test` → 209/209 verde
- [x] `pnpm lint` → sin avisos
- [x] `pnpm build` → compila

🤖 Generated with [Claude Code](https://claude.com/claude-code)