### PR TITLE
feat(movimientos): paginación cursor por (date, id)

### DIFF
--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -3,7 +3,10 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { MovimientosClient } from '@/components/transactions/MovimientosClient'
 import { MovimientosSkeleton } from '@/components/transactions/MovimientosSkeleton'
+import { buildNextCursor } from '@/lib/pagination'
 import type { TransactionWithAccount } from '@/types'
+
+const INITIAL_PAGE_SIZE = 200
 
 export default function MovimientosPage({
   searchParams,
@@ -37,9 +40,8 @@ async function MovimientosContent({
       .select('*, account:accounts(id, name, color)')
       .gte('date', cutoffStr)
       .order('date', { ascending: false })
-      .order('created_at', { ascending: false })
       .order('id', { ascending: false })
-      .limit(200),
+      .limit(INITIAL_PAGE_SIZE),
     supabase
       .from('accounts')
       .select('id, name, color, number')
@@ -69,9 +71,13 @@ async function MovimientosContent({
   const initialAccountIds =
     cuenta && accountsList.some(a => a.id === cuenta) ? [cuenta] : []
 
+  const initialTransactions = (transactions ?? []) as TransactionWithAccount[]
+  const initialCursor = buildNextCursor(initialTransactions, INITIAL_PAGE_SIZE)
+
   return (
     <MovimientosClient
-      initialTransactions={(transactions ?? []) as TransactionWithAccount[]}
+      initialTransactions={initialTransactions}
+      initialCursor={initialCursor}
       accounts={accountsList}
       manualAccountId={manualAccountId ?? ''}
       initialAccountIds={initialAccountIds}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -50,23 +50,33 @@ export async function GET(request: NextRequest) {
   const dateFrom = searchParams.get('dateFrom')
   const dateTo   = searchParams.get('dateTo')
   const limit = Math.min(Number(searchParams.get('limit') ?? '200'), 500)
+  const beforeDate = searchParams.get('before_date')
+  const beforeId   = searchParams.get('before_id')
+  const hasCursor  = !!(beforeDate && beforeId)
 
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - 90)
   const cutoffStr = cutoff.toISOString().slice(0, 10)
 
+  // Pedimos limit + 1 para distinguir "exactamente limit ítems quedan" de "hay más".
   let query = supabase
     .from('transactions')
     .select('*, account:accounts(id, name, color)')
     .eq('user_id', user.id)
     .order('date', { ascending: false })
-    .order('created_at', { ascending: false })
     .order('id', { ascending: false })
-    .limit(limit)
+    .limit(limit + 1)
 
-  if (dateFrom) query = query.gte('date', dateFrom)
-  else          query = query.gte('date', cutoffStr)
-  if (dateTo)   query = query.lte('date', dateTo)
+  if (dateFrom)        query = query.gte('date', dateFrom)
+  else if (!hasCursor) query = query.gte('date', cutoffStr)
+  if (dateTo)          query = query.lte('date', dateTo)
+
+  if (hasCursor) {
+    // Keyset: (date, id) DESC → traer items "después" del cursor.
+    query = query.or(
+      `date.lt.${beforeDate},and(date.eq.${beforeDate},id.lt.${beforeId})`
+    )
+  }
 
   if (accountsParam) {
     const ids = accountsParam.split(',').filter(Boolean)
@@ -86,5 +96,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 
-  return NextResponse.json({ data: data ?? [], meta: { count: data?.length ?? 0 } })
+  const raw = data ?? []
+  const hasMore = raw.length > limit
+  const items = hasMore ? raw.slice(0, limit) : raw
+  const last = items[items.length - 1]
+  const nextCursor = hasMore && last
+    ? { date: last.date as string, id: last.id as string }
+    : null
+
+  return NextResponse.json({
+    data: items,
+    meta: { count: items.length, nextCursor },
+  })
 }

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -10,18 +10,22 @@ import { MovimientosList } from './MovimientosList'
 import { AddTxFab } from './AddTxFab'
 import { useMovimientosFilters } from './useMovimientosFilters'
 import { useTxMutations } from './useTxMutations'
+import { useTxPagination } from './useTxPagination'
 import { groupTxByDate } from '@/lib/transactions'
+import type { TransactionCursor } from '@/lib/pagination'
 import type { Account, TransactionWithAccount } from '@/types'
 
 interface MovimientosClientProps {
   initialTransactions: TransactionWithAccount[]
+  initialCursor: TransactionCursor | null
   accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
   manualAccountId: string
   initialAccountIds?: string[]
 }
 
-export function MovimientosClient({ initialTransactions, accounts, manualAccountId, initialAccountIds }: MovimientosClientProps) {
-  const { transactions, addTx, deleteTx, recategorize } = useTxMutations(initialTransactions)
+export function MovimientosClient({ initialTransactions, initialCursor, accounts, manualAccountId, initialAccountIds }: MovimientosClientProps) {
+  const { transactions, addTx, appendTxs, deleteTx, recategorize } = useTxMutations(initialTransactions)
+  const pagination = useTxPagination({ initialCursor, appendTxs })
   const filters = useMovimientosFilters(transactions, initialAccountIds)
 
   // `?cuenta=` solo actúa como deep-link de entrada: lo consumimos en el server
@@ -78,6 +82,10 @@ export function MovimientosClient({ initialTransactions, accounts, manualAccount
         onSwipe={setSwipedTxId}
         onRecategorize={handleRecategorize}
         onTap={handleTxTap}
+        onLoadMore={pagination.loadMore}
+        hasMore={pagination.hasMore}
+        loadingMore={pagination.loading}
+        loadMoreError={pagination.error}
       />
 
       <AccountFilter

--- a/components/transactions/MovimientosList.tsx
+++ b/components/transactions/MovimientosList.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import { TxRow } from './TxRow'
+import { Skeleton } from '@/components/ui/skeleton'
 import { fmt } from '@/lib/formatting'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
 import type { TransactionWithAccount } from '@/types'
@@ -11,49 +13,113 @@ interface MovimientosListProps {
   onSwipe: (id: string | null) => void
   onRecategorize: (tx: TransactionWithAccount) => void
   onTap: (tx: TransactionWithAccount) => void
+  onLoadMore: () => void
+  hasMore: boolean
+  loadingMore: boolean
+  loadMoreError: string | null
 }
 
-export function MovimientosList({ groups, swipedTxId, onSwipe, onRecategorize, onTap }: MovimientosListProps) {
-  if (groups.length === 0) {
-    return (
-      <div className="flex items-center justify-center py-16">
-        <p className="text-sm text-muted-foreground text-center">No hay movimientos con estos filtros</p>
-      </div>
+export function MovimientosList({
+  groups,
+  swipedTxId,
+  onSwipe,
+  onRecategorize,
+  onTap,
+  onLoadMore,
+  hasMore,
+  loadingMore,
+  loadMoreError,
+}: MovimientosListProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  // El sentinel se monta siempre al final, incluso con lista filtrada vacía,
+  // para que la auto-paginación dispare búsquedas que solo matcheen en
+  // histórico antiguo. Si el observer detecta intersección y hay más datos,
+  // pedimos la siguiente página.
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || !hasMore || loadingMore || loadMoreError) return
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries.some(e => e.isIntersecting)) onLoadMore()
+      },
+      { rootMargin: '400px' },
     )
-  }
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [hasMore, loadingMore, loadMoreError, onLoadMore])
+
+  const isEmpty = groups.length === 0
 
   return (
     <div className="flex flex-col gap-4">
-      {groups.map(group => {
-        const netStr = (group.net >= 0 ? '+' : '') + fmt(group.net, 2) + ' €'
-        const netColor = group.net >= 0 ? '#22c55e' : 'var(--foreground)'
+      {isEmpty ? (
+        <div className="flex items-center justify-center py-16">
+          <p className="text-sm text-muted-foreground text-center">
+            {hasMore ? 'Buscando en el histórico…' : 'No hay movimientos con estos filtros'}
+          </p>
+        </div>
+      ) : (
+        groups.map(group => {
+          const netStr = (group.net >= 0 ? '+' : '') + fmt(group.net, 2) + ' €'
+          const netColor = group.net >= 0 ? '#22c55e' : 'var(--foreground)'
 
-        return (
-          <div key={group.date} className="flex flex-col gap-0.5">
-            <div className="flex items-center justify-between px-3 pb-1">
-              <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
-                {formatDayLabel(group.date)}
-              </span>
-              <span className="text-xs font-bold" style={{ color: netColor }}>
-                {netStr}
-              </span>
-            </div>
+          return (
+            <div key={group.date} className="flex flex-col gap-0.5">
+              <div className="flex items-center justify-between px-3 pb-1">
+                <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
+                  {formatDayLabel(group.date)}
+                </span>
+                <span className="text-xs font-bold" style={{ color: netColor }}>
+                  {netStr}
+                </span>
+              </div>
 
-            <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
-              {group.transactions.map(tx => (
-                <TxRow
-                  key={tx.id}
-                  tx={tx}
-                  swipedId={swipedTxId}
-                  onSwipe={onSwipe}
-                  onRecategorize={onRecategorize}
-                  onTap={onTap}
-                />
-              ))}
+              <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+                {group.transactions.map(tx => (
+                  <TxRow
+                    key={tx.id}
+                    tx={tx}
+                    swipedId={swipedTxId}
+                    onSwipe={onSwipe}
+                    onRecategorize={onRecategorize}
+                    onTap={onTap}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        )
-      })}
+          )
+        })
+      )}
+
+      <div ref={sentinelRef} aria-hidden="true" />
+
+      {loadingMore && (
+        <div className="flex flex-col gap-2">
+          {[0, 1, 2].map(i => (
+            <Skeleton key={i} className="h-15.5 rounded-2xl" />
+          ))}
+        </div>
+      )}
+
+      {loadMoreError && (
+        <div className="flex flex-col items-center gap-2 py-4">
+          <p className="text-sm text-muted-foreground">{loadMoreError}</p>
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className="text-sm font-semibold text-primary"
+          >
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      {!hasMore && !isEmpty && !loadingMore && !loadMoreError && (
+        <p className="text-xs text-muted-foreground text-center py-4">
+          No hay más movimientos
+        </p>
+      )}
     </div>
   )
 }

--- a/components/transactions/useTxMutations.ts
+++ b/components/transactions/useTxMutations.ts
@@ -12,28 +12,52 @@ export function useTxMutations(initial: TransactionWithAccount[]) {
     setTransactions(prev => [tx, ...prev])
   }, [])
 
+  // Anexa una página paginada al final de la lista, dedup por id para
+  // protegerse de carreras (p.ej. tx nueva que entra por la cabecera y
+  // también aparece en la siguiente página). Mantiene el orden de llegada
+  // para items nuevos; los duplicados se ignoran.
+  const appendTxs = useCallback((items: TransactionWithAccount[]) => {
+    if (items.length === 0) return
+    setTransactions(prev => {
+      const known = new Set(prev.map(t => t.id))
+      const fresh = items.filter(t => !known.has(t.id))
+      if (fresh.length === 0) return prev
+      return [...prev, ...fresh]
+    })
+  }, [])
+
   // El callback de Reintentar del toast re-ejecuta la propia operación. Se usa
   // una función con nombre (`attempt`) para poder referenciarla recursivamente
   // sin acceder a la variable del useCallback antes de declararla.
+  // Snapshot capturado antes de mutar para que el rollback no descarte items
+  // ya paginados ni mutaciones concurrentes.
   const deleteTx = useCallback((id: string) => {
     return (async function attempt() {
-      setTransactions(prev => prev.filter(t => t.id !== id))
+      let snapshot: TransactionWithAccount[] = []
+      setTransactions(prev => {
+        snapshot = prev
+        return prev.filter(t => t.id !== id)
+      })
       try {
         const res = await fetch(`/api/transactions/${id}`, { method: 'DELETE' })
         if (!res.ok) throw new Error(await res.text())
       } catch (err) {
-        setTransactions(initial)
+        setTransactions(snapshot)
         console.error('[useTxMutations.deleteTx] Error eliminando:', err)
         showToast('No se pudo eliminar el movimiento', () => { void attempt() })
       }
     })()
-  }, [initial, showToast])
+  }, [showToast])
 
   const recategorize = useCallback((id: string, category: CategoryId) => {
     return (async function attempt() {
-      setTransactions(prev => prev.map(t =>
-        t.id === id ? { ...t, category_manual: category } : t
-      ))
+      let snapshot: TransactionWithAccount[] = []
+      setTransactions(prev => {
+        snapshot = prev
+        return prev.map(t =>
+          t.id === id ? { ...t, category_manual: category } : t
+        )
+      })
       try {
         const res = await fetch(`/api/transactions/${id}`, {
           method: 'PATCH',
@@ -42,12 +66,12 @@ export function useTxMutations(initial: TransactionWithAccount[]) {
         })
         if (!res.ok) throw new Error(await res.text())
       } catch (err) {
-        setTransactions(initial)
+        setTransactions(snapshot)
         console.error('[useTxMutations.recategorize] Error recategorizando:', err)
         showToast('No se pudo recategorizar el movimiento', () => { void attempt() })
       }
     })()
-  }, [initial, showToast])
+  }, [showToast])
 
-  return { transactions, addTx, deleteTx, recategorize }
+  return { transactions, addTx, appendTxs, deleteTx, recategorize }
 }

--- a/components/transactions/useTxPagination.ts
+++ b/components/transactions/useTxPagination.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { buildPaginationParams, type TransactionCursor } from '@/lib/pagination'
+import type { TransactionWithAccount } from '@/types'
+
+const PAGE_SIZE = 200
+
+interface UseTxPaginationArgs {
+  initialCursor: TransactionCursor | null
+  appendTxs: (items: TransactionWithAccount[]) => void
+}
+
+export function useTxPagination({ initialCursor, appendTxs }: UseTxPaginationArgs) {
+  const [cursor, setCursor] = useState<TransactionCursor | null>(initialCursor)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Evita disparos concurrentes del IntersectionObserver mientras el fetch está en vuelo.
+  const inFlight = useRef(false)
+
+  const loadMore = useCallback(async () => {
+    if (inFlight.current || !cursor) return
+    inFlight.current = true
+    setLoading(true)
+    setError(null)
+    try {
+      const params = buildPaginationParams(cursor, { limit: PAGE_SIZE })
+      const res = await fetch(`/api/transactions?${params.toString()}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json = await res.json() as {
+        data: TransactionWithAccount[]
+        meta: { count: number; nextCursor: TransactionCursor | null }
+      }
+      appendTxs(json.data ?? [])
+      setCursor(json.meta?.nextCursor ?? null)
+    } catch (err) {
+      console.error('[useTxPagination.loadMore]', err)
+      setError('No se pudieron cargar más movimientos')
+    } finally {
+      inFlight.current = false
+      setLoading(false)
+    }
+  }, [cursor, appendTxs])
+
+  return {
+    loadMore,
+    hasMore: cursor !== null,
+    loading,
+    error,
+  }
+}

--- a/docs/finanzas-spec.md
+++ b/docs/finanzas-spec.md
@@ -1074,3 +1074,15 @@ Fue implementado y retirado por resultar confuso en UX. La idea: un toggle en Me
 - **Trimestre YTD:** acumulado creciente (Q2 = Ene–Jun, Q3 = Ene–Sep…)
 
 Para reimplementarlo, ver el historial del prototipo. Requiere datos mock separados por granularidad y un toggle claramente explicado al usuario con el rango de fechas exacto visible en todo momento.
+
+### 14.16 Filtros server-side en Movimientos
+
+Con la paginación cursor introducida en #109, los filtros de Movimientos (búsqueda por descripción/categoría, tipo, cuenta) siguen ejecutándose en cliente sobre el subconjunto cargado. El sentinel de infinite scroll auto-pagina cuando la lista filtrada queda corta, así que el comportamiento es funcionalmente correcto, pero:
+
+- Una búsqueda con matches sólo en histórico antiguo provoca N peticiones encadenadas para llegar a verlos.
+- Con dataset grande (10k+ tx en memoria), filtrar en JS empieza a notarse — converge con §14.9.
+
+Cuando moleste, mover los tres filtros a query params del endpoint `/api/transactions` (`?accounts=` ya existe). Cambios necesarios:
+- Endpoint: aplicar filtros en SQL (búsqueda con `ilike` o `websearch_to_tsquery` sobre `description`; tipo vía join con `categories.type`).
+- Cliente: `useMovimientosFilters` deja de filtrar localmente y dispara fetch con reset del cursor al cambiar filtros; añadir debounce al input de búsqueda.
+- Tests: del endpoint con cada combinación.

--- a/lib/pagination.test.ts
+++ b/lib/pagination.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { buildNextCursor, buildPaginationParams } from './pagination'
+
+describe('buildNextCursor', () => {
+  it('devuelve null cuando la lista está vacía', () => {
+    expect(buildNextCursor([], 200)).toBeNull()
+  })
+
+  it('devuelve null cuando vienen menos items que el límite', () => {
+    const items = [
+      { date: '2026-05-21', id: 'a' },
+      { date: '2026-05-20', id: 'b' },
+    ]
+    expect(buildNextCursor(items, 200)).toBeNull()
+  })
+
+  it('devuelve el cursor del último item cuando se alcanza el límite', () => {
+    const items = [
+      { date: '2026-05-21', id: 'a' },
+      { date: '2026-05-20', id: 'b' },
+      { date: '2026-05-19', id: 'c' },
+    ]
+    expect(buildNextCursor(items, 3)).toEqual({ date: '2026-05-19', id: 'c' })
+  })
+
+  it('ignora campos extra del item al construir el cursor', () => {
+    const items = [
+      { date: '2026-05-21', id: 'a', amount: 100, description: 'foo' },
+      { date: '2026-05-20', id: 'b', amount: -50, description: 'bar' },
+    ]
+    expect(buildNextCursor(items, 2)).toEqual({ date: '2026-05-20', id: 'b' })
+  })
+})
+
+describe('buildPaginationParams', () => {
+  it('devuelve params vacíos cuando el cursor es null y no hay extras', () => {
+    const params = buildPaginationParams(null)
+    expect(params.toString()).toBe('')
+  })
+
+  it('incluye before_date + before_id cuando hay cursor', () => {
+    const params = buildPaginationParams({ date: '2026-05-19', id: 'c' })
+    expect(params.get('before_date')).toBe('2026-05-19')
+    expect(params.get('before_id')).toBe('c')
+  })
+
+  it('mergea extras con el cursor', () => {
+    const params = buildPaginationParams({ date: '2026-05-19', id: 'c' }, {
+      limit: 200,
+      accounts: 'acc-1,acc-2',
+    })
+    expect(params.get('before_date')).toBe('2026-05-19')
+    expect(params.get('before_id')).toBe('c')
+    expect(params.get('limit')).toBe('200')
+    expect(params.get('accounts')).toBe('acc-1,acc-2')
+  })
+
+  it('omite extras con valor undefined o cadena vacía', () => {
+    const params = buildPaginationParams(null, {
+      limit: 200,
+      accounts: undefined,
+      category: '',
+    })
+    expect(params.get('limit')).toBe('200')
+    expect(params.has('accounts')).toBe(false)
+    expect(params.has('category')).toBe(false)
+  })
+})

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,29 @@
+export interface TransactionCursor {
+  date: string
+  id: string
+}
+
+export function buildNextCursor<T extends { date: string; id: string }>(
+  items: T[],
+  limit: number,
+): TransactionCursor | null {
+  if (items.length < limit) return null
+  const last = items[items.length - 1]
+  return { date: last.date, id: last.id }
+}
+
+export function buildPaginationParams(
+  cursor: TransactionCursor | null,
+  extras: Record<string, string | number | undefined> = {},
+): URLSearchParams {
+  const params = new URLSearchParams()
+  if (cursor) {
+    params.set('before_date', cursor.date)
+    params.set('before_id', cursor.id)
+  }
+  for (const [key, value] of Object.entries(extras)) {
+    if (value === undefined || value === '') continue
+    params.set(key, String(value))
+  }
+  return params
+}


### PR DESCRIPTION
Closes #109

## Resumen

El `.limit(200)` duro sobre 90 días en `/movimientos` era un bug latente de correctitud: al superarlo, la lista se truncaba sin avisar y falseaba búsquedas, agrupaciones y totales parciales. Esta PR introduce paginación **keyset** por `(date, id)`, sólida ante drift cuando entran/salen transacciones entre peticiones.

## Cambios

### Servidor
- `app/api/transactions/route.ts`
  - Acepta `before_date` (YYYY-MM-DD) + `before_id` (uuid). Si ambos vienen, NO aplica el cutoff por defecto de 90 días — la paginación puede llegar al inicio del histórico.
  - Pide internamente `LIMIT limit + 1` para detectar `hasMore` sin falsos positivos. Devuelve `meta.nextCursor: { date, id } | null`.
  - Orden simplificado a `date DESC, id DESC` (se elimina `created_at` como tiebreaker para que el cursor sea inequívoco). Diferencia visual nula salvo en colisiones intra-día muy raras.
- `app/(app)/movimientos/page.tsx`
  - Mismo orden simplificado en el fetch inicial.
  - Calcula `initialCursor` con `buildNextCursor` y lo pasa a `MovimientosClient`.

### Cliente
- `lib/pagination.ts` (nuevo) — helpers puros:
  - `buildNextCursor(items, limit)` → `{ date, id } | null`.
  - `buildPaginationParams(cursor, extras)` → `URLSearchParams`.
- `lib/pagination.test.ts` (nuevo) — 8 tests (`pnpm test`).
- `components/transactions/useTxPagination.ts` (nuevo) — hook con `loadMore`, `hasMore`, `loading`, `error`. `inFlight` ref evita disparos concurrentes del IntersectionObserver.
- `components/transactions/useTxMutations.ts` — añade `appendTxs` con dedupe por id y corrige rollback de `deleteTx`/`recategorize` para usar snapshot capturado antes de mutar (antes hacía `setTransactions(initial)` y, con paginación, eso descartaba todo lo cargado por scroll).
- `components/transactions/MovimientosClient.tsx` — cablea el hook de paginación con `appendTxs`.
- `components/transactions/MovimientosList.tsx`
  - `<div ref={sentinelRef} />` siempre montado al final (también con lista filtrada vacía), `rootMargin: '400px'`, dispara `loadMore` cuando entra en viewport.
  - Footer: skeleton de 3 filas mientras carga, mensaje de error con reintento, "No hay más movimientos" cuando se agota.
  - Empty state inteligente: "Buscando en el histórico…" si hay más datos pendientes; "No hay movimientos con estos filtros" si ya se acabó.

### Documentación
- `docs/finanzas-spec.md` — nueva §14.16 "Filtros server-side en Movimientos" como futura mejora. Los filtros siguen client-side; el sentinel auto-pagina si la lista filtrada queda corta.

## Decisiones de diseño

- **Cursor `(date, id)` y no `(date, created_at, id)`**: simplifica la condición keyset en SQL a costa de una diferencia visual nula salvo en colisiones intra-día con `created_at` distintos.
- **Cap 90d solo en initial**: primer paint rápido; cuando llega cursor, deja de aplicarse.
- **Filtros client-side**: aceptado como limitación porque mantiene #109 acotada a correctitud. El sentinel auto-pagina mientras no haya suficientes matches.
- **`LIMIT limit + 1`**: evita falsos positivos en `nextCursor` cuando hay exactamente `limit` ítems restantes.

## Validación

- `pnpm test` → 217 ✅ (incluyendo 8 nuevos de `lib/pagination`)
- `pnpm lint` ✅
- `pnpm build` ✅
- Manual con page size temporalmente bajado a 10 (restaurado a 200 antes del commit):
  - Lista renderiza igual que antes.
  - Sentinel dispara `GET /api/transactions?before_date=…&before_id=…&limit=200` al scrollear.
  - Una petición por intersección, sin duplicados.
  - "No hay más movimientos" al agotar histórico.
  - Búsqueda con matches solo en histórico antiguo: auto-pagina mostrando "Buscando en el histórico…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)