### PR TITLE
feat(pwa): manifest base y metadata appleWebApp (#111)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,11 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   title: 'Finanzas',
   description: 'App de gestión financiera personal',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Finanzas',
+  },
 }
 
 export default function RootLayout({

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Finanzas Personales',
+    short_name: 'Finanzas',
+    description: 'Gestiona y analiza tus finanzas personales',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#f5f5f7',
+    theme_color: '#6366f1',
+    icons: [
+      { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
+      { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' },
+      {
+        src: '/icons/icon-maskable.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -47,6 +47,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|manifest.webmanifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }


### PR DESCRIPTION
## Resumen

Primera pieza de la Fase 7 (PWA). Hace la app instalable como aplicación con identidad propia.

- **`app/manifest.ts` (nuevo)** — devuelve el `MetadataRoute.Manifest` con los valores literales de spec §7.1 (`name`, `short_name`, `description`, `start_url`, `display: 'standalone'`, `background_color: '#f5f5f7'`, `theme_color: '#6366f1'` y 3 referencias de iconos). Next sirve la ruta `/manifest.webmanifest` automáticamente (confirmado en el output de `pnpm build`).
- **`app/layout.tsx`** — añade el bloque `metadata.appleWebApp` (`capable: true`, `statusBarStyle: 'default'`, `title: 'Finanzas'`) para que iOS reconozca la app como standalone con identidad propia. Se elige `'default'` porque encaja con `background_color: '#f5f5f7'` y no requiere safe-area (que va en otra issue de la fase). El `viewport.themeColor` ya existente no se toca.

## Fuera de alcance (issues separadas de la fase)

- PNG físicos en `public/icons/` (DevTools mostrará warning de iconos no encontrados hasta entonces — aceptable según la issue).
- Service worker / offline.
- Safe-area CSS (§7.2 del spec).

## Test plan

- [x] `pnpm lint` — verde
- [x] `pnpm test` — 217 tests verdes
- [x] `pnpm build` — verde, `/manifest.webmanifest` listado como ruta estática
- [ ] `pnpm dev` y verificar en DevTools → Application → Manifest que carga sin warnings (excepto los de iconos no encontrados)
- [ ] `curl -s http://localhost:3000/manifest.webmanifest | jq` — JSON válido con los 7 campos de spec §7.1
- [ ] Vista del `<head>`: presentes `<link rel="manifest">` y los 3 `<meta name="apple-mobile-web-app-*">`

Closes #111