### PR TITLE
feat(pwa): safe-area en sub-headers sticky y utilidades Tailwind (#112)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,11 +158,3 @@
 .animate-fade-in {
   animation: fadeIn 0.2s ease forwards;
 }
-
-.safe-top {
-  padding-top: env(safe-area-inset-top);
-}
-
-.safe-bottom {
-  padding-bottom: max(env(safe-area-inset-bottom), 1.5rem);
-}

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -94,8 +94,9 @@ export default function AnalyticsClient() {
     <div>
       {/* Sticky header */}
       <div
-        className="sticky top-12 z-30 border-b border-border px-5 pt-3 pb-3"
+        className="sticky z-30 border-b border-border px-5 pt-3 pb-3"
         style={{
+          top: 'calc(env(safe-area-inset-top) + 3rem)',
           background: 'color-mix(in srgb, var(--background) 92%, transparent)',
           backdropFilter: 'blur(16px)',
         }}

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -154,7 +154,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
         style={{
           background: 'color-mix(in srgb, var(--background) 92%, transparent)',
           backdropFilter: 'blur(16px)',
-          paddingTop: 52,
+          paddingTop: 'calc(env(safe-area-inset-top) + 52px)',
         }}
       >
         <div className="flex items-center justify-between">

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -13,7 +13,7 @@ export function AppHeader({ email, consentBanner }: Props) {
   if (pathname.startsWith('/analisis/categoria/')) return null
 
   return (
-    <header className="safe-top sticky top-0 z-40 bg-background/85 backdrop-blur-xl">
+    <header className="pt-[env(safe-area-inset-top)] sticky top-0 z-40 bg-background/85 backdrop-blur-xl">
       <div className="flex h-12 items-center justify-between px-4">
         <UserMenuTrigger email={email} />
         <button

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -19,7 +19,7 @@ export function BottomNav() {
   return (
     <nav
       className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-105 z-100
-                 border-t border-border safe-bottom"
+                 border-t border-border pb-[max(env(safe-area-inset-bottom),1.5rem)]"
       style={{ background: 'var(--app-nav-bg)', backdropFilter: 'blur(20px)' }}
     >
       <div className="flex pt-2.5">


### PR DESCRIPTION
## Contexto

Cierra #112. Al explorar el código se descubrió que casi todo el "Alcance" literal de la issue **ya estaba implementado** en PRs anteriores:

- `viewport: Viewport` con todos los valores → `app/layout.tsx` (PR #111)
- `padding-top`/`padding-bottom` de safe-area en header y bottom-nav (PR #12)
- Contenedor raíz con `overflow-clip`

El problema real que quedaba es el que anticipaba la sección *"Cuidado con sticky"* de la issue: al activar `viewportFit: 'cover'` (#111) los insets de safe-area dejaron de ser 0, y dos sub-headers sticky con offset fijo se descolocan en dispositivos con notch.

## Cambios

**1. Sub-headers sticky conscientes del safe-area**
- `AnalyticsClient.tsx`: el sticky de Análisis pasa de `top-12` a `top: calc(env(safe-area-inset-top) + 3rem)` (3rem = altura de la barra del header global). Antes se solapaba con el header global en notch.
- `CategoryDetailClient.tsx`: `paddingTop: 52` → `calc(env(safe-area-inset-top) + 52px)`. En esa ruta el header global se oculta, así que su propio sticky `top-0` quedaba bajo el notch.

> En dispositivos sin notch (inset = 0) el aspecto no cambia.

**2. Refactor a utilidades Tailwind v4**
- `app-header.tsx`: `.safe-top` → `pt-[env(safe-area-inset-top)]`
- `bottom-nav.tsx`: `.safe-bottom` → `pb-[max(env(safe-area-inset-bottom),1.5rem)]` (forma idéntica a la ya usada en los modales del proyecto)
- `globals.css`: eliminadas las clases propias `.safe-top`/`.safe-bottom`, alineando con la convención del resto del codebase.

## Verificación

- ✅ `pnpm test` (217 tests), `pnpm lint`, `pnpm build` — los tres en verde
- Pendiente verificación manual con DevTools responsive (iPhone 14/15 Pro): header despegado del notch, bottom-nav del home indicator, y los sub-headers de Análisis / Detalle de categoría anclados correctamente al hacer scroll.

## Criterios de aceptación

- [x] `viewport` exportado en `app/layout.tsx` con los valores indicados
- [x] Padding de safe-area aplicado en header y bottom nav (vía Tailwind)
- [x] Sticky headers (Análisis, Movimientos, Detalle de categoría) conscientes del safe-area
- [x] `pnpm build`, `pnpm lint` y `pnpm test` verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)