### PR TITLE
feat(pwa): notificaciones push Web Push + aviso caducidad PSD2 (#115)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app
 
 # Web Push (notificaciones push, issue #115)
 # Genera el par una sola vez con: npx web-push generate-vapid-keys
-# Las tres deben estar también en Vercel y en GitHub Secrets (las usa el cron para firmar pushes).
+# Las tres van en Vercel (el cron firma el push ahí dentro). NO hacen falta en
+# GitHub Secrets: el workflow solo hace curl al endpoint, no envía pushes.
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=   # clave pública (va al cliente)
 VAPID_PRIVATE_KEY=              # clave privada (solo servidor)
 VAPID_SUBJECT=mailto:victor.sales83@gmail.com

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ APP_URL=http://localhost:3000   # destino del webhook (lo usan scrape:edenred y 
 
 # App
 NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app
+
+# Web Push (notificaciones push, issue #115)
+# Genera el par una sola vez con: npx web-push generate-vapid-keys
+# Las tres deben estar también en Vercel y en GitHub Secrets (las usa el cron para firmar pushes).
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=   # clave pública (va al cliente)
+VAPID_PRIVATE_KEY=              # clave privada (solo servidor)
+VAPID_SUBJECT=mailto:victor.sales83@gmail.com

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -57,6 +57,8 @@ export async function GET(request: NextRequest) {
       .update({
         session_id: session.session_id,
         consent_expires_at: session.access.valid_until,
+        // Nueva caducidad → re-habilita el aviso PSD2 para el próximo ciclo (#115).
+        consent_reminder_sent_for: null,
         ...(ebAcc && { external_id: ebAcc.uid }),
         aspsp_name: state.aspspName,
         aspsp_country: state.aspspCountry,
@@ -83,6 +85,8 @@ export async function GET(request: NextRequest) {
       external_id: acc.uid,
       session_id: session.session_id,
       consent_expires_at: session.access.valid_until,
+      // Nueva caducidad → re-habilita el aviso PSD2 para el próximo ciclo (#115).
+      consent_reminder_sent_for: null,
       aspsp_name: state?.aspspName ?? null,
       aspsp_country: state?.aspspCountry ?? null,
       is_active: true,

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Guarda la PushSubscription del navegador para el usuario autenticado
+ * (issue #115). Upsert por `endpoint`: re-suscribirse desde el mismo navegador
+ * actualiza las claves en vez de duplicar la fila.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { endpoint, keys } = await request.json().catch(() => ({}))
+  if (!endpoint || !keys?.p256dh || !keys?.auth) {
+    return NextResponse.json({ error: 'Suscripción inválida' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('push_subscriptions')
+    .upsert(
+      { user_id: user.id, endpoint, p256dh: keys.p256dh, auth: keys.auth },
+      { onConflict: 'endpoint' }
+    )
+
+  if (error) {
+    console.error('[push/subscribe]', error)
+    return NextResponse.json({ error: 'No se pudo guardar la suscripción' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/push/unsubscribe/route.ts
+++ b/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Elimina la PushSubscription del usuario autenticado por `endpoint`
+ * (issue #115). La RLS ya garantiza que solo borra filas propias.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { endpoint } = await request.json().catch(() => ({}))
+  if (!endpoint) {
+    return NextResponse.json({ error: 'endpoint es obligatorio' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('push_subscriptions')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('endpoint', endpoint)
+
+  if (error) {
+    console.error('[push/unsubscribe]', error)
+    return NextResponse.json({ error: 'No se pudo eliminar la suscripción' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -3,6 +3,8 @@ import { timingSafeEqual } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
+import { getConsentStatus } from '@/lib/accounts'
+import { sendPushToUser, selectAccountsToNotify, type NotifiableAccount } from '@/lib/push'
 
 function safeBearerMatch(header: string | null, secret: string): boolean {
   if (!header) return false
@@ -28,7 +30,7 @@ export async function POST(req: Request) {
 
   const { data: accounts, error: accountsError } = await db
     .from('accounts')
-    .select('id, user_id, external_id, session_id, last_synced, consent_expires_at')
+    .select('id, user_id, name, external_id, session_id, last_synced, consent_expires_at, consent_reminder_sent_for')
     .eq('source', 'enablebanking')
     .eq('is_active', true)
 
@@ -158,10 +160,67 @@ export async function POST(req: Request) {
   const { error: refreshError } = await db.rpc('refresh_monthly_summary')
   if (refreshError) console.error('[sync/eb/cron] refresh_monthly_summary:', refreshError)
 
+  // Aviso de caducidad PSD2 (≤7 días, issue #115). Se evalúa sobre todas las
+  // cuentas (las críticas siguen siendo sincronizables) y se manda una sola vez
+  // por ciclo de caducidad gracias a consent_reminder_sent_for.
+  const notified = await notifyExpiringConsents(db, accounts as NotifiableAccount[])
+
   return NextResponse.json({
     synced: totalSynced,
     accounts: syncable.length,
     skipped,
     failed,
+    notified,
   })
+}
+
+type CronDb = ReturnType<typeof createServiceClient>
+
+/**
+ * Envía el aviso de caducidad PSD2 a los usuarios con cuentas en ventana crítica
+ * y marca cada cuenta como notificada. Devuelve el nº de cuentas avisadas.
+ */
+async function notifyExpiringConsents(db: CronDb, accounts: NotifiableAccount[]): Promise<number> {
+  const toNotify = selectAccountsToNotify(accounts)
+  if (toNotify.length === 0) return 0
+
+  // Agrupar por usuario: un push por usuario aunque tenga varias cuentas a punto.
+  const byUser = new Map<string, NotifiableAccount[]>()
+  for (const account of toNotify) {
+    const list = byUser.get(account.user_id)
+    if (list) list.push(account)
+    else byUser.set(account.user_id, [account])
+  }
+
+  for (const [userId, userAccounts] of byUser) {
+    const first = userAccounts[0]
+    const daysLeft = getConsentStatus(first.consent_expires_at).daysLeft
+    const body =
+      userAccounts.length === 1
+        ? `Renueva la conexión de ${first.name} en los próximos ${daysLeft} día${daysLeft === 1 ? '' : 's'}.`
+        : `${userAccounts.length} conexiones bancarias caducan en breve. Renuévalas para seguir sincronizando.`
+
+    try {
+      await sendPushToUser(db, userId, {
+        title: 'Tu acceso bancario caduca pronto',
+        body,
+        url: '/cuentas',
+      })
+    } catch (err) {
+      console.error('[sync/eb/cron] push caducidad:', err)
+      continue
+    }
+
+    // Marcar como notificadas (idempotente por el valor de consent_expires_at).
+    await Promise.all(
+      userAccounts.map(account =>
+        db
+          .from('accounts')
+          .update({ consent_reminder_sent_for: account.consent_expires_at })
+          .eq('id', account.id)
+      )
+    )
+  }
+
+  return toNotify.length
 }

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -34,3 +34,51 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+// ── Notificaciones push (issue #115) ──────────────────────────────────────
+// El servidor envía un JSON { title, body, url }. Mostramos la notificación
+// nativa y, al pulsarla, enfocamos una pestaña abierta o abrimos la ruta.
+interface PushPayload {
+  title: string;
+  body: string;
+  url: string;
+}
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  let payload: PushPayload;
+  try {
+    payload = event.data.json() as PushPayload;
+  } catch {
+    payload = { title: "Finanzas", body: event.data.text(), url: "/" };
+  }
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, {
+      body: payload.body,
+      icon: "/icons/icon-192.png",
+      badge: "/icons/icon-192.png",
+      data: { url: payload.url || "/" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = (event.notification.data as { url?: string })?.url || "/";
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        // Reutiliza una pestaña ya abierta de la app si la hay.
+        for (const client of clientList) {
+          if ("focus" in client) {
+            client.navigate(url);
+            return client.focus();
+          }
+        }
+        return self.clients.openWindow(url);
+      }),
+  );
+});

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { Bell } from 'lucide-react'
 import { UserMenuTrigger } from './dashboard/UserMenuTrigger'
+import { NotificationsTrigger } from './notifications/NotificationsTrigger'
 import { StatusBanner } from './sync/StatusBanner'
 import type { ConsentBannerData } from '@/lib/accounts'
 
@@ -16,14 +16,7 @@ export function AppHeader({ email, consentBanner }: Props) {
     <header className="pt-[env(safe-area-inset-top)] sticky top-0 z-40 bg-background/85 backdrop-blur-xl">
       <div className="flex h-12 items-center justify-between px-4">
         <UserMenuTrigger email={email} />
-        <button
-          type="button"
-          aria-label="Notificaciones"
-          disabled
-          className="grid size-9 place-items-center rounded-full text-muted-foreground disabled:cursor-not-allowed"
-        >
-          <Bell className="size-4.5" strokeWidth={2} />
-        </button>
+        <NotificationsTrigger />
       </div>
       <StatusBanner consent={consentBanner} />
     </header>

--- a/components/notifications/NotificationsTrigger.tsx
+++ b/components/notifications/NotificationsTrigger.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState } from 'react'
+import { Bell, BellOff, BellRing } from 'lucide-react'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { usePushSubscription } from '@/hooks/usePushSubscription'
+
+/**
+ * Campana del header (issue #115). Abre un Sheet para activar/desactivar las
+ * notificaciones push. El permiso se solicita solo al pulsar "Activar".
+ */
+export function NotificationsTrigger() {
+  const [open, setOpen] = useState(false)
+  const { support, enabled, busy, denied, subscribe, unsubscribe } = usePushSubscription()
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
+          <button
+            type="button"
+            aria-label="Notificaciones"
+            className="grid size-9 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {enabled ? (
+              <BellRing className="size-4.5 text-primary" strokeWidth={2} />
+            ) : (
+              <Bell className="size-4.5" strokeWidth={2} />
+            )}
+          </button>
+        }
+      />
+      <SheetContent
+        side="bottom"
+        className="rounded-t-3xl pt-2 pb-[max(env(safe-area-inset-bottom),1.5rem)]"
+      >
+        <SheetHeader className="flex flex-row items-center gap-3 pt-3">
+          <div className="grid size-10 place-items-center rounded-full bg-accent text-foreground">
+            <Bell className="size-5" strokeWidth={2} />
+          </div>
+          <div className="flex flex-col gap-0.5 text-left">
+            <SheetTitle className="text-sm">Notificaciones</SheetTitle>
+            <SheetDescription className="text-xs">
+              Avisos de caducidad del acceso bancario
+            </SheetDescription>
+          </div>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-3 px-4 pb-2 pt-2">
+          {support === 'unsupported' && (
+            <p className="text-xs text-muted-foreground">
+              Tu navegador no admite notificaciones push. En iPhone, instala antes la app desde
+              «Compartir → Añadir a pantalla de inicio» (requiere iOS 16.4 o superior).
+            </p>
+          )}
+
+          {support === 'supported' && denied && !enabled && (
+            <p className="text-xs text-muted-foreground">
+              Has bloqueado las notificaciones para este sitio. Habilítalas en los ajustes del
+              navegador para poder activarlas.
+            </p>
+          )}
+
+          {support === 'supported' && !denied && (
+            <p className="text-xs text-muted-foreground">
+              {enabled
+                ? 'Recibirás un aviso cuando el acceso a alguno de tus bancos esté a punto de caducar.'
+                : 'Activa los avisos para enterarte antes de que caduque el acceso a tus bancos.'}
+            </p>
+          )}
+
+          {support === 'supported' &&
+            (enabled ? (
+              <button
+                type="button"
+                onClick={unsubscribe}
+                disabled={busy}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-border px-3 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+              >
+                <BellOff className="size-4.5" strokeWidth={2} />
+                Desactivar notificaciones
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={subscribe}
+                disabled={busy || denied}
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary px-3 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              >
+                <BellRing className="size-4.5" strokeWidth={2} />
+                Activar notificaciones
+              </button>
+            ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Node scripts ejecutados fuera del bundle de Next.
     "scripts/**",
+    // Service worker generado por Serwist en build (gitignored, minificado).
+    "public/sw.js",
     // Prototipo visual de referencia (no producción) — ver CLAUDE.md.
     "docs/**",
     // Templates de skills de Claude Code (no se compilan con la app).

--- a/hooks/usePushSubscription.ts
+++ b/hooks/usePushSubscription.ts
@@ -1,0 +1,115 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { urlBase64ToUint8Array } from '@/lib/push-client'
+
+/**
+ * Gestiona la suscripción a notificaciones push del navegador (issue #115).
+ *
+ * - `support`: 'loading' mientras se comprueba, 'supported' o 'unsupported'.
+ *   No soportado típico: Safari iOS sin instalar la PWA (requiere iOS 16.4+ y
+ *   "Añadir a pantalla de inicio").
+ * - `enabled`: hay una suscripción activa para este navegador.
+ * - `subscribe`/`unsubscribe`: solo deben llamarse desde una interacción
+ *   explícita del usuario (pedir permiso al cargar es mal patrón).
+ */
+export type PushSupport = 'loading' | 'supported' | 'unsupported'
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+
+export function usePushSubscription() {
+  const [support, setSupport] = useState<PushSupport>('loading')
+  const [enabled, setEnabled] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [denied, setDenied] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    // La detección de soporte y el estado de la suscripción se resuelven en una
+    // única actualización asíncrona (evita setState síncrono dentro del effect).
+    async function detect() {
+      const supported =
+        typeof window !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        'PushManager' in window &&
+        'Notification' in window &&
+        Boolean(VAPID_PUBLIC_KEY)
+
+      if (!supported) return { support: 'unsupported' as const, enabled: false, denied: false }
+
+      const reg = await navigator.serviceWorker.ready
+      const sub = await reg.pushManager.getSubscription().catch(() => null)
+      return {
+        support: 'supported' as const,
+        enabled: Boolean(sub),
+        denied: Notification.permission === 'denied',
+      }
+    }
+
+    detect().then(state => {
+      if (cancelled) return
+      setSupport(state.support)
+      setEnabled(state.enabled)
+      setDenied(state.denied)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const subscribe = useCallback(async () => {
+    if (support !== 'supported' || !VAPID_PUBLIC_KEY) return
+    setBusy(true)
+    try {
+      const permission = await Notification.requestPermission()
+      if (permission !== 'granted') {
+        setDenied(permission === 'denied')
+        return
+      }
+
+      const reg = await navigator.serviceWorker.ready
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+      })
+
+      const json = sub.toJSON()
+      const res = await fetch('/api/push/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
+      })
+      if (!res.ok) {
+        await sub.unsubscribe()
+        throw new Error('No se pudo guardar la suscripción')
+      }
+      setEnabled(true)
+    } finally {
+      setBusy(false)
+    }
+  }, [support])
+
+  const unsubscribe = useCallback(async () => {
+    if (support !== 'supported') return
+    setBusy(true)
+    try {
+      const reg = await navigator.serviceWorker.ready
+      const sub = await reg.pushManager.getSubscription()
+      if (sub) {
+        await fetch('/api/push/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: sub.endpoint }),
+        })
+        await sub.unsubscribe()
+      }
+      setEnabled(false)
+    } finally {
+      setBusy(false)
+    }
+  }, [support])
+
+  return { support, enabled, busy, denied, subscribe, unsubscribe }
+}

--- a/lib/push-client.ts
+++ b/lib/push-client.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers de push seguros para el cliente (issue #115). No importa `web-push`
+ * (Node-only) para no arrastrarlo al bundle del navegador.
+ */
+
+/**
+ * Convierte la clave VAPID pública (base64url) al `Uint8Array` que exige
+ * `pushManager.subscribe({ applicationServerKey })`.
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  // Buffer ArrayBuffer explícito: satisface el tipo BufferSource que exige
+  // pushManager.subscribe (TS 5.7+ distingue ArrayBuffer de ArrayBufferLike).
+  const outputArray = new Uint8Array(new ArrayBuffer(rawData.length))
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}

--- a/lib/push.test.ts
+++ b/lib/push.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock de web-push: capturamos los envíos y controlamos los fallos por endpoint.
+const sendNotification = vi.fn()
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: (...args: unknown[]) => sendNotification(...args),
+  },
+}))
+
+import { selectAccountsToNotify, urlBase64ToUint8Array, sendPushToUser, type NotifiableAccount } from './push'
+
+const DAY_MS = 86_400_000
+const NOW = new Date('2026-05-21T12:00:00.000Z')
+
+function isoInDays(days: number): string {
+  return new Date(NOW.getTime() + days * DAY_MS).toISOString()
+}
+
+function account(over: Partial<NotifiableAccount> = {}): NotifiableAccount {
+  return {
+    id: 'acc-1',
+    user_id: 'user-1',
+    name: 'Cuenta Corriente',
+    consent_expires_at: isoInDays(3),
+    consent_reminder_sent_for: null,
+    ...over,
+  }
+}
+
+describe('selectAccountsToNotify', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('incluye cuentas en ventana crítica (≤7 días) no notificadas', () => {
+    const result = selectAccountsToNotify([account({ consent_expires_at: isoInDays(3) })])
+    expect(result).toHaveLength(1)
+  })
+
+  it('ignora cuentas en warning (>=7 días) y ok', () => {
+    const result = selectAccountsToNotify([
+      account({ id: 'a', consent_expires_at: isoInDays(10) }),
+      account({ id: 'b', consent_expires_at: isoInDays(30) }),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignora cuentas ya caducadas', () => {
+    const result = selectAccountsToNotify([account({ consent_expires_at: isoInDays(-1) })])
+    expect(result).toHaveLength(0)
+  })
+
+  it('respeta el dedupe: no reenvía si ya se notificó este consent_expires_at', () => {
+    const expiry = isoInDays(3)
+    const result = selectAccountsToNotify([
+      account({ consent_expires_at: expiry, consent_reminder_sent_for: expiry }),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('vuelve a notificar si la caducidad cambió respecto a la ya notificada', () => {
+    const result = selectAccountsToNotify([
+      account({ consent_expires_at: isoInDays(3), consent_reminder_sent_for: isoInDays(-90) }),
+    ])
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodifica base64url a los bytes correctos', () => {
+    // "Man" en base64 estándar es "TWFu"; en base64url es igual aquí.
+    const bytes = urlBase64ToUint8Array('TWFu')
+    expect(Array.from(bytes)).toEqual([77, 97, 110])
+  })
+
+  it('maneja el alfabeto url-safe (- y _) y el padding ausente', () => {
+    // 0xFB 0xFF 0xBF → base64 "+/+/", base64url "-_-_"
+    const bytes = urlBase64ToUint8Array('-_-_')
+    expect(Array.from(bytes)).toEqual([251, 255, 191])
+  })
+})
+
+describe('sendPushToUser', () => {
+  beforeEach(() => {
+    sendNotification.mockReset()
+    process.env.VAPID_SUBJECT = 'mailto:test@example.com'
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pub'
+    process.env.VAPID_PRIVATE_KEY = 'priv'
+  })
+
+  function makeDb(subs: { endpoint: string; p256dh: string; auth: string }[]) {
+    const deleted: string[][] = []
+    const db = {
+      from() {
+        return {
+          select() {
+            return { eq: () => Promise.resolve({ data: subs, error: null }) }
+          },
+          delete() {
+            return {
+              in(_col: string, endpoints: string[]) {
+                deleted.push(endpoints)
+                return Promise.resolve({ error: null })
+              },
+            }
+          },
+        }
+      },
+    }
+    return { db, deleted }
+  }
+
+  it('poda las suscripciones que devuelven 410 Gone', async () => {
+    const { db, deleted } = makeDb([
+      { endpoint: 'https://push/ok', p256dh: 'k1', auth: 'a1' },
+      { endpoint: 'https://push/gone', p256dh: 'k2', auth: 'a2' },
+    ])
+    sendNotification.mockImplementation((sub: { endpoint: string }) => {
+      if (sub.endpoint === 'https://push/gone') {
+        return Promise.reject({ statusCode: 410 })
+      }
+      return Promise.resolve()
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sent = await sendPushToUser(db as any, 'user-1', { title: 't', body: 'b', url: '/' })
+
+    expect(sent).toBe(1)
+    expect(deleted).toEqual([['https://push/gone']])
+  })
+
+  it('no borra nada si todos los envíos van bien', async () => {
+    const { db, deleted } = makeDb([{ endpoint: 'https://push/ok', p256dh: 'k', auth: 'a' }])
+    sendNotification.mockResolvedValue(undefined)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sent = await sendPushToUser(db as any, 'user-1', { title: 't', body: 'b', url: '/' })
+
+    expect(sent).toBe(1)
+    expect(deleted).toEqual([])
+  })
+})

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,123 @@
+import webpush from 'web-push'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getConsentStatus } from '@/lib/accounts'
+
+// Re-exportado por conveniencia; el cliente debe importarlo de '@/lib/push-client'
+// para no arrastrar web-push (Node-only) al bundle del navegador.
+export { urlBase64ToUint8Array } from '@/lib/push-client'
+
+/**
+ * Lógica de notificaciones push (Web Push API, issue #115).
+ *
+ * - Envío firmado con VAPID desde servidor (`sendPushToUser`), podando
+ *   suscripciones muertas.
+ * - Selección de cuentas con consentimiento PSD2 a punto de caducar
+ *   (`selectAccountsToNotify`), helper puro reutilizado por el cron y los tests.
+ * - Conversión de la clave VAPID pública para `pushManager.subscribe`
+ *   (`urlBase64ToUint8Array`), compartida con el cliente.
+ */
+
+export interface PushPayload {
+  title: string
+  body: string
+  /** Ruta a la que navegar al pulsar la notificación (la maneja el SW). */
+  url: string
+}
+
+let vapidConfigured = false
+
+/**
+ * Configura las claves VAPID en `web-push` una sola vez por proceso. Lanza si
+ * faltan las variables de entorno (el llamante decide cómo degradar).
+ */
+function ensureVapidConfigured(): void {
+  if (vapidConfigured) return
+  const subject = process.env.VAPID_SUBJECT
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const privateKey = process.env.VAPID_PRIVATE_KEY
+  if (!subject || !publicKey || !privateKey) {
+    throw new Error('VAPID env vars no configuradas (VAPID_SUBJECT / *_VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY)')
+  }
+  webpush.setVapidDetails(subject, publicKey, privateKey)
+  vapidConfigured = true
+}
+
+interface SubscriptionRow {
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+/**
+ * Envía `payload` a todas las suscripciones del usuario. Las suscripciones que
+ * el push service reporta como caducadas (404/410 Gone) se eliminan de la BD.
+ * Devuelve cuántos envíos tuvieron éxito.
+ */
+export async function sendPushToUser(
+  db: SupabaseClient,
+  userId: string,
+  payload: PushPayload
+): Promise<number> {
+  ensureVapidConfigured()
+
+  const { data: subs, error } = await db
+    .from('push_subscriptions')
+    .select('endpoint, p256dh, auth')
+    .eq('user_id', userId)
+
+  if (error) {
+    console.error('[push] fetch subscriptions:', error)
+    return 0
+  }
+  if (!subs || subs.length === 0) return 0
+
+  const body = JSON.stringify(payload)
+  const gone: string[] = []
+  let sent = 0
+
+  await Promise.all(
+    (subs as SubscriptionRow[]).map(async sub => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          body
+        )
+        sent++
+      } catch (err) {
+        const statusCode = (err as { statusCode?: number }).statusCode
+        if (statusCode === 404 || statusCode === 410) {
+          gone.push(sub.endpoint)
+        } else {
+          console.error('[push] sendNotification:', err)
+        }
+      }
+    })
+  )
+
+  if (gone.length > 0) {
+    await db.from('push_subscriptions').delete().in('endpoint', gone)
+  }
+
+  return sent
+}
+
+export interface NotifiableAccount {
+  id: string
+  user_id: string
+  name: string
+  consent_expires_at: string | null
+  consent_reminder_sent_for: string | null
+}
+
+/**
+ * Filtra las cuentas cuyo consentimiento PSD2 está en estado `critical`
+ * (caduca pronto, spec §9.2) y para las que aún no se ha enviado el aviso de
+ * este ciclo de caducidad (`consent_reminder_sent_for !== consent_expires_at`).
+ */
+export function selectAccountsToNotify(accounts: NotifiableAccount[]): NotifiableAccount[] {
+  return accounts.filter(account => {
+    const { status } = getConsentStatus(account.consent_expires_at)
+    if (status !== 'critical') return false
+    return account.consent_reminder_sent_for !== account.consent_expires_at
+  })
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "icons:generate": "node scripts/generate-icons.mjs",
     "scrape:edenred": "node --env-file-if-exists=.env.local scripts/edenred-scrape.mjs",
     "scrape:edenred:login": "node --env-file=.env.local scripts/edenred-login.mjs",
-    "cron:edenred:status": "node scripts/edenred-status.mjs"
+    "cron:edenred:status": "node scripts/edenred-status.mjs",
+    "push:test": "node --env-file=.env.local scripts/send-test-push.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -29,7 +30,8 @@
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
     "shadcn": "^4.6.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@serwist/next": "^9.5.11",
@@ -37,6 +39,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "playwright": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@serwist/next':
         specifier: ^9.5.11
@@ -66,6 +69,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -1060,6 +1066,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1337,6 +1346,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1376,6 +1388,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1395,6 +1410,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1675,6 +1693,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
@@ -2161,6 +2182,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2458,6 +2483,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2631,6 +2662,9 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3055,6 +3089,9 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -3524,6 +3561,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -4543,6 +4585,10 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
@@ -4849,6 +4895,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -4872,6 +4925,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.27: {}
+
+  bn.js@4.12.3: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -4907,6 +4962,8 @@ snapshots:
       electron-to-chromium: 1.5.349
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -5132,6 +5189,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   eciesjs@0.4.18:
     dependencies:
@@ -5800,6 +5861,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -6054,6 +6117,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6181,6 +6255,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6658,6 +6734,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -7217,6 +7295,16 @@ snapshots:
       '@types/node': 20.19.39
     transitivePeerDependencies:
       - msw
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 

--- a/scripts/send-test-push.mjs
+++ b/scripts/send-test-push.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Envía una notificación push de prueba a todas las suscripciones de un usuario.
+// Sirve para validar el E2E de la issue #115 (aviso con la app cerrada).
+//
+// Uso:
+//   node --env-file=.env.local scripts/send-test-push.mjs <user_id> [mensaje]
+//
+// Requiere en el entorno: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+// NEXT_PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT.
+
+import { createClient } from '@supabase/supabase-js'
+import webpush from 'web-push'
+
+const [userId, ...rest] = process.argv.slice(2)
+const message = rest.join(' ') || 'Notificación de prueba de Finanzas.'
+
+if (!userId) {
+  console.error('Uso: node --env-file=.env.local scripts/send-test-push.mjs <user_id> [mensaje]')
+  process.exit(1)
+}
+
+const {
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+  VAPID_PRIVATE_KEY,
+  VAPID_SUBJECT,
+} = process.env
+
+for (const [name, value] of Object.entries({
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+  VAPID_PRIVATE_KEY,
+  VAPID_SUBJECT,
+})) {
+  if (!value) {
+    console.error(`Falta la variable de entorno ${name}`)
+    process.exit(1)
+  }
+}
+
+webpush.setVapidDetails(VAPID_SUBJECT, NEXT_PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY)
+
+const db = createClient(NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+const { data: subs, error } = await db
+  .from('push_subscriptions')
+  .select('endpoint, p256dh, auth')
+  .eq('user_id', userId)
+
+if (error) {
+  console.error('Error al leer suscripciones:', error.message)
+  process.exit(1)
+}
+if (!subs || subs.length === 0) {
+  console.error(`El usuario ${userId} no tiene suscripciones push.`)
+  process.exit(1)
+}
+
+const payload = JSON.stringify({
+  title: 'Finanzas — prueba',
+  body: message,
+  url: '/cuentas',
+})
+
+let ok = 0
+for (const sub of subs) {
+  try {
+    await webpush.sendNotification(
+      { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+      payload,
+    )
+    ok++
+    console.log('✓ enviado a', sub.endpoint.slice(0, 60) + '…')
+  } catch (err) {
+    console.error('✗ fallo en', sub.endpoint.slice(0, 60) + '…', '·', err.statusCode ?? err.message)
+  }
+}
+
+console.log(`\n${ok}/${subs.length} notificaciones enviadas.`)

--- a/supabase/migrations/20260530000000_push_subscriptions.sql
+++ b/supabase/migrations/20260530000000_push_subscriptions.sql
@@ -1,0 +1,34 @@
+-- Issue #115: Notificaciones push (Web Push API)
+-- Tabla de suscripciones push por usuario + columna de dedupe del aviso de caducidad PSD2.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- TABLA: push_subscriptions
+-- ============================================================
+-- Una fila por endpoint del navegador. Un mismo usuario puede tener varias
+-- (varios dispositivos / navegadores). El endpoint es único globalmente.
+CREATE TABLE push_subscriptions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint    TEXT NOT NULL UNIQUE,   -- URL del push service del navegador
+  p256dh      TEXT NOT NULL,          -- clave pública de la suscripción (cifrado)
+  auth        TEXT NOT NULL,          -- secreto de autenticación de la suscripción
+  created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_push_subscriptions_user_id ON push_subscriptions(user_id);
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users access own push subscriptions"
+  ON push_subscriptions FOR ALL USING (auth.uid() = user_id);
+
+-- ============================================================
+-- accounts: dedupe del aviso de caducidad PSD2
+-- ============================================================
+-- Guarda el valor de consent_expires_at para el que ya se envió el aviso de
+-- "caduca en ≤7 días", para no reenviarlo cada día. Al renovar el consentimiento
+-- cambia consent_expires_at y el callback resetea esta columna a NULL, dejando
+-- la cuenta elegible para un nuevo aviso en el siguiente ciclo de caducidad.
+ALTER TABLE accounts ADD COLUMN consent_reminder_sent_for TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
Closes #115

Monta la cañería **Web Push** completa de la PWA y un único emisor real: aviso de **caducidad PSD2 a ≤7 días**.

## Qué incluye

**Base de datos** (`supabase/migrations/20260530000000_push_subscriptions.sql`)
- Tabla `push_subscriptions` (`user_id`, `endpoint` único, `p256dh`, `auth`, `created_at`) con RLS `auth.uid() = user_id` e índice por `user_id`.
- Columna `accounts.consent_reminder_sent_for` para **deduplicar** el aviso (guarda el `consent_expires_at` ya notificado; se resetea solo al renovar).

**Servidor**
- `lib/push.ts`: `sendPushToUser` (firma VAPID, **poda suscripciones muertas** 404/410) y `selectAccountsToNotify` (helper puro, reutiliza `getConsentStatus`).
- `lib/push-client.ts`: `urlBase64ToUint8Array` aislado para **no arrastrar `web-push` (Node-only) al bundle de cliente**.
- `POST /api/push/subscribe` y `POST /api/push/unsubscribe` (autenticadas).
- Emisor integrado en el **cron diario existente** (`/api/sync/enablebanking/cron`), que ya carga las cuentas con `consent_expires_at`; añade `notified` a la respuesta. Reset del dedupe en el callback de banking al renovar.

**Service worker** (`app/sw.ts`)
- Listeners `push` (muestra la notificación nativa) y `notificationclick` (enfoca pestaña abierta o abre la ruta).

**UI**
- Campana del header (antes deshabilitada) → Sheet "Notificaciones" para activar/desactivar.
- Hook `usePushSubscription` con detección de soporte; el permiso se solicita **solo tras click explícito**. Mensaje para iOS sin instalar la PWA.

**Tooling**
- `scripts/send-test-push.mjs` (`pnpm push:test <user_id>`) para el E2E.
- `public/sw.js` (generado, gitignored) añadido a los ignores de ESLint.

## Añadidos respecto al alcance literal de la issue (acordados)
- Columna `consent_reminder_sent_for` (dedupe del aviso).
- Script `send-test-push.mjs` para validar la notificación con la app cerrada.

## Pendiente de configuración manual (no en el código)
- Ejecutar la migración en Supabase.
- Añadir `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` **a Vercel** (el cron firma el push ahí dentro). **No** hacen falta en GitHub Secrets: el workflow solo hace `curl` al endpoint, no envía pushes. Ya están en `.env.local` local y documentadas en `.env.example`.

## Validación
- ✅ `pnpm test` (226 tests, incluye `lib/push.test.ts`)
- ✅ `pnpm lint`
- ✅ `pnpm build`

E2E manual pendiente de hacer en `pnpm build && pnpm start` (Chrome desktop): activar → push de prueba con la app cerrada → click abre `/cuentas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)