### PR TITLE
fix(pwa): feedback de error y estado de carga en notificaciones push

### DIFF
--- a/components/notifications/NotificationsTrigger.tsx
+++ b/components/notifications/NotificationsTrigger.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Bell, BellOff, BellRing } from 'lucide-react'
+import { Bell, BellOff, BellRing, Loader2 } from 'lucide-react'
 import {
   Sheet,
   SheetContent,
@@ -11,6 +11,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { usePushSubscription } from '@/hooks/usePushSubscription'
+import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
 
 /**
  * Campana del header (issue #115). Abre un Sheet para activar/desactivar las
@@ -19,6 +20,30 @@ import { usePushSubscription } from '@/hooks/usePushSubscription'
 export function NotificationsTrigger() {
   const [open, setOpen] = useState(false)
   const { support, enabled, busy, denied, subscribe, unsubscribe } = usePushSubscription()
+  const { showToast } = useSyncStatus()
+
+  // El hook rechaza la promesa si algo falla; aquí la capturamos para avisar al
+  // usuario en vez de dejar el botón como si «no hubiera pasado nada» (#123).
+  async function handleSubscribe() {
+    try {
+      await subscribe()
+    } catch (err) {
+      console.error('[NotificationsTrigger.subscribe]', err)
+      showToast('No se pudieron activar las notificaciones, inténtalo de nuevo.', handleSubscribe)
+    }
+  }
+
+  async function handleUnsubscribe() {
+    try {
+      await unsubscribe()
+    } catch (err) {
+      console.error('[NotificationsTrigger.unsubscribe]', err)
+      showToast(
+        'No se pudieron desactivar las notificaciones, inténtalo de nuevo.',
+        handleUnsubscribe
+      )
+    }
+  }
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -54,6 +79,20 @@ export function NotificationsTrigger() {
         </SheetHeader>
 
         <div className="flex flex-col gap-3 px-4 pb-2 pt-2">
+          {support === 'loading' && (
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" strokeWidth={2} />
+              Comprobando compatibilidad…
+            </p>
+          )}
+
+          {support === 'error' && (
+            <p className="text-xs text-muted-foreground">
+              No se pudo cargar el servicio de notificaciones. Recarga la página e inténtalo de
+              nuevo.
+            </p>
+          )}
+
           {support === 'unsupported' && (
             <p className="text-xs text-muted-foreground">
               Tu navegador no admite notificaciones push. En iPhone, instala antes la app desde
@@ -80,7 +119,7 @@ export function NotificationsTrigger() {
             (enabled ? (
               <button
                 type="button"
-                onClick={unsubscribe}
+                onClick={handleUnsubscribe}
                 disabled={busy}
                 className="flex w-full items-center justify-center gap-2 rounded-xl border border-border px-3 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
               >
@@ -90,7 +129,7 @@ export function NotificationsTrigger() {
             ) : (
               <button
                 type="button"
-                onClick={subscribe}
+                onClick={handleSubscribe}
                 disabled={busy || denied}
                 className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary px-3 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
               >

--- a/hooks/usePushSubscription.ts
+++ b/hooks/usePushSubscription.ts
@@ -6,16 +6,24 @@ import { urlBase64ToUint8Array } from '@/lib/push-client'
 /**
  * Gestiona la suscripción a notificaciones push del navegador (issue #115).
  *
- * - `support`: 'loading' mientras se comprueba, 'supported' o 'unsupported'.
- *   No soportado típico: Safari iOS sin instalar la PWA (requiere iOS 16.4+ y
- *   "Añadir a pantalla de inicio").
+ * - `support`: 'loading' mientras se comprueba, 'supported', 'unsupported' o
+ *   'error' si la detección no pudo completarse (p. ej. el service worker nunca
+ *   activa). No soportado típico: Safari iOS sin instalar la PWA (requiere
+ *   iOS 16.4+ y "Añadir a pantalla de inicio").
  * - `enabled`: hay una suscripción activa para este navegador.
  * - `subscribe`/`unsubscribe`: solo deben llamarse desde una interacción
- *   explícita del usuario (pedir permiso al cargar es mal patrón).
+ *   explícita del usuario (pedir permiso al cargar es mal patrón). Rechazan la
+ *   promesa si algo falla; el llamante debe capturarla para avisar al usuario.
  */
-export type PushSupport = 'loading' | 'supported' | 'unsupported'
+export type PushSupport = 'loading' | 'supported' | 'unsupported' | 'error'
 
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+
+/**
+ * Tope de espera para `navigator.serviceWorker.ready`: ese promise nunca resuelve
+ * si la SW no llega a activar, lo que dejaría el estado colgado en 'loading'.
+ */
+const READY_TIMEOUT_MS = 10_000
 
 export function usePushSubscription() {
   const [support, setSupport] = useState<PushSupport>('loading')
@@ -38,7 +46,14 @@ export function usePushSubscription() {
 
       if (!supported) return { support: 'unsupported' as const, enabled: false, denied: false }
 
-      const reg = await navigator.serviceWorker.ready
+      // `serviceWorker.ready` puede no resolver nunca; lo corremos contra un
+      // timeout para no quedarnos colgados en 'loading' indefinidamente.
+      const reg = await Promise.race([
+        navigator.serviceWorker.ready,
+        new Promise<null>(resolve => setTimeout(() => resolve(null), READY_TIMEOUT_MS)),
+      ])
+      if (!reg) return { support: 'error' as const, enabled: false, denied: false }
+
       const sub = await reg.pushManager.getSubscription().catch(() => null)
       return {
         support: 'supported' as const,
@@ -47,12 +62,18 @@ export function usePushSubscription() {
       }
     }
 
-    detect().then(state => {
-      if (cancelled) return
-      setSupport(state.support)
-      setEnabled(state.enabled)
-      setDenied(state.denied)
-    })
+    detect()
+      .then(state => {
+        if (cancelled) return
+        setSupport(state.support)
+        setEnabled(state.enabled)
+        setDenied(state.denied)
+      })
+      .catch(err => {
+        if (cancelled) return
+        console.error('[usePushSubscription.detect]', err)
+        setSupport('error')
+      })
 
     return () => {
       cancelled = true


### PR DESCRIPTION
Cierra #123. Detectado en la QA de #116, sobre la activación de notificaciones push (#115).

## Problemas resueltos

1. **Errores silenciados.** `subscribe`/`unsubscribe` rechazaban la promesa pero `NotificationsTrigger` la invocaba sin `await`/`catch`: el fallo quedaba como *unhandled rejection* y al usuario le parecía que «no pasó nada».
2. **Sheet en blanco durante la carga**, de forma permanente si la SW nunca activaba (`navigator.serviceWorker.ready` no resuelve).

## Cambios

- **`hooks/usePushSubscription.ts`**: `Promise.race` de `serviceWorker.ready` contra un timeout (10s) y nuevo estado `'error'` para no quedar colgado en `'loading'` si la SW no activa. El hook sigue siendo agnóstico de UI.
- **`components/notifications/NotificationsTrigger.tsx`**: handlers con `catch` que muestran un toast (con «Reintentar», reutilizando `showToast` de `SyncStatusProvider`) al fallar `subscribe`/`unsubscribe`; rama de carga con spinner (`Loader2`) y rama de error en el Sheet.

## Criterios de aceptación

- [x] Un fallo al suscribirse/desuscribirse muestra un mensaje visible → toast con Reintentar
- [x] El Sheet muestra estado de carga mientras se resuelve el soporte → rama `loading` con spinner
- [x] No queda en blanco indefinidamente si la SW no activa → timeout → rama `error`

## Validación

`pnpm lint` ✅ · `pnpm test` (226 ✅) · `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)