### PR TITLE
fix(push): TTL acotado y urgency en los envíos web-push (#124)

### DIFF
--- a/lib/push.test.ts
+++ b/lib/push.test.ts
@@ -145,4 +145,18 @@ describe('sendPushToUser', () => {
     expect(sent).toBe(1)
     expect(deleted).toEqual([])
   })
+
+  it('envía con TTL acotado y urgency normal (issue #124)', async () => {
+    const { db } = makeDb([{ endpoint: 'https://push/ok', p256dh: 'k', auth: 'a' }])
+    sendNotification.mockResolvedValue(undefined)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await sendPushToUser(db as any, 'user-1', { title: 't', body: 'b', url: '/' })
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      { TTL: 86400, urgency: 'normal' },
+    )
+  })
 })

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -24,6 +24,14 @@ export interface PushPayload {
   url: string
 }
 
+/**
+ * Opciones de envío comunes (issue #124). Acotamos el TTL a 1 día: el aviso de
+ * caducidad PSD2 (#115) pierde valor si llega con días de retraso, así que si el
+ * dispositivo sigue offline pasado ese plazo es mejor que el push service lo
+ * descarte. `urgency: 'normal'` es lo apropiado para un aviso no interactivo.
+ */
+const PUSH_OPTIONS = { TTL: 86400, urgency: 'normal' } as const
+
 let vapidConfigured = false
 
 /**
@@ -80,7 +88,8 @@ export async function sendPushToUser(
       try {
         await webpush.sendNotification(
           { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-          body
+          body,
+          PUSH_OPTIONS
         )
         sent++
       } catch (err) {

--- a/scripts/send-test-push.mjs
+++ b/scripts/send-test-push.mjs
@@ -70,6 +70,7 @@ for (const sub of subs) {
     await webpush.sendNotification(
       { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
       payload,
+      { TTL: 86400, urgency: 'normal' },
     )
     ok++
     console.log('✓ enviado a', sub.endpoint.slice(0, 60) + '…')


### PR DESCRIPTION
Cierra #124.

## Qué

Pasa `{ TTL: 86400, urgency: 'normal' }` a `webpush.sendNotification`:
- En [`lib/push.ts`](https://github.com/MrClit/fin-app/blob/fix/push-ttl-urgency/lib/push.ts) (envío real del cron PSD2), extraído a una constante `PUSH_OPTIONS` documentada.
- En [`scripts/send-test-push.mjs`](https://github.com/MrClit/fin-app/blob/fix/push-ttl-urgency/scripts/send-test-push.mjs) (script de prueba E2E), para que refleje el envío real.

## Por qué

`TTL` y `urgency` son cabeceras HTTP que viajan al push service (en iOS, **APNs**), así que **afectan a la entrega en iPhone**. Sin opciones se aplicaba el TTL por defecto de web-push (~4 semanas): un aviso de "tu acceso bancario PSD2 caduca pronto" (#115) podía entregarse con días de retraso si el dispositivo estuvo offline — justo cuando ya no sirve. Con TTL de 1 día, si sigue sin entregarse pasado ese plazo, el push service lo descarta.

## Recorte respecto a la issue original

La propuesta original incluía también un `badge` monocromo. Se **descarta**: el campo `badge` es **exclusivo de Android** (iOS/Safari lo ignora y muestra el icono de la app web). Como el proyecto es de usuario único en iPhone, no aporta nada y `app/sw.ts` se deja sin cambios.

## Validación
- ✅ `pnpm test` — 227 tests, incluye nuevo aserto de que los envíos pasan `{ TTL: 86400, urgency: 'normal' }`
- ✅ `pnpm lint`
- ✅ `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)