### PR TITLE
ci: workflow que ejecuta lint, test y build en cada PR (#126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
   lint-test-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # No fijamos versión aquí: pnpm/action-setup lee "packageManager" de package.json
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No fijamos versión aquí: pnpm/action-setup lee "packageManager" de package.json
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+# Cancela ejecuciones antiguas de la misma rama/PR cuando se hace push nuevo
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        env:
+          # Placeholders válidos: el build de páginas dinámicas (usan cookies()) no instancia
+          # Supabase, pero estos evitan que cualquier ruta prerenderizada lance
+          # "supabaseUrl is required". No son secretos reales.
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+          NEXT_PUBLIC_APP_URL: https://example.com
+          NEXT_PUBLIC_VAPID_PUBLIC_KEY: placeholder-vapid-public-key
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fin-app",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "next dev",
     "tunnel": "ngrok http --domain=decidable-rendering-propeller.ngrok-free.dev 3000",


### PR DESCRIPTION
Closes #126.

## Qué hace
Añade `.github/workflows/ci.yml`, el primer workflow de **CI** del repo. Hasta ahora `CLAUDE.md` exigía correr `pnpm lint`, `pnpm test` y `pnpm build` a mano antes de cada PR, pero nada lo verificaba.

## Cómo funciona
- **Se dispara** en `pull_request` hacia `develop`/`main` y en `push` a `develop`/`main`.
- **Corre** en `ubuntu-latest`: checkout → pnpm 9 → Node 22 (con caché de pnpm) → `pnpm install --frozen-lockfile` → `lint` → `test` → `build`.
- Si lint/test/build fallan, el check de la PR se pone en rojo.

## Decisiones
- **Node 22**: runtime por defecto de Vercel para Next 16 (el repo no fija `engines` ni `vercel.json`), así CI y producción quedan alineados.
- **pnpm 9**: acorde a `lockfileVersion: 9.0` del lockfile.
- **`pnpm build`** ya es `next build --webpack` → reproduce el build de producción (incluye la generación del service worker de Serwist).
- **Placeholders `NEXT_PUBLIC_*`** en el paso de build: las páginas que tocan Supabase son dinámicas (`cookies()`), pero los placeholders blindan cualquier ruta estática frente a `supabaseUrl is required`. No son secretos reales.
- `concurrency` con `cancel-in-progress` para evitar ejecuciones redundantes.

## Verificación local (entorno tipo-CI, sin `.env.local`)
- ✅ `pnpm lint`
- ✅ `pnpm test` — 227 tests
- ✅ `pnpm build` con los placeholders → build de producción correcto (25 rutas)

## Fuera de alcance
Marcar el check como *required* en la protección de rama (acción manual en Settings → Branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)