### PR TITLE
feat(pwa): loading.tsx por ruta para feedback instantáneo al navegar (#129)

### DIFF
--- a/app/(app)/analisis/loading.tsx
+++ b/app/(app)/analisis/loading.tsx
@@ -1,0 +1,5 @@
+import { AnalisisSkeleton } from '@/components/analytics/AnalisisSkeleton'
+
+export default function Loading() {
+  return <AnalisisSkeleton />
+}

--- a/app/(app)/cuentas/loading.tsx
+++ b/app/(app)/cuentas/loading.tsx
@@ -1,0 +1,5 @@
+import { CuentasSkeleton } from '@/components/accounts/CuentasSkeleton'
+
+export default function Loading() {
+  return <CuentasSkeleton />
+}

--- a/app/(app)/loading.tsx
+++ b/app/(app)/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton'
+
+export default function Loading() {
+  return <DashboardSkeleton />
+}

--- a/app/(app)/movimientos/loading.tsx
+++ b/app/(app)/movimientos/loading.tsx
@@ -1,0 +1,5 @@
+import { MovimientosSkeleton } from '@/components/transactions/MovimientosSkeleton'
+
+export default function Loading() {
+  return <MovimientosSkeleton />
+}

--- a/components/analytics/AnalisisSkeleton.tsx
+++ b/components/analytics/AnalisisSkeleton.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+function CardSkeleton({ height = 120 }: { height?: number }) {
+  return <Skeleton className="rounded-[20px]" style={{ height }} />
+}
+
+/**
+ * Estado de carga de ruta para /analisis. Replica la estructura de
+ * AnalyticsClient (header sticky + tarjetas) para que no haya salto de layout
+ * al llegar el contenido real. Se sirve vía app/(app)/analisis/loading.tsx.
+ */
+export function AnalisisSkeleton() {
+  return (
+    <div>
+      {/* Sticky header — mismo encuadre que AnalyticsClient */}
+      <div
+        className="sticky z-30 border-b border-border px-5 pt-3 pb-3"
+        style={{
+          top: 'calc(env(safe-area-inset-top) + 3rem)',
+          background: 'color-mix(in srgb, var(--background) 92%, transparent)',
+          backdropFilter: 'blur(16px)',
+        }}
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-xl font-bold text-foreground">Análisis</span>
+          <Skeleton className="h-7 w-24 rounded-full" />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col gap-4 px-5 py-3">
+        {/* KPI row */}
+        <div className="flex gap-2.5">
+          <CardSkeleton />
+          <CardSkeleton />
+        </div>
+        {/* Chart card */}
+        <CardSkeleton height={220} />
+        {/* Category breakdown */}
+        <CardSkeleton height={420} />
+        {/* Savings card */}
+        <CardSkeleton />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Cierra #129.

## Problema
Al navegar entre secciones de `(app)` había un "tiempo muerto" sin feedback (detectado en QA en iPhone/PWA, #116). No existía ningún `loading.tsx`: las páginas server tienen `<Suspense>` interno, pero ese boundary solo actúa cuando el servidor ya está respondiendo. La fase previa —desde el tap hasta que llega el RSC payload de la ruta dinámica— solo muestra feedback instantáneo si el segmento tiene un `loading.tsx`.

## Cambios
Un `loading.tsx` por sección que renderiza el skeleton correspondiente:

- `app/(app)/loading.tsx` → `DashboardSkeleton`
- `app/(app)/movimientos/loading.tsx` → `MovimientosSkeleton`
- `app/(app)/cuentas/loading.tsx` → `CuentasSkeleton`
- `app/(app)/analisis/loading.tsx` → nuevo `AnalisisSkeleton` (replica header sticky + tarjetas de `AnalyticsClient`)

Cada sección necesita el suyo para **sobrescribir la herencia** del `loading.tsx` de la ruta índice (dashboard), que de otro modo Next aplicaría a todos los segmentos hijos.

## Decisiones
- **`analisis/categoria/[id]`**: sin `loading.tsx`. RSC trivial (`await params`, sin queries) y skeleton interno en `CategoryDetailClient`; el tiempo muerto es despreciable. Hereda el de análisis. Seguimiento si en QA molesta.
- **`animate-fade-in` en `<main>`**: se mantiene. Vive en el layout `(app)`, que persiste entre navegaciones, así que solo anima el montaje inicial de la app y no entra en conflicto con los skeletons.
- **No se modifica `AnalyticsClient`**: su header es interactivo (`useAnalytics`) y cada sección conmuta su skeleton de forma independiente, así que reutilizar `AnalisisSkeleton` ahí no aporta.

## Criterios de aceptación
- [x] Al navegar entre secciones aparece de inmediato un skeleton/placeholder
- [x] No hay "tiempo muerto" perceptible entre pulsar y ver contenido

## Validación
`pnpm test` (227 ✓), `pnpm lint` y `pnpm build` pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)