### PR TITLE
fix(pwa): unificar padding lateral a 16px (px-4) en todas las pantallas (#130)

### DIFF
--- a/app/(app)/cuentas/page.tsx
+++ b/app/(app)/cuentas/page.tsx
@@ -40,7 +40,7 @@ async function CuentasContent({
   const params = await searchParams
 
   return (
-    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+    <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       <h1 className="text-xl font-bold text-foreground mb-2">Cuentas</h1>
 
       {params.connected === 'true' && (

--- a/components/accounts/CuentasSkeleton.tsx
+++ b/components/accounts/CuentasSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function CuentasSkeleton() {
   return (
-    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+    <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       {/* Título */}
       <Skeleton className="mb-2 h-7 w-28" />
       {/* Tarjetas de cuenta */}

--- a/components/analytics/AnalisisSkeleton.tsx
+++ b/components/analytics/AnalisisSkeleton.tsx
@@ -14,7 +14,7 @@ export function AnalisisSkeleton() {
     <div>
       {/* Sticky header — mismo encuadre que AnalyticsClient */}
       <div
-        className="sticky z-30 border-b border-border px-5 pt-3 pb-3"
+        className="sticky z-30 border-b border-border px-4 pt-3 pb-3"
         style={{
           top: 'calc(env(safe-area-inset-top) + 3rem)',
           background: 'color-mix(in srgb, var(--background) 92%, transparent)',
@@ -28,7 +28,7 @@ export function AnalisisSkeleton() {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-4 px-5 py-3">
+      <div className="flex flex-col gap-4 px-4 py-3">
         {/* KPI row */}
         <div className="flex gap-2.5">
           <CardSkeleton />

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -94,7 +94,7 @@ export default function AnalyticsClient() {
     <div>
       {/* Sticky header */}
       <div
-        className="sticky z-30 border-b border-border px-5 pt-3 pb-3"
+        className="sticky z-30 border-b border-border px-4 pt-3 pb-3"
         style={{
           top: 'calc(env(safe-area-inset-top) + 3rem)',
           background: 'color-mix(in srgb, var(--background) 92%, transparent)',
@@ -125,7 +125,7 @@ export default function AnalyticsClient() {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-4 px-5 py-3">
+      <div className="flex flex-col gap-4 px-4 py-3">
         {/* KPI row */}
         {loading || !activeBar ? (
           <div className="flex gap-2.5">

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -150,7 +150,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
     <div>
       {/* Sticky header */}
       <div
-        className="sticky top-0 z-50 border-b border-border px-5 pb-3"
+        className="sticky top-0 z-50 border-b border-border px-4 pb-3"
         style={{
           background: 'color-mix(in srgb, var(--background) 92%, transparent)',
           backdropFilter: 'blur(16px)',
@@ -210,7 +210,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-4 px-5 py-4">
+      <div className="flex flex-col gap-4 px-4 py-4">
         {/* Evolution card */}
         <div style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20 }}>
           <div className="mb-1 flex items-center justify-between">

--- a/components/transactions/MovimientosClient.tsx
+++ b/components/transactions/MovimientosClient.tsx
@@ -63,7 +63,7 @@ export function MovimientosClient({ initialTransactions, initialCursor, accounts
   }
 
   return (
-    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+    <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       <h1 className="text-xl font-bold text-foreground">Movimientos</h1>
 
       <MovimientosToolbar

--- a/components/transactions/MovimientosSkeleton.tsx
+++ b/components/transactions/MovimientosSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function MovimientosSkeleton() {
   return (
-    <div className="px-5 pt-3 pb-6 flex flex-col gap-4">
+    <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       {/* Título */}
       <Skeleton className="h-7 w-40" />
       {/* Toolbar (búsqueda + filtros) */}

--- a/docs/finanzas-app.jsx
+++ b/docs/finanzas-app.jsx
@@ -495,7 +495,7 @@ export default function App() {
         </div>
       </div>
 
-      <div style={{ padding: "0 20px", display: "flex", flexDirection: "column", gap: 16 }}>
+      <div style={{ padding: "0 16px", display: "flex", flexDirection: "column", gap: 16 }}>
 
         {/* Balance total card */}
         <div style={{
@@ -797,7 +797,7 @@ export default function App() {
             <Icon d={Icons.plus} size={18} stroke="white" />
           </button>
         </div>
-        <div style={{ padding: "0 20px", display: "flex", flexDirection: "column", gap: 12 }}>
+        <div style={{ padding: "0 16px", display: "flex", flexDirection: "column", gap: 12 }}>
 
           {/* Buscador */}
           <div style={{
@@ -917,7 +917,7 @@ export default function App() {
           <Icon d={Icons.plus} size={18} stroke="white" />
         </button>
       </div>
-      <div style={{ padding: "0 20px", display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ padding: "0 16px", display: "flex", flexDirection: "column", gap: 12 }}>
         {mockAccounts.map(acc => (
           <div key={acc.id} style={{
             background: t.surface, borderRadius: 20, padding: "20px",
@@ -1390,7 +1390,7 @@ export default function App() {
           position: "sticky", top: 0, zIndex: 50,
           background: dark ? "rgba(15,15,20,0.92)" : "rgba(245,245,247,0.92)",
           backdropFilter: "blur(16px)",
-          padding: "52px 20px 14px",
+          padding: "52px 16px 14px",
           display: "flex", alignItems: "center", justifyContent: "space-between",
           borderBottom: `1px solid ${t.border}`,
           marginBottom: 4,
@@ -1399,7 +1399,7 @@ export default function App() {
           <PeriodButton />
         </div>
 
-        <div style={{ padding: "12px 20px", display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ padding: "12px 16px", display: "flex", flexDirection: "column", gap: 16 }}>
 
           <div style={{ display: "flex", gap: 10 }}>
             {[
@@ -2114,7 +2114,7 @@ export default function App() {
           position: "sticky", top: 0, zIndex: 50,
           background: dark ? "rgba(15,15,20,0.92)" : "rgba(245,245,247,0.92)",
           backdropFilter: "blur(16px)",
-          padding: "52px 20px 14px",
+          padding: "52px 16px 14px",
           borderBottom: `1px solid ${t.border}`,
         }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
@@ -2156,7 +2156,7 @@ export default function App() {
           </div>
         </div>
 
-        <div style={{ padding: "16px 20px", display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ padding: "16px 16px", display: "flex", flexDirection: "column", gap: 16 }}>
           <div style={{ ...styles.card }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
               <div style={{ fontSize: 14, fontWeight: 700, color: t.text }}>Evolución</div>


### PR DESCRIPTION
Cierra #130.

## Contexto
En QA en dispositivo (iPhone, PWA) los márgenes laterales se percibían grandes y el padding horizontal era inconsistente entre pantallas: Dashboard usaba `px-4` (16px) y Movimientos / Cuentas / Análisis (+ headers sticky y detalle de categoría) usaban `px-5` (20px).

## Decisión
Unificar todo a **16px (`px-4`)** — el valor que más reduce los márgenes y aprovecha más ancho. El header superior (`AppHeader` / `StatusBanner`) ya estaba en `px-4`, así que queda alineado con el contenido.

## Cambios
- `px-5` → `px-4` en el contenido y headers sticky de: Cuentas, Movimientos, Análisis y el detalle de categoría.
- Mismos ajustes en los skeletons (`MovimientosSkeleton`, `CuentasSkeleton`, `AnalisisSkeleton`) para que coincidan con su pantalla.
- Prototipo `docs/finanzas-app.jsx` actualizado a 16px en los contenedores de pantalla y headers, manteniéndolo como fuente de verdad coherente.

## Fuera de alcance
Los modales / bottom-sheets (`AddTxModal`, `AccountFilter`, `CategoryPicker`, `TxModal`, `GranPicker`) conservan su padding propio: son overlays con contexto visual distinto, no pantallas.

## Validaciones
- `pnpm lint` ✅
- `pnpm test` ✅ (227 tests)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)