### PR TITLE
feat(auth): login con Google (OAuth) junto a email/contraseña (#132)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -10,6 +10,12 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
+  // Datos de perfil del proveedor OAuth (Google rellena estos campos en
+  // user_metadata). Con login email/contraseña vienen vacíos.
+  const meta = user.user_metadata ?? {}
+  const avatarUrl = (meta.avatar_url ?? meta.picture ?? null) as string | null
+  const fullName = (meta.full_name ?? meta.name ?? null) as string | null
+
   // Estado de caducidad PSD2 para el banner global (spec §9.2). Consulta
   // ligera; se reejecuta al montar el grupo (app) y tras router.refresh().
   const { data: ebAccounts } = await supabase
@@ -22,7 +28,12 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   return (
     <div className="relative mx-auto w-full max-w-105 min-h-screen overflow-clip bg-background">
       <SyncStatusProvider>
-        <AppHeader email={user.email ?? ''} consentBanner={consentBanner} />
+        <AppHeader
+          email={user.email ?? ''}
+          avatarUrl={avatarUrl}
+          fullName={fullName}
+          consentBanner={consentBanner}
+        />
         <main className="pb-22.5 animate-fade-in">
           {children}
         </main>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,15 +1,53 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M23.52 12.27c0-.79-.07-1.54-.2-2.27H12v4.51h6.47a5.53 5.53 0 0 1-2.4 3.63v3h3.88c2.27-2.09 3.57-5.17 3.57-8.87Z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 24c3.24 0 5.96-1.07 7.95-2.9l-3.88-3c-1.08.72-2.45 1.15-4.07 1.15-3.13 0-5.78-2.11-6.73-4.96H1.28v3.09A12 12 0 0 0 12 24Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.27 14.29a7.2 7.2 0 0 1 0-4.58V6.62H1.28a12 12 0 0 0 0 10.76l3.99-3.09Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.44-3.44A11.96 11.96 0 0 0 12 0 12 12 0 0 0 1.28 6.62l3.99 3.09C6.22 6.86 8.87 4.75 12 4.75Z"
+      />
+    </svg>
+  )
+}
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [googleLoading, setGoogleLoading] = useState(false)
+  // Si el callback OAuth falla (p. ej. el usuario cancela en Google), vuelve
+  // aquí con ?error=auth. Lo leemos en el render inicial y limpiamos la URL.
+  const [error, setError] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
+    const params = new URLSearchParams(window.location.search)
+    return params.get('error') === 'auth'
+      ? 'No se pudo iniciar sesión con Google. Inténtalo de nuevo.'
+      : null
+  })
   const router = useRouter()
+
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).has('error')) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -29,6 +67,26 @@ export default function LoginPage() {
     }
   }
 
+  async function handleGoogle() {
+    setGoogleLoading(true)
+    setError(null)
+
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${location.origin}/auth/callback` },
+    })
+
+    // Si signInWithOAuth tiene éxito, el navegador redirige a Google y este
+    // código ya no se ejecuta. Solo gestionamos el caso de error.
+    if (error) {
+      setGoogleLoading(false)
+      setError('No se pudo iniciar sesión con Google. Inténtalo de nuevo.')
+    }
+  }
+
+  const busy = loading || googleLoading
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-neutral-950 px-4">
       <div className="w-full max-w-sm">
@@ -38,6 +96,22 @@ export default function LoginPage() {
         </div>
 
         <div className="rounded-2xl bg-neutral-900 border border-neutral-800 p-6">
+          <button
+            type="button"
+            onClick={handleGoogle}
+            disabled={busy}
+            className="w-full flex items-center justify-center gap-2.5 rounded-lg bg-white hover:bg-neutral-100 disabled:bg-neutral-300 disabled:text-neutral-500 px-4 py-2.5 text-sm font-medium text-neutral-900 transition-colors"
+          >
+            <GoogleIcon />
+            {googleLoading ? 'Conectando…' : 'Continuar con Google'}
+          </button>
+
+          <div className="my-5 flex items-center gap-3">
+            <div className="h-px flex-1 bg-neutral-800" />
+            <span className="text-xs text-neutral-500">o</span>
+            <div className="h-px flex-1 bg-neutral-800" />
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label htmlFor="email" className="block text-sm text-neutral-400 mb-1.5">
@@ -75,7 +149,7 @@ export default function LoginPage() {
 
             <button
               type="submit"
-              disabled={loading || !email || !password}
+              disabled={busy || !email || !password}
               className="w-full rounded-lg bg-blue-600 hover:bg-blue-500 disabled:bg-neutral-700 disabled:text-neutral-500 px-4 py-2.5 text-sm font-medium text-white transition-colors"
             >
               {loading ? 'Entrando…' : 'Entrar'}

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -6,16 +6,21 @@ import { NotificationsTrigger } from './notifications/NotificationsTrigger'
 import { StatusBanner } from './sync/StatusBanner'
 import type { ConsentBannerData } from '@/lib/accounts'
 
-type Props = { email: string; consentBanner: ConsentBannerData | null }
+type Props = {
+  email: string
+  avatarUrl?: string | null
+  fullName?: string | null
+  consentBanner: ConsentBannerData | null
+}
 
-export function AppHeader({ email, consentBanner }: Props) {
+export function AppHeader({ email, avatarUrl, fullName, consentBanner }: Props) {
   const pathname = usePathname()
   if (pathname.startsWith('/analisis/categoria/')) return null
 
   return (
     <header className="pt-[env(safe-area-inset-top)] sticky top-0 z-40 bg-background/85 backdrop-blur-xl">
       <div className="flex h-12 items-center justify-between px-4">
-        <UserMenuTrigger email={email} />
+        <UserMenuTrigger email={email} avatarUrl={avatarUrl} fullName={fullName} />
         <NotificationsTrigger />
       </div>
       <StatusBanner consent={consentBanner} />

--- a/components/dashboard/UserMenuTrigger.tsx
+++ b/components/dashboard/UserMenuTrigger.tsx
@@ -13,11 +13,11 @@ import {
 import { signOut } from '@/app/actions/auth'
 import { ThemeToggle } from '@/components/theme-toggle'
 
-type Props = { email: string }
+type Props = { email: string; avatarUrl?: string | null; fullName?: string | null }
 
-export function UserMenuTrigger({ email }: Props) {
+export function UserMenuTrigger({ email, avatarUrl, fullName }: Props) {
   const [open, setOpen] = useState(false)
-  const initial = email.trim().charAt(0).toUpperCase()
+  const initial = (fullName?.trim() || email.trim()).charAt(0).toUpperCase()
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -26,9 +26,19 @@ export function UserMenuTrigger({ email }: Props) {
           <button
             type="button"
             aria-label="Abrir menú de usuario"
-            className="grid size-9 place-items-center rounded-full border border-border bg-card text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+            className="grid size-9 place-items-center overflow-hidden rounded-full border border-border bg-card text-sm font-semibold text-foreground transition-colors hover:bg-muted"
           >
-            {initial || <User className="size-4.5" strokeWidth={2} />}
+            {avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element -- avatar remoto de Google, sin optimización de next/image
+              <img
+                src={avatarUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+                className="size-full object-cover"
+              />
+            ) : (
+              initial || <User className="size-4.5" strokeWidth={2} />
+            )}
           </button>
         }
       />
@@ -38,13 +48,23 @@ export function UserMenuTrigger({ email }: Props) {
       >
         <SheetHeader className="flex flex-row items-center gap-3 pt-3">
           <div
-            className="grid size-10 place-items-center rounded-full text-base font-semibold text-white"
+            className="grid size-10 place-items-center overflow-hidden rounded-full text-base font-semibold text-white"
             style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
           >
-            {initial || <UserCircle2 className="size-5" />}
+            {avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element -- avatar remoto de Google, sin optimización de next/image
+              <img
+                src={avatarUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+                className="size-full object-cover"
+              />
+            ) : (
+              initial || <UserCircle2 className="size-5" />
+            )}
           </div>
           <div className="flex flex-col gap-0.5 text-left">
-            <SheetTitle className="text-sm">Tu cuenta</SheetTitle>
+            <SheetTitle className="text-sm">{fullName || 'Tu cuenta'}</SheetTitle>
             <SheetDescription className="text-xs">{email || 'Sin email'}</SheetDescription>
           </div>
         </SheetHeader>


### PR DESCRIPTION
Cierra #132.

## Cambios de código
- Botón **"Continuar con Google"** en `app/login/page.tsx` usando `supabase.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: \`${location.origin}/auth/callback\` } })`.
- **Convive** con el formulario email/contraseña (decisión confirmada: ambos métodos disponibles, email/contraseña como respaldo).
- Logo de Google como SVG inline (Lucide no incluye marca de Google).
- Mensaje de error en `/login` cuando el callback OAuth redirige con `?error=auth` (p. ej. el usuario cancela en Google). Se lee en el render inicial y se limpia la URL.
- El callback OAuth (`app/auth/callback/route.ts`) ya existía y no necesita cambios.

## ⚠️ Configuración externa requerida (manual, no incluida en el repo)
Sin esto, el botón redirige pero Google rechaza el login:

1. **Google Cloud Console** → crear *OAuth Client ID* (tipo Web) y añadir como *Authorized redirect URI*: `https://<proyecto>.supabase.co/auth/v1/callback`.
2. **Supabase Dashboard** → Authentication → Providers → Google → pegar *Client ID* + *Secret* y activarlo.

## Requisito "mismo email = mismo usuario"
Supabase **vincula automáticamente** identidades con el mismo email *verificado* (Google siempre verifica el email) → el mismo email cae en el mismo `auth.uid()` tanto por Google como por email/contraseña, y por tanto ve los mismos datos. No requiere cambios de esquema. (La RLS actual `auth.uid() = user_id` sigue siendo correcta para este caso.)

## Validación
- ✅ `pnpm lint`
- ✅ `pnpm test` (227 tests)
- ✅ `pnpm build`
- ⏳ E2E manual (login → callback → sesión → `/`): pendiente de la configuración externa de Google/Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)