### PR TITLE
feat(db): modelo de hogar para datos financieros compartidos (#131, Fase 1)

### DIFF
--- a/app/(app)/movimientos/page.tsx
+++ b/app/(app)/movimientos/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import { MovimientosClient } from '@/components/transactions/MovimientosClient'
 import { MovimientosSkeleton } from '@/components/transactions/MovimientosSkeleton'
 import { buildNextCursor } from '@/lib/pagination'
@@ -30,6 +31,9 @@ async function MovimientosContent({
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) redirect('/login')
+
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - 90)
   const cutoffStr = cutoff.toISOString().slice(0, 10)
@@ -50,7 +54,7 @@ async function MovimientosContent({
     supabase
       .from('accounts')
       .select('id')
-      .eq('user_id', user.id)
+      .eq('household_id', householdId)
       .eq('source', 'manual')
       .order('created_at', { ascending: true })
       .limit(1),
@@ -61,7 +65,7 @@ async function MovimientosContent({
   if (!manualAccountId) {
     const { data: created } = await supabase
       .from('accounts')
-      .insert({ user_id: user.id, name: 'Manual', type: 'cash', source: 'manual', color: '#64748b' })
+      .insert({ user_id: user.id, household_id: householdId, name: 'Manual', type: 'cash', source: 'manual', color: '#64748b' })
       .select('id')
       .single()
     manualAccountId = created?.id

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 
 export async function GET() {
   const supabase = await createClient()
@@ -8,10 +9,15 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { data: accounts, error } = await supabase
     .from('accounts')
     .select('id, name, type, source, is_liability, balance, number, color, currency, last_synced, consent_expires_at, created_at')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .eq('is_active', true)
     .order('created_at', { ascending: true })
 

--- a/app/api/analytics/categoria/route.test.ts
+++ b/app/api/analytics/categoria/route.test.ts
@@ -9,12 +9,13 @@ vi.mock('@/lib/supabase/server', () => ({
 const { GET } = await import('./route')
 
 const USER_ID = '00000000-0000-0000-0000-000000000001'
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000a1'
 
 // Jueves 21 mayo 2026, 12:00 local
 const NOW = new Date(2026, 4, 21, 12, 0, 0, 0)
 
 interface RpcParams {
-  p_user_id: string
+  p_household_id: string
   p_start_date: string
   p_end_date: string
 }
@@ -40,6 +41,22 @@ interface MockOpts {
   user?: { id: string } | null
   authError?: unknown
   rpc?: RpcImpl
+  householdId?: string | null
+}
+
+/** Builder encadenable que imita la consulta de getHouseholdId(). */
+function householdBuilder(householdId: string | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    maybeSingle: async () => ({
+      data: householdId ? { household_id: householdId } : null,
+      error: null,
+    }),
+  }
+  return builder
 }
 
 function buildSupabase(opts: MockOpts = {}) {
@@ -50,6 +67,7 @@ function buildSupabase(opts: MockOpts = {}) {
         error: null,
       }))
   )
+  const householdId = opts.householdId === undefined ? HOUSEHOLD_ID : opts.householdId
   const supabase = {
     auth: {
       getUser: vi.fn(async () => ({
@@ -57,6 +75,7 @@ function buildSupabase(opts: MockOpts = {}) {
         error: opts.authError ?? null,
       })),
     },
+    from: vi.fn(() => householdBuilder(householdId)),
     rpc: rpcSpy,
   }
   return { supabase, rpcSpy }
@@ -243,7 +262,7 @@ describe('GET /api/analytics/categoria — drilldown por categoría', () => {
     for (const p of body.periods) expect(p.amount).toBe(0)
   })
 
-  it('llama al RPC con p_user_id y fechas ISO por cada periodo', async () => {
+  it('llama al RPC con p_household_id y fechas ISO por cada periodo', async () => {
     const { supabase, rpcSpy } = buildSupabase()
     vi.mocked(createClient).mockResolvedValue(
       supabase as unknown as Awaited<ReturnType<typeof createClient>>
@@ -252,7 +271,7 @@ describe('GET /api/analytics/categoria — drilldown por categoría', () => {
     await GET(req({ gran: 'month', id: 'restaurant' }))
     for (const [name, params] of rpcSpy.mock.calls) {
       expect(name).toBe('get_period_data')
-      expect(params.p_user_id).toBe(USER_ID)
+      expect(params.p_household_id).toBe(HOUSEHOLD_ID)
       expect(params.p_start_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
       expect(params.p_end_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
     }

--- a/app/api/analytics/categoria/route.ts
+++ b/app/api/analytics/categoria/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import { getWindowPeriods, toISODate } from '@/lib/analytics'
 import type { Granularity, CategoryId, CategoryAnalyticsResponse } from '@/types'
 import { CATEGORY_META } from '@/lib/theme'
@@ -22,6 +23,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   try {
     const allPeriods = getWindowPeriods(gran, 0)
     const window = allPeriods.slice(-WINDOW)
@@ -29,9 +35,9 @@ export async function GET(request: NextRequest) {
     const periods = await Promise.all(
       window.map(async (range) => {
         const { data } = await supabase.rpc('get_period_data', {
-          p_user_id:    user.id,
-          p_start_date: toISODate(range.start),
-          p_end_date:   toISODate(range.end),
+          p_household_id: householdId,
+          p_start_date:   toISODate(range.start),
+          p_end_date:     toISODate(range.end),
         })
         const row = data?.[0]
         const byCategory: { category: string | null; amount: number }[] = row?.by_category ?? []

--- a/app/api/analytics/route.test.ts
+++ b/app/api/analytics/route.test.ts
@@ -11,12 +11,13 @@ vi.mock('@/lib/supabase/server', () => ({
 const { GET } = await import('./route')
 
 const USER_ID = '00000000-0000-0000-0000-000000000001'
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000a1'
 
 // NOW = jueves 21 mayo 2026, 12:00 local. Mismo bedrock que lib/analytics.test.ts
 const NOW = new Date(2026, 4, 21, 12, 0, 0, 0)
 
 interface RpcParams {
-  p_user_id: string
+  p_household_id: string
   p_start_date: string
   p_end_date: string
 }
@@ -37,6 +38,22 @@ interface MockOpts {
   user?: { id: string } | null
   authError?: unknown
   rpc?: RpcImpl
+  householdId?: string | null
+}
+
+/** Builder encadenable que imita la consulta de getHouseholdId(). */
+function householdBuilder(householdId: string | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    maybeSingle: async () => ({
+      data: householdId ? { household_id: householdId } : null,
+      error: null,
+    }),
+  }
+  return builder
 }
 
 const emptyRow = (): PeriodRow => ({
@@ -76,6 +93,7 @@ function buildSupabase(opts: MockOpts = {}) {
   const rpcSpy = vi.fn<RpcImpl>(
     opts.rpc ?? (async () => ({ data: [emptyRow()], error: null }))
   )
+  const householdId = opts.householdId === undefined ? HOUSEHOLD_ID : opts.householdId
   const supabase = {
     auth: {
       getUser: vi.fn(async () => ({
@@ -83,6 +101,7 @@ function buildSupabase(opts: MockOpts = {}) {
         error: opts.authError ?? null,
       })),
     },
+    from: vi.fn(() => householdBuilder(householdId)),
     rpc: rpcSpy,
   }
   return { supabase, rpcSpy }
@@ -242,7 +261,7 @@ describe('GET /api/analytics — shape de la respuesta', () => {
     expect(rpcSpy).toHaveBeenCalledTimes(24)
     for (const [name, params] of rpcSpy.mock.calls) {
       expect(name).toBe('get_period_data')
-      expect(params.p_user_id).toBe(USER_ID)
+      expect(params.p_household_id).toBe(HOUSEHOLD_ID)
       expect(params.p_start_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
       expect(params.p_end_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
     }

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import { getWindowPeriods, getYoYRange, toISODate } from '@/lib/analytics'
 import type { Granularity, PeriodData, AnalyticsResponse } from '@/types'
 
@@ -20,6 +21,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   try {
     const window = getWindowPeriods(gran, offset)
 
@@ -28,12 +34,12 @@ export async function GET(request: NextRequest) {
         const yoy = getYoYRange(range)
         const [cur, prev] = await Promise.all([
           supabase.rpc('get_period_data', {
-            p_user_id:    user.id,
+            p_household_id: householdId,
             p_start_date: toISODate(range.start),
             p_end_date:   toISODate(range.end),
           }),
           supabase.rpc('get_period_data', {
-            p_user_id:    user.id,
+            p_household_id: householdId,
             p_start_date: toISODate(yoy.start),
             p_end_date:   toISODate(yoy.end),
           }),

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import { createSessionFromCode, decodeBankingState } from '@/lib/enablebanking'
 
 /** Normaliza un IBAN para comparar (sin espacios, mayúsculas). */
@@ -24,6 +25,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${appUrl}/login`)
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.redirect(`${appUrl}/login`)
+  }
+
   let session
   try {
     session = await createSessionFromCode(code)
@@ -38,7 +44,7 @@ export async function GET(request: NextRequest) {
       .from('accounts')
       .select('id, iban')
       .eq('id', state.accountId)
-      .eq('user_id', user.id)
+      .eq('household_id', householdId)
       .maybeSingle()
 
     if (!target) {
@@ -76,6 +82,7 @@ export async function GET(request: NextRequest) {
 
     const accountData = {
       user_id: user.id,
+      household_id: householdId,
       name: acc.product ?? acc.name ?? 'Cuenta bancaria',
       type: 'bank' as const,
       source: 'enablebanking' as const,
@@ -96,7 +103,7 @@ export async function GET(request: NextRequest) {
       const { data: existing } = await supabase
         .from('accounts')
         .select('id')
-        .eq('user_id', user.id)
+        .eq('household_id', householdId)
         .eq('iban', iban)
         .maybeSingle()
 
@@ -108,7 +115,7 @@ export async function GET(request: NextRequest) {
     } else {
       await supabase.from('accounts').upsert(
         { ...accountData, balance: null },
-        { onConflict: 'user_id,external_id' }
+        { onConflict: 'household_id,external_id' }
       )
     }
   }

--- a/app/api/banking/renew/route.ts
+++ b/app/api/banking/renew/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
 
 /**
@@ -15,6 +16,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { accountId } = await request.json()
   if (!accountId) {
     return NextResponse.json({ error: 'accountId es obligatorio' }, { status: 400 })
@@ -24,7 +30,7 @@ export async function POST(request: NextRequest) {
     .from('accounts')
     .select('id, source, aspsp_name, aspsp_country')
     .eq('id', accountId)
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .maybeSingle()
 
   if (!account || account.source !== 'enablebanking') {

--- a/app/api/edenred/route.test.ts
+++ b/app/api/edenred/route.test.ts
@@ -9,10 +9,11 @@ const { POST } = await import('./route')
 
 const SECRET = 'test-secret'
 const USER_ID = '00000000-0000-0000-0000-000000000001'
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000a1'
 const ACCOUNT_ID = '00000000-0000-0000-0000-000000000aaa'
 
 type MockOpts = {
-  userConfig?: { data: { user_id: string } | null; error?: unknown }
+  userConfig?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
   accountSelect?: { data: { id: string } | null; error?: unknown }
   accountInsert?: { data: { id: string } | null; error?: unknown }
   accountUpdate?: { error?: unknown }
@@ -236,7 +237,7 @@ describe('POST /api/edenred — user_config', () => {
 describe('POST /api/edenred — primer POST (crea cuenta)', () => {
   it('inserta la cuenta Edenred con los campos esperados y upsertea las txns', async () => {
     const { db, insertSpy, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID }, error: null },
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: null, error: null },
       accountInsert: { data: { id: ACCOUNT_ID }, error: null },
     })
@@ -251,6 +252,7 @@ describe('POST /api/edenred — primer POST (crea cuenta)', () => {
     expect(insertSpy).toHaveBeenCalledTimes(1)
     expect(insertSpy).toHaveBeenCalledWith({
       user_id: USER_ID,
+      household_id: HOUSEHOLD_ID,
       name: 'Edenred',
       type: 'edenred',
       source: 'scraper',
@@ -265,6 +267,7 @@ describe('POST /api/edenred — primer POST (crea cuenta)', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({
       user_id: USER_ID,
+      household_id: HOUSEHOLD_ID,
       account_id: ACCOUNT_ID,
       external_id: 'ext-1',
       source: 'scraper',
@@ -275,7 +278,7 @@ describe('POST /api/edenred — primer POST (crea cuenta)', () => {
 describe('POST /api/edenred — POST siguiente (actualiza cuenta)', () => {
   it('actualiza solo balance y last_synced de la cuenta existente', async () => {
     const { db, insertSpy, updateSpy, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID }, error: null },
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -301,9 +304,9 @@ describe('POST /api/edenred — POST siguiente (actualiza cuenta)', () => {
 })
 
 describe('POST /api/edenred — idempotencia', () => {
-  it('llama a upsert con onConflict="user_id,external_id" e ignoreDuplicates=false', async () => {
+  it('llama a upsert con onConflict="household_id,external_id" e ignoreDuplicates=false', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID }, error: null },
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -315,7 +318,7 @@ describe('POST /api/edenred — idempotencia', () => {
     expect(upsertSpy).toHaveBeenCalledTimes(1)
     const [, options] = upsertSpy.mock.calls[0]
     expect(options).toEqual({
-      onConflict: 'user_id,external_id',
+      onConflict: 'household_id,external_id',
       ignoreDuplicates: false,
     })
   })
@@ -324,7 +327,7 @@ describe('POST /api/edenred — idempotencia', () => {
 describe('POST /api/edenred — mapeo de category', () => {
   it('aplica "restaurant" cuando la txn no trae category', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID }, error: null },
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -349,7 +352,7 @@ describe('POST /api/edenred — mapeo de category', () => {
 
   it('respeta la category provista por el scraper (p. ej. "income" en una recarga)', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID }, error: null },
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -66,24 +66,25 @@ export async function POST(req: Request) {
 
   const db = createServiceClient()
 
-  // App de usuario único: el webhook no tiene sesión, así que el user_id se
-  // resuelve leyendo el único registro de user_config (decisión documentada
-  // en el plan de #53).
+  // El webhook no tiene sesión: se resuelve el hogar (y un user_id de
+  // creador/auditoría) leyendo el único registro de user_config. App personal
+  // con un único hogar (decisión documentada en el plan de #53, adaptada a #131).
   const { data: userRow, error: userErr } = await db
     .from('user_config')
-    .select('user_id')
+    .select('user_id, household_id')
     .limit(1)
     .maybeSingle()
-  if (userErr || !userRow) {
-    console.error('[edenred] no user_config:', userErr)
+  if (userErr || !userRow || !userRow.household_id) {
+    console.error('[edenred] no user_config/household:', userErr)
     return NextResponse.json({ error: 'No user configured' }, { status: 500 })
   }
   const userId = userRow.user_id as string
+  const householdId = userRow.household_id as string
 
   const { data: existingAccount, error: accSelErr } = await db
     .from('accounts')
     .select('id')
-    .eq('user_id', userId)
+    .eq('household_id', householdId)
     .eq('source', 'scraper')
     .eq('name', 'Edenred')
     .maybeSingle()
@@ -109,6 +110,7 @@ export async function POST(req: Request) {
       .from('accounts')
       .insert({
         user_id: userId,
+        household_id: householdId,
         name: 'Edenred',
         type: 'edenred',
         source: 'scraper',
@@ -131,6 +133,7 @@ export async function POST(req: Request) {
   if (payload.transactions.length > 0) {
     const rows = payload.transactions.map(tx => ({
       user_id: userId,
+      household_id: householdId,
       account_id: accountId,
       date: tx.transaction_date,
       amount: tx.amount,
@@ -142,7 +145,7 @@ export async function POST(req: Request) {
 
     const { error: upsertErr } = await db
       .from('transactions')
-      .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: false })
+      .upsert(rows, { onConflict: 'household_id,external_id', ignoreDuplicates: false })
     if (upsertErr) {
       console.error('[edenred] upsert transactions:', upsertErr)
       return NextResponse.json({ error: 'DB error' }, { status: 500 })

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 
 /**
  * Guarda la PushSubscription del navegador para el usuario autenticado
@@ -13,6 +14,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { endpoint, keys } = await request.json().catch(() => ({}))
   if (!endpoint || !keys?.p256dh || !keys?.auth) {
     return NextResponse.json({ error: 'Suscripción inválida' }, { status: 400 })
@@ -21,7 +27,7 @@ export async function POST(request: NextRequest) {
   const { error } = await supabase
     .from('push_subscriptions')
     .upsert(
-      { user_id: user.id, endpoint, p256dh: keys.p256dh, auth: keys.auth },
+      { user_id: user.id, household_id: householdId, endpoint, p256dh: keys.p256dh, auth: keys.auth },
       { onConflict: 'endpoint' }
     )
 

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
 
   const { data: accounts, error: accountsError } = await db
     .from('accounts')
-    .select('id, user_id, name, external_id, session_id, last_synced, consent_expires_at, consent_reminder_sent_for')
+    .select('id, user_id, household_id, name, external_id, session_id, last_synced, consent_expires_at, consent_reminder_sent_for')
     .eq('source', 'enablebanking')
     .eq('is_active', true)
 
@@ -58,11 +58,11 @@ export async function POST(req: Request) {
     return true
   })
 
-  const userIds = Array.from(new Set(syncable.map(a => a.user_id as string)))
+  const householdIds = Array.from(new Set(syncable.map(a => a.household_id as string)))
   const { data: rulesData, error: rulesError } = await db
     .from('categorization_rules')
-    .select('user_id, pattern, field, category_id')
-    .in('user_id', userIds)
+    .select('household_id, pattern, field, category_id')
+    .in('household_id', householdIds)
     .eq('is_active', true)
     .order('priority', { ascending: false })
 
@@ -71,17 +71,17 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 
-  const rulesByUser = new Map<string, DbCategorizationRule[]>()
+  const rulesByHousehold = new Map<string, DbCategorizationRule[]>()
   for (const row of rulesData ?? []) {
-    const userId = (row as { user_id: string }).user_id
+    const householdId = (row as { household_id: string }).household_id
     const rule: DbCategorizationRule = {
       pattern: (row as { pattern: string }).pattern,
       field: (row as { field: DbCategorizationRule['field'] }).field,
       category_id: (row as { category_id: string }).category_id,
     }
-    const list = rulesByUser.get(userId)
+    const list = rulesByHousehold.get(householdId)
     if (list) list.push(rule)
-    else rulesByUser.set(userId, [rule])
+    else rulesByHousehold.set(householdId, [rule])
   }
 
   let totalSynced = 0
@@ -91,7 +91,8 @@ export async function POST(req: Request) {
     if (!account.external_id || !account.session_id) continue
 
     const userId = account.user_id as string
-    const dbRules = rulesByUser.get(userId) ?? []
+    const householdId = account.household_id as string
+    const dbRules = rulesByHousehold.get(householdId) ?? []
     const dateFrom = account.last_synced
       ? (account.last_synced as string).slice(0, 10)
       : undefined
@@ -123,20 +124,21 @@ export async function POST(req: Request) {
         const amount = parseFloat(tx.transaction_amount.amount) * sign
 
         return {
-          user_id:     userId,
-          account_id:  account.id,
-          date:        tx.booking_date,
+          user_id:      userId,
+          household_id: householdId,
+          account_id:   account.id,
+          date:         tx.booking_date,
           amount,
           description,
-          category:    categorizeWithRules(dbRules, description, merchant ?? undefined),
-          source:      'enablebanking' as const,
-          external_id: externalId,
+          category:     categorizeWithRules(dbRules, description, merchant ?? undefined),
+          source:       'enablebanking' as const,
+          external_id:  externalId,
         }
       })
 
       const { error: upsertError } = await db
         .from('transactions')
-        .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: true })
+        .upsert(rows, { onConflict: 'household_id,external_id', ignoreDuplicates: true })
 
       if (upsertError) {
         console.error(`[sync/eb/cron] upsert ${account.external_id}:`, upsertError)

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getHouseholdId } from '@/lib/household'
 import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 import { SYNC_COOLDOWN_MS } from '@/lib/sync'
@@ -10,6 +11,11 @@ export async function POST(request: Request) {
   const supabase = await createClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -29,7 +35,7 @@ export async function POST(request: Request) {
   let accountsQuery = db
     .from('accounts')
     .select('id, external_id, session_id, last_synced')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .eq('source', 'enablebanking')
     .eq('is_active', true)
     // Caducidad PSD2: no se sincronizan conexiones caducadas (issue #78).
@@ -42,7 +48,7 @@ export async function POST(request: Request) {
     db
       .from('categorization_rules')
       .select('pattern, field, category_id')
-      .eq('user_id', user.id)
+      .eq('household_id', householdId)
       .eq('is_active', true)
       .order('priority', { ascending: false }),
   ])
@@ -109,6 +115,7 @@ export async function POST(request: Request) {
 
         return {
           user_id:              user.id,
+          household_id:         householdId,
           account_id:           account.id,
           date:                 tx.booking_date,
           amount,
@@ -121,7 +128,7 @@ export async function POST(request: Request) {
 
       const { error: upsertError } = await db
         .from('transactions')
-        .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: true })
+        .upsert(rows, { onConflict: 'household_id,external_id', ignoreDuplicates: true })
 
       if (upsertError) {
         console.error(`[sync/eb] upsert ${account.external_id}:`, upsertError)

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import type { CategoryId } from '@/types'
 
 const VALID_CATEGORIES: CategoryId[] = [
@@ -26,6 +27,11 @@ export async function PATCH(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
   const body = await request.json()
   const { category_manual } = body
@@ -38,7 +44,7 @@ export async function PATCH(
     .from('transactions')
     .update({ category_manual })
     .eq('id', id)
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .select()
     .single()
 
@@ -60,13 +66,18 @@ export async function DELETE(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { id } = await params
 
   const { data: tx } = await supabase
     .from('transactions')
     .select('source')
     .eq('id', id)
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .single()
 
   if (!tx) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -78,7 +89,7 @@ export async function DELETE(
     .from('transactions')
     .delete()
     .eq('id', id)
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
 
   if (error) {
     console.error('[DELETE /api/transactions/[id]]', error)

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -19,6 +25,7 @@ export async function POST(request: NextRequest) {
     .from('transactions')
     .insert({
       user_id: user.id,
+      household_id: householdId,
       account_id,
       amount,
       description,
@@ -44,6 +51,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { searchParams } = request.nextUrl
   const accountsParam = searchParams.get('accounts')
   const category = searchParams.get('category')
@@ -62,7 +74,7 @@ export async function GET(request: NextRequest) {
   let query = supabase
     .from('transactions')
     .select('*, account:accounts(id, name, color)')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .order('date', { ascending: false })
     .order('id', { ascending: false })
     .limit(limit + 1)

--- a/components/dashboard/UserMenuTrigger.tsx
+++ b/components/dashboard/UserMenuTrigger.tsx
@@ -17,7 +17,11 @@ type Props = { email: string; avatarUrl?: string | null; fullName?: string | nul
 
 export function UserMenuTrigger({ email, avatarUrl, fullName }: Props) {
   const [open, setOpen] = useState(false)
+  // Si la imagen remota (avatar de Google) falla o la bloquea una extensión,
+  // se cae a la inicial en vez de dejar el círculo vacío.
+  const [imgError, setImgError] = useState(false)
   const initial = (fullName?.trim() || email.trim()).charAt(0).toUpperCase()
+  const showAvatar = Boolean(avatarUrl) && !imgError
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -28,12 +32,13 @@ export function UserMenuTrigger({ email, avatarUrl, fullName }: Props) {
             aria-label="Abrir menú de usuario"
             className="grid size-9 place-items-center overflow-hidden rounded-full border border-border bg-card text-sm font-semibold text-foreground transition-colors hover:bg-muted"
           >
-            {avatarUrl ? (
+            {showAvatar ? (
               // eslint-disable-next-line @next/next/no-img-element -- avatar remoto de Google, sin optimización de next/image
               <img
-                src={avatarUrl}
+                src={avatarUrl!}
                 alt=""
                 referrerPolicy="no-referrer"
+                onError={() => setImgError(true)}
                 className="size-full object-cover"
               />
             ) : (
@@ -51,12 +56,13 @@ export function UserMenuTrigger({ email, avatarUrl, fullName }: Props) {
             className="grid size-10 place-items-center overflow-hidden rounded-full text-base font-semibold text-white"
             style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
           >
-            {avatarUrl ? (
+            {showAvatar ? (
               // eslint-disable-next-line @next/next/no-img-element -- avatar remoto de Google, sin optimización de next/image
               <img
-                src={avatarUrl}
+                src={avatarUrl!}
                 alt=""
                 referrerPolicy="no-referrer"
+                onError={() => setImgError(true)}
                 className="size-full object-cover"
               />
             ) : (

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
 import type { Account } from '@/types'
 
 export interface DashboardData {
@@ -24,10 +25,13 @@ export async function getDashboardData(): Promise<DashboardData> {
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) throw new Error('Unauthorized')
 
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) throw new Error('Unauthorized')
+
   const { data: accounts, error: accError } = await supabase
     .from('accounts')
     .select('id, name, type, is_liability, balance, number, color, currency, source, last_synced, consent_expires_at, created_at, user_id, external_id, session_id, is_active')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .eq('is_active', true)
     .order('created_at', { ascending: true })
 
@@ -42,7 +46,7 @@ export async function getDashboardData(): Promise<DashboardData> {
   const { data: transactions, error: txError } = await supabase
     .from('transactions')
     .select('date, amount')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .gte('date', thirtyDaysAgo.toISOString())
 
   if (txError) throw new Error('Failed to fetch transactions')
@@ -78,7 +82,7 @@ export async function getDashboardData(): Promise<DashboardData> {
   const { data: monthlyTxData } = await supabase
     .from('transactions')
     .select('date, amount')
-    .eq('user_id', user.id)
+    .eq('household_id', householdId)
     .gte('date', twelveMonthsAgo.toISOString().split('T')[0])
 
   const txByMonth: Record<string, number> = {}

--- a/lib/household.ts
+++ b/lib/household.ts
@@ -1,0 +1,27 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Resuelve el hogar al que pertenece un usuario.
+ *
+ * La propiedad y la visibilidad de los datos financieros se determinan por
+ * `household_id` (issue #131). Cada usuario pertenece a un único hogar en
+ * Fase 1; se devuelve el más antiguo por si en el futuro hubiera varios.
+ *
+ * Devuelve `null` si el usuario no tiene hogar (no debería ocurrir tras la
+ * migración, pero los llamadores deben tratarlo como "sin datos / no autorizado").
+ */
+export async function getHouseholdId(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return data.household_id as string
+}

--- a/supabase/migrations/20260603000000_households.sql
+++ b/supabase/migrations/20260603000000_households.sql
@@ -1,0 +1,68 @@
+-- Issue #131 (Fase 1): modelo de hogar / datos financieros compartidos.
+-- Crea las tablas del hogar y el helper de pertenencia usado por la RLS.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- TABLA: households
+-- ============================================================
+-- Un hogar agrupa a varios usuarios que comparten el mismo conjunto de datos
+-- financieros. La config que afecta a las agregaciones (moneda, día de inicio
+-- de período) vive aquí para que sea consistente entre miembros.
+CREATE TABLE IF NOT EXISTS households (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name             TEXT NOT NULL DEFAULT 'Mi hogar',
+  primary_currency TEXT DEFAULT 'EUR',
+  month_start_day  INTEGER DEFAULT 1,   -- día del mes en que empieza el período
+  created_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- TABLA: household_members
+-- ============================================================
+-- Membresía de cada usuario en un hogar. `role` se reserva para extensibilidad;
+-- en Fase 1 todos los miembros tienen acceso idéntico de lectura/escritura.
+CREATE TABLE IF NOT EXISTS household_members (
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role         TEXT NOT NULL DEFAULT 'member',
+  created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  PRIMARY KEY (household_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_household_members_user ON household_members(user_id);
+
+-- ============================================================
+-- HELPER: current_household_ids()
+-- ============================================================
+-- Devuelve los hogares a los que pertenece el usuario autenticado.
+-- SECURITY DEFINER para que la RLS de las tablas de datos pueda comprobar
+-- pertenencia sin que la consulta a household_members dispare su propia RLS
+-- (evita recursión). Se fija search_path por seguridad.
+CREATE OR REPLACE FUNCTION current_household_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT household_id FROM household_members WHERE user_id = auth.uid();
+$$;
+
+-- ============================================================
+-- ROW LEVEL SECURITY de las tablas del hogar
+-- ============================================================
+ALTER TABLE households        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE household_members ENABLE ROW LEVEL SECURITY;
+
+-- Un usuario sólo ve los hogares a los que pertenece...
+DROP POLICY IF EXISTS "Members access their households" ON households;
+CREATE POLICY "Members access their households" ON households
+  FOR ALL USING (id IN (SELECT current_household_ids()))
+  WITH CHECK (id IN (SELECT current_household_ids()));
+
+-- ...y sólo las filas de membresía de sus propios hogares.
+DROP POLICY IF EXISTS "Members access household membership" ON household_members;
+CREATE POLICY "Members access household membership" ON household_members
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));

--- a/supabase/migrations/20260603000001_add_household_id.sql
+++ b/supabase/migrations/20260603000001_add_household_id.sql
@@ -1,0 +1,110 @@
+-- Issue #131 (Fase 1): añadir household_id a las tablas de datos, migrar los
+-- datos existentes a un hogar inicial por usuario y reescribir las constraints
+-- únicas de user_id -> household_id.
+--
+-- Se conserva user_id en todas las tablas como creador/auditoría; la propiedad
+-- y la visibilidad pasan a determinarse por household_id.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- 1. Añadir columna household_id (nullable de momento, para poder backfillear)
+-- ============================================================
+ALTER TABLE accounts             ADD COLUMN IF NOT EXISTS household_id UUID REFERENCES households(id) ON DELETE CASCADE;
+ALTER TABLE transactions         ADD COLUMN IF NOT EXISTS household_id UUID REFERENCES households(id) ON DELETE CASCADE;
+ALTER TABLE user_config          ADD COLUMN IF NOT EXISTS household_id UUID REFERENCES households(id) ON DELETE CASCADE;
+ALTER TABLE categorization_rules ADD COLUMN IF NOT EXISTS household_id UUID REFERENCES households(id) ON DELETE CASCADE;
+ALTER TABLE push_subscriptions   ADD COLUMN IF NOT EXISTS household_id UUID REFERENCES households(id) ON DELETE CASCADE;
+
+-- ============================================================
+-- 2. Backfill: un hogar inicial por cada usuario existente.
+-- ============================================================
+-- IMPORTANTE: cada usuario distinto recibe su propio hogar (NO se fusionan
+-- usuarios separados en un mismo hogar). En la práctica hoy hay un único
+-- usuario => un único hogar "Mi hogar". El bloque es idempotente: si el usuario
+-- ya tiene membresía, reutiliza su hogar y sólo rellena filas sin household_id.
+DO $$
+DECLARE
+  u   RECORD;
+  hid UUID;
+BEGIN
+  FOR u IN
+    SELECT DISTINCT user_id FROM (
+      SELECT user_id FROM accounts
+      UNION SELECT user_id FROM transactions
+      UNION SELECT user_id FROM user_config
+      UNION SELECT user_id FROM categorization_rules
+      UNION SELECT user_id FROM push_subscriptions
+    ) s
+    WHERE user_id IS NOT NULL
+  LOOP
+    SELECT hm.household_id INTO hid
+    FROM household_members hm
+    WHERE hm.user_id = u.user_id
+    LIMIT 1;
+
+    IF hid IS NULL THEN
+      INSERT INTO households (name, primary_currency, month_start_day)
+      SELECT 'Mi hogar',
+             COALESCE(uc.primary_currency, 'EUR'),
+             COALESCE(uc.month_start_day, 1)
+      FROM (SELECT u.user_id AS uid) base
+      LEFT JOIN user_config uc ON uc.user_id = base.uid
+      RETURNING id INTO hid;
+
+      -- El usuario migrado es el propietario inicial del hogar.
+      INSERT INTO household_members (household_id, user_id, role)
+      VALUES (hid, u.user_id, 'owner');
+    END IF;
+
+    UPDATE accounts             SET household_id = hid WHERE user_id = u.user_id AND household_id IS NULL;
+    UPDATE transactions         SET household_id = hid WHERE user_id = u.user_id AND household_id IS NULL;
+    UPDATE user_config          SET household_id = hid WHERE user_id = u.user_id AND household_id IS NULL;
+    UPDATE categorization_rules SET household_id = hid WHERE user_id = u.user_id AND household_id IS NULL;
+    UPDATE push_subscriptions   SET household_id = hid WHERE user_id = u.user_id AND household_id IS NULL;
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 3. household_id pasa a NOT NULL (ya backfilleado)
+-- ============================================================
+ALTER TABLE accounts             ALTER COLUMN household_id SET NOT NULL;
+ALTER TABLE transactions         ALTER COLUMN household_id SET NOT NULL;
+ALTER TABLE user_config          ALTER COLUMN household_id SET NOT NULL;
+ALTER TABLE categorization_rules ALTER COLUMN household_id SET NOT NULL;
+ALTER TABLE push_subscriptions   ALTER COLUMN household_id SET NOT NULL;
+
+-- ============================================================
+-- 4. Índices por household_id
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_accounts_household             ON accounts(household_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_household_date    ON transactions(household_id, date DESC);
+CREATE INDEX IF NOT EXISTS idx_categorization_rules_household ON categorization_rules(household_id, priority DESC) WHERE is_active;
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_household   ON push_subscriptions(household_id);
+
+-- ============================================================
+-- 5. Reescribir constraints únicas: dedupe a nivel de hogar.
+-- ============================================================
+-- Las cuentas pertenecen al hogar, así que la deduplicación de external_id /
+-- iban / cuenta manual debe ser por household_id, no por user_id.
+
+-- transactions: la UNIQUE inline del schema inicial se llama
+-- transactions_user_id_external_id_key.
+ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_user_id_external_id_key;
+ALTER TABLE transactions ADD  CONSTRAINT transactions_household_external_unique UNIQUE (household_id, external_id);
+
+-- accounts: external_id
+ALTER TABLE accounts DROP CONSTRAINT IF EXISTS accounts_user_external_unique;
+ALTER TABLE accounts ADD  CONSTRAINT accounts_household_external_unique UNIQUE (household_id, external_id);
+
+-- accounts: iban (índice parcial)
+DROP INDEX IF EXISTS accounts_user_iban_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS accounts_household_iban_unique
+  ON accounts (household_id, iban)
+  WHERE iban IS NOT NULL;
+
+-- accounts: una única cuenta manual por hogar
+DROP INDEX IF EXISTS accounts_user_manual_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS accounts_household_manual_unique
+  ON accounts (household_id)
+  WHERE source = 'manual';

--- a/supabase/migrations/20260603000002_household_rls.sql
+++ b/supabase/migrations/20260603000002_household_rls.sql
@@ -1,0 +1,35 @@
+-- Issue #131 (Fase 1): reescribir la RLS de las tablas de datos.
+-- La visibilidad pasa de "fila propia" (auth.uid() = user_id) a "fila del hogar
+-- al que pertenece el usuario" (household_id IN current_household_ids()).
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- accounts
+DROP POLICY IF EXISTS "Users access own accounts" ON accounts;
+CREATE POLICY "Household members access accounts" ON accounts
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));
+
+-- transactions
+DROP POLICY IF EXISTS "Users access own transactions" ON transactions;
+CREATE POLICY "Household members access transactions" ON transactions
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));
+
+-- user_config
+DROP POLICY IF EXISTS "Users access own config" ON user_config;
+CREATE POLICY "Household members access config" ON user_config
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));
+
+-- categorization_rules
+DROP POLICY IF EXISTS "own_rules" ON categorization_rules;
+CREATE POLICY "Household members access rules" ON categorization_rules
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));
+
+-- push_subscriptions
+DROP POLICY IF EXISTS "Users access own push subscriptions" ON push_subscriptions;
+CREATE POLICY "Household members access push subscriptions" ON push_subscriptions
+  FOR ALL USING (household_id IN (SELECT current_household_ids()))
+  WITH CHECK (household_id IN (SELECT current_household_ids()));

--- a/supabase/migrations/20260603000003_analytics_by_household.sql
+++ b/supabase/migrations/20260603000003_analytics_by_household.sql
@@ -1,0 +1,85 @@
+-- Issue #131 (Fase 1): agregaciones a nivel de hogar.
+-- La vista materializada y get_period_data pasan de agrupar/filtrar por user_id
+-- a hacerlo por household_id. La clasificación por categories.type (#63) no cambia.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- 1. Recrear la vista materializada agrupando por household_id
+-- ============================================================
+DROP MATERIALIZED VIEW IF EXISTS transactions_monthly_summary;
+
+CREATE MATERIALIZED VIEW transactions_monthly_summary AS
+SELECT
+  t.household_id,
+  t.account_id,
+  DATE_TRUNC('month', t.date)::date                                  AS month,
+  COALESCE(t.category_manual, t.category)                            AS effective_category,
+  SUM(CASE WHEN c.type = 'income'  THEN t.amount ELSE 0 END)         AS ingresos,
+  SUM(CASE WHEN c.type = 'expense' THEN t.amount ELSE 0 END)         AS gastos,
+  COUNT(*)                                                            AS tx_count
+FROM   transactions t
+JOIN   categories  c ON c.id = COALESCE(t.category_manual, t.category)
+WHERE  c.type IN ('income', 'expense')
+GROUP  BY t.household_id, t.account_id, DATE_TRUNC('month', t.date), COALESCE(t.category_manual, t.category);
+
+-- Índice único requerido para REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX idx_monthly_unique
+  ON transactions_monthly_summary(household_id, account_id, month, effective_category)
+  NULLS NOT DISTINCT;
+
+CREATE INDEX idx_monthly_household_month
+  ON transactions_monthly_summary(household_id, month DESC);
+
+-- refresh_monthly_summary() no cambia: sigue refrescando CONCURRENTLY.
+
+-- ============================================================
+-- 2. Recrear get_period_data filtrando por household_id
+-- ============================================================
+DROP FUNCTION IF EXISTS get_period_data(UUID, DATE, DATE);
+
+CREATE OR REPLACE FUNCTION get_period_data(
+  p_household_id UUID,
+  p_start_date   DATE,
+  p_end_date     DATE
+) RETURNS TABLE (
+  ingresos    DECIMAL,
+  gastos      DECIMAL,
+  ahorro      DECIMAL,
+  by_category JSONB
+) LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH txs AS (
+    SELECT t.amount,
+           COALESCE(t.category_manual, t.category) AS cat,
+           c.type                                  AS cat_type
+    FROM   transactions t
+    LEFT   JOIN categories c
+           ON c.id = COALESCE(t.category_manual, t.category)
+    WHERE  t.household_id = p_household_id
+      AND  t.date BETWEEN p_start_date AND p_end_date
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(amount) FILTER (WHERE cat_type = 'income'),       0) AS inc,
+      COALESCE(ABS(SUM(amount) FILTER (WHERE cat_type = 'expense')), 0) AS exp
+    FROM txs
+  ),
+  cats AS (
+    SELECT cat, SUM(amount) AS total
+    FROM   txs
+    WHERE  cat_type IN ('income', 'expense')
+    GROUP  BY cat
+  )
+  SELECT
+    totals.inc,
+    totals.exp,
+    totals.inc - totals.exp AS sav,
+    COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object('category', cat, 'amount', total)) FROM cats),
+      '[]'::jsonb
+    )
+  FROM totals;
+END;
+$$;

--- a/types/index.ts
+++ b/types/index.ts
@@ -48,9 +48,25 @@ export type CategoryId =
   | 'transfer'
   | 'loan_payment'
 
+export interface Household {
+  id: string
+  name: string
+  primary_currency: string
+  month_start_day: number
+  created_at: string
+}
+
+export interface HouseholdMember {
+  household_id: string
+  user_id: string
+  role: string
+  created_at: string
+}
+
 export interface Account {
   id: string
   user_id: string
+  household_id: string
   name: string
   type: AccountType
   source: DataSource
@@ -72,6 +88,7 @@ export interface Account {
 export interface Transaction {
   id: string
   user_id: string
+  household_id: string
   account_id: string
   date: string
   amount: number
@@ -97,6 +114,7 @@ export interface TransactionWithAccount extends Transaction {
 
 export interface UserConfig {
   user_id: string
+  household_id: string
   primary_currency: string
   month_start_day: number
   created_at: string


### PR DESCRIPTION
Cierra parcialmente #131 (Fase 1: base de datos + acceso a datos).

## Contexto
La app era estrictamente mono-usuario (`auth.uid() = user_id` en toda la RLS), lo que impedía que una segunda persona viera los mismos datos. Esta PR migra el modelo de propiedad a un **hogar compartido**, manteniendo identidades separadas y sin perder datos. Continúa el modelo de identidad de #132.

## Cambios

### Base de datos (`supabase/migrations/2026060300000{0..3}_*.sql`)
- **Nuevas tablas** `households` (incluye `primary_currency` y `month_start_day` a nivel hogar) y `household_members(household_id, user_id, role)`.
- **`household_id`** en `accounts`, `transactions`, `user_config`, `categorization_rules`, `push_subscriptions`, con índices y constraints únicas reescritas de `user_id` → `household_id`.
- **Migración de datos**: un hogar inicial ("Mi hogar") por usuario existente; backfill de todas las filas; el usuario migrado queda como `owner`. Bloque idempotente.
- **Helper `current_household_ids()`** (SECURITY DEFINER, evita recursión de RLS) y **RLS reescrita** en todas las tablas para comprobar pertenencia al hogar.
- **Agregaciones por hogar**: MV `transactions_monthly_summary` y `get_period_data(p_household_id, …)`.

### Capa de acceso a datos
- Nuevo helper `lib/household.ts` → `getHouseholdId()`.
- Filtrado/inserción por `household_id` en dashboard, cuentas, movimientos, transacciones, analytics RPC y webhooks service-role (`edenred`, `sync/enablebanking` y su `cron`).
- Se **conserva `user_id`** como creador/auditoría.
- Tipos `Household`/`HouseholdMember` y `household_id` añadidos en `types/index.ts`.

## Notas de despliegue
Las migraciones se aplican manualmente en el SQL Editor de Supabase (convención del repo), en orden de timestamp.

## Fuera de alcance (issue de seguimiento)
- UI de gestión de miembros del hogar.
- Lista de emails pre-autorizados + auto-join en el login.
- Roles diferenciados / expulsión de miembros.

## Validación
- `pnpm test` ✅ (227 tests)
- `pnpm lint` ✅
- `pnpm build` ✅

Verificación funcional pendiente en Supabase: aplicar migraciones, comprobar backfill, y validar compartición añadiendo un segundo `household_members` por SQL (criterio de aceptación de la issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)