### PR TITLE
feat(edenred): notificación macOS al detectar sesión caducada (#99)

### DIFF
--- a/scripts/edenred-scrape.mjs
+++ b/scripts/edenred-scrape.mjs
@@ -18,6 +18,7 @@ import { chromium } from 'playwright'
 import { existsSync, readdirSync, unlinkSync, closeSync, openSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
 
 import { LOCAL_STORAGE_PATH, EDENRED_ACCOUNT_URL } from './lib/edenred-config.mjs'
 
@@ -28,6 +29,10 @@ import { LOCAL_STORAGE_PATH, EDENRED_ACCOUNT_URL } from './lib/edenred-config.mj
 const CRON_MODE = process.env.EDENRED_CRON === '1'
 const CRON_LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
 const CRON_MARKER_PREFIX = 'edenred-last-success.'
+// Marker para throttlear la notificación de sesión caducada a 1/día: el plist
+// dispara 6 slots, pero sólo queremos un aviso. Se borra al primer éxito (ver
+// writeCronMarker) para "re-armar" el aviso ante un fallo posterior del día.
+const NOTIFY_MARKER_PREFIX = 'edenred-notified.'
 function cronMarkerPath() {
   const today = new Date().toISOString().slice(0, 10)
   return join(CRON_LOG_DIR, `${CRON_MARKER_PREFIX}${today}`)
@@ -35,13 +40,41 @@ function cronMarkerPath() {
 function cronMarkerExists() {
   return existsSync(cronMarkerPath())
 }
+function notifyMarkerPath() {
+  const today = new Date().toISOString().slice(0, 10)
+  return join(CRON_LOG_DIR, `${NOTIFY_MARKER_PREFIX}${today}`)
+}
 function writeCronMarker() {
   closeSync(openSync(cronMarkerPath(), 'a'))
   for (const name of readdirSync(CRON_LOG_DIR)) {
-    if (name.startsWith(CRON_MARKER_PREFIX) && join(CRON_LOG_DIR, name) !== cronMarkerPath()) {
+    // Limpia markers de éxito antiguos y cualquier marker de notificación:
+    // tras un éxito el sistema vuelve a estar "armado" para volver a avisar.
+    const isStaleSuccess =
+      name.startsWith(CRON_MARKER_PREFIX) && join(CRON_LOG_DIR, name) !== cronMarkerPath()
+    const isNotify = name.startsWith(NOTIFY_MARKER_PREFIX)
+    if (isStaleSuccess || isNotify) {
       try { unlinkSync(join(CRON_LOG_DIR, name)) } catch {}
     }
   }
+}
+
+// Notificación nativa de macOS cuando la sesión Edenred caduca (exit 2). Sólo
+// se dispara desde el cron (CRON_MODE): en ejecuciones manuales el error ya se
+// ve por pantalla. Throttle de 1/día vía marker. Nunca debe romper el exit del
+// script, por eso todo va envuelto en try/catch.
+function notifySessionExpired() {
+  try {
+    if (existsSync(notifyMarkerPath())) return
+    const title = 'Edenred: sesión caducada'
+    const message = 'Ejecuta pnpm scrape:edenred:login para regenerarla.'
+    // JSON.stringify produce literales de cadena válidos para AppleScript
+    // (comillas dobles + escape). execFileSync no usa shell → sin inyección.
+    execFileSync('osascript', [
+      '-e',
+      `display notification ${JSON.stringify(message)} with title ${JSON.stringify(title)}`,
+    ])
+    closeSync(openSync(notifyMarkerPath(), 'a'))
+  } catch {}
 }
 
 // Selectores capturados sobre empleados.edenred.es con el design system
@@ -62,6 +95,7 @@ const SELECTORS = {
 
 function die(code, msg) {
   console.error(`[edenred-scrape] ${msg}`)
+  if (code === 2 && CRON_MODE) notifySessionExpired()
   process.exit(code)
 }
 


### PR DESCRIPTION
Closes #99

## Qué hace

Cuando el cron de Edenred sale con **exit 2** (sesión inválida / pide 2FA), dispara una **notificación nativa de macOS** (`osascript -e 'display notification ...'`) con el comando de recuperación:

> **Edenred: sesión caducada** — Ejecuta `pnpm scrape:edenred:login` para regenerarla.

## Detalle

- **Sólo exit 2** (no 1/3/4 — esos son ruido transitorio).
- **Throttle 1/día** mediante marker `~/Library/Logs/fin-app/edenred-notified.YYYY-MM-DD`, para no spamear con los 6 slots horarios del plist.
- **Re-armado en éxito**: `writeCronMarker()` borra los markers `edenred-notified.*` al primer éxito, de modo que un fallo posterior del mismo día vuelve a avisar.
- **Sólo en modo cron** (`EDENRED_CRON=1`): en ejecuciones manuales el error ya se ve por pantalla y no debe gastar el throttle.
- Toda la lógica de notificación va en `try/catch` → **nunca rompe el exit code** del script.
- `execFileSync` sin shell + strings AppleScript vía `JSON.stringify` → sin riesgo de inyección.

Sólo se modifica [scripts/edenred-scrape.mjs](scripts/edenred-scrape.mjs); no se toca el plist ni el wrapper de install.

## Verificación

- `pnpm test` (227 ✓), `pnpm lint` (✓), `pnpm build` (✓).
- Notificación nativa confirmada en macOS con el comando exacto que emite el script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)