### PR TITLE
feat(edenred): volcar DOM + screenshot al fallar el scraper (#100)

### DIFF
--- a/scripts/edenred-scrape.mjs
+++ b/scripts/edenred-scrape.mjs
@@ -15,7 +15,7 @@
 //   4 — error de scraping (no se encontraron selectores en el DOM)
 
 import { chromium } from 'playwright'
-import { existsSync, readdirSync, unlinkSync, closeSync, openSync } from 'node:fs'
+import { existsSync, readdirSync, unlinkSync, closeSync, openSync, writeFileSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
@@ -33,6 +33,10 @@ const CRON_MARKER_PREFIX = 'edenred-last-success.'
 // dispara 6 slots, pero sólo queremos un aviso. Se borra al primer éxito (ver
 // writeCronMarker) para "re-armar" el aviso ante un fallo posterior del día.
 const NOTIFY_MARKER_PREFIX = 'edenred-notified.'
+// Prefijo de los volcados de diagnóstico (screenshot + HTML) que se generan al
+// fallar. Compartido implícitamente con edenred-status.mjs (mismo literal allí).
+const FAILURE_PREFIX = 'edenred-failure-'
+const FAILURE_KEEP = 5
 function cronMarkerPath() {
   const today = new Date().toISOString().slice(0, 10)
   return join(CRON_LOG_DIR, `${CRON_MARKER_PREFIX}${today}`)
@@ -93,6 +97,44 @@ const SELECTORS = {
   transactionRow: 'tbody tr.ore-table-row',
 }
 
+// Timestamp local "YYYY-MM-DD_HHmm" para nombrar los volcados de fallo.
+function failureStamp() {
+  const d = new Date()
+  const p = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}`
+}
+
+// Conserva sólo los FAILURE_KEEP volcados más recientes por extensión; borra el
+// resto. El stamp ordena cronológicamente, así que basta ordenar por nombre.
+function rotateFailureDumps() {
+  for (const ext of ['.png', '.html']) {
+    const files = readdirSync(CRON_LOG_DIR)
+      .filter((n) => n.startsWith(FAILURE_PREFIX) && n.endsWith(ext))
+      .sort()
+    for (const name of files.slice(0, -FAILURE_KEEP)) {
+      try { unlinkSync(join(CRON_LOG_DIR, name)) } catch {}
+    }
+  }
+}
+
+// Vuelca screenshot + HTML de la página a CRON_LOG_DIR para diagnosticar fallos
+// (sesión caducada, selector cambiado) sin reproducir con playwright codegen.
+// Todo va en try/catch silencioso: si el dump falla (página cerrada, etc.) el
+// die() posterior debe salir igualmente con su exit code original.
+async function dumpFailure(page) {
+  try {
+    mkdirSync(CRON_LOG_DIR, { recursive: true })
+    const stamp = failureStamp()
+    const pngPath = join(CRON_LOG_DIR, `${FAILURE_PREFIX}${stamp}.png`)
+    const htmlPath = join(CRON_LOG_DIR, `${FAILURE_PREFIX}${stamp}.html`)
+    await page.screenshot({ fullPage: true, path: pngPath })
+    writeFileSync(htmlPath, await page.content())
+    console.error(`[edenred-scrape] dump: ${pngPath}`)
+    console.error(`[edenred-scrape] dump: ${htmlPath}`)
+    rotateFailureDumps()
+  } catch {}
+}
+
 function die(code, msg) {
   console.error(`[edenred-scrape] ${msg}`)
   if (code === 2 && CRON_MODE) notifySessionExpired()
@@ -146,14 +188,20 @@ async function isSessionInvalid(page) {
 
 async function extractBalance(page) {
   const el = page.locator(SELECTORS.balance).first()
-  if (!(await el.isVisible().catch(() => false))) die(4, 'Saldo no encontrado en el DOM')
+  if (!(await el.isVisible().catch(() => false))) {
+    await dumpFailure(page)
+    die(4, 'Saldo no encontrado en el DOM')
+  }
   const text = (await el.textContent()) ?? ''
   return parseAmount(text)
 }
 
 async function extractTransactions(page) {
   const rows = await page.locator(SELECTORS.transactionRow).all()
-  if (rows.length === 0) die(4, 'No se encontró ninguna fila de transacciones')
+  if (rows.length === 0) {
+    await dumpFailure(page)
+    die(4, 'No se encontró ninguna fila de transacciones')
+  }
 
   const txs = []
   for (const row of rows) {
@@ -230,6 +278,7 @@ async function main() {
 
     const invalid = await isSessionInvalid(page)
     if (invalid) {
+      await dumpFailure(page)
       die(2, `Sesión Edenred no válida (${invalid}). Regenera con: pnpm scrape:edenred:login`)
     }
 

--- a/scripts/edenred-status.mjs
+++ b/scripts/edenred-status.mjs
@@ -11,6 +11,7 @@ const LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
 const OUT_LOG = join(LOG_DIR, 'edenred-scraper.out.log')
 const ERR_LOG = join(LOG_DIR, 'edenred-scraper.err.log')
 const MARKER_PREFIX = 'edenred-last-success.'
+const FAILURE_PREFIX = 'edenred-failure-'
 const AGENT_LABEL = 'com.fin-app.edenred-scraper'
 
 const fmtDate = (d) =>
@@ -37,6 +38,16 @@ function lastMarker() {
     date: name.slice(MARKER_PREFIX.length),
     mtime: statSync(path).mtime,
   }
+}
+
+function lastFailureDump() {
+  if (!existsSync(LOG_DIR)) return null
+  const dumps = readdirSync(LOG_DIR)
+    .filter((n) => n.startsWith(FAILURE_PREFIX) && n.endsWith('.png'))
+    .sort()
+  if (dumps.length === 0) return null
+  const name = dumps[dumps.length - 1]
+  return { name, mtime: statSync(join(LOG_DIR, name)).mtime }
 }
 
 function logSummary(path) {
@@ -107,4 +118,13 @@ if (!err.exists) {
 } else {
   console.log(`  ${fmtDate(err.mtime)} · ${err.size} B`)
   for (const line of err.tail) console.log(`  | ${line}`)
+}
+
+const dump = lastFailureDump()
+if (!dump) {
+  console.log('\nÚltimo dump de fallo: (ninguno)')
+} else {
+  console.log(
+    `\nÚltimo dump de fallo: ${join(LOG_DIR, dump.name)} · ${fmtDate(dump.mtime)} (${ageSince(dump.mtime)})`,
+  )
 }


### PR DESCRIPTION
Closes #100

## Qué hace

Cuando el scraper de Edenred falla, ahora vuelca un **screenshot** (`fullPage`) y el **HTML** de la página a `~/Library/Logs/fin-app/` para poder diagnosticar sin reproducir manualmente con `playwright codegen`.

### `scripts/edenred-scrape.mjs`
- Nueva `dumpFailure(page)` que escribe `edenred-failure-YYYY-MM-DD_HHmm.png` + `.html`.
- Se invoca (`await`) justo **antes** de los 3 `die()` con acceso a la página:
  - `die(2)` sesión inválida (`main`)
  - `die(4)` saldo no encontrado (`extractBalance`)
  - `die(4)` sin filas de transacciones (`extractTransactions`)
- Todo el dump va en `try/catch` silencioso: si falla (página cerrada, etc.) el `die()` sale igualmente con su exit code original.
- **Rotación:** conserva sólo los 5 más recientes por tipo (`.png` / `.html`).
- Loguea la ruta en stderr (`[edenred-scrape] dump: …`), así aparece en `pnpm cron:edenred:status`.
- `mkdirSync(..., { recursive: true })` para que el dump funcione también en ejecuciones manuales aunque el log dir no exista aún.

### `scripts/edenred-status.mjs`
- Nueva sección **"Último dump de fallo"** con la ruta + antigüedad del `.png` más reciente, o `(ninguno)`.

### Fuera de alcance
El `die(4)` de `parseDate` (mes desconocido) queda excluido: es un fallo de parseo de datos en función síncrona sin acceso a `page`, no un fallo de DOM/selector.

## Verificación
- ✅ `pnpm test` (227), `pnpm lint`, `pnpm build`.
- ✅ Fallo simulado (selector roto) → genera `.png` + `.html`, loguea ruta y mantiene el exit 4.
- ✅ `pnpm cron:edenred:status` muestra el último dump.
- ✅ Rotación: con 7 ficheros sembrados por tipo, tras un dump quedan exactamente 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)