### PR TITLE
fix(edenred): documentar y blindar dependencia de categorías del scraper (#101)

### DIFF
--- a/app/api/edenred/categories.test.ts
+++ b/app/api/edenred/categories.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Categorías que usa la integración Edenred. Deben coincidir con un `id`
+// sembrado en la tabla `categories`, porque la matview
+// `transactions_monthly_summary` hace INNER JOIN sobre `categories`: un `id`
+// desconocido excluiría la tx de las agregaciones SIN error. Ver issue #101.
+// - 'restaurant': consumo (fallback del webhook en route.ts)
+// - 'income':     recarga / top-up (RECARGA en scripts/edenred-scrape.mjs)
+const EDENRED_CATEGORIES = ['restaurant', 'income'] as const
+
+const SEED_PATH = fileURLToPath(
+  new URL(
+    '../../../supabase/migrations/20260509000000_categories_type.sql',
+    import.meta.url
+  )
+)
+
+function seededCategoryIds(): Set<string> {
+  const sql = readFileSync(SEED_PATH, 'utf8')
+  // Cada fila del INSERT empieza con `  ('<id>', ...`
+  const ids = new Set<string>()
+  for (const match of sql.matchAll(/^\s*\(\s*'([a-z_]+)'\s*,/gm)) {
+    ids.add(match[1])
+  }
+  return ids
+}
+
+describe('dependencia de categorías Edenred ↔ seed de `categories`', () => {
+  it('el seed contiene varias categorías (sanity del parser)', () => {
+    expect(seededCategoryIds().size).toBeGreaterThan(10)
+  })
+
+  it.each(EDENRED_CATEGORIES)(
+    'la categoría "%s" que emite Edenred existe en el seed',
+    category => {
+      expect(seededCategoryIds().has(category)).toBe(true)
+    }
+  )
+})

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -131,6 +131,13 @@ export async function POST(req: Request) {
 
   let upserted = 0
   if (payload.transactions.length > 0) {
+    // `category` debe coincidir con un `id` de la tabla `categories` (datos de
+    // referencia compartidos, seed en
+    // supabase/migrations/20260509000000_categories_type.sql). La matview
+    // `transactions_monthly_summary` hace INNER JOIN sobre `categories`, así que
+    // un `id` desconocido excluiría la tx de las agregaciones SIN error. El
+    // scraper sólo emite 'restaurant' e 'income', y el fallback de aquí es
+    // 'restaurant'; ambos están garantizados por ese seed. Ver issue #101.
     const rows = payload.transactions.map(tx => ({
       user_id: userId,
       household_id: householdId,

--- a/scripts/edenred-scrape.mjs
+++ b/scripts/edenred-scrape.mjs
@@ -216,8 +216,12 @@ async function extractTransactions(page) {
     const description = rawDesc.trim().replace(/\s+/g, ' ')
 
     // Edenred muestra los importes sin signo. Distinguimos por la
-    // descripción literal: "RECARGA" es un ingreso (top-up de empresa),
-    // todo lo demás es consumo en restaurante.
+    // descripción literal: "RECARGA" es un ingreso (top-up del ticket
+    // restaurante que carga la empresa: retribución que forma parte de la
+    // nómina), todo lo demás es consumo en restaurante.
+    // Las categorías deben coincidir con un `id` del seed de la tabla
+    // `categories` (supabase/migrations/20260509000000_categories_type.sql):
+    // 'income' (Nómina) para la recarga y 'restaurant' (expense) para el consumo.
     const isRecarga = description.toUpperCase() === 'RECARGA'
     const amount = isRecarga ? parseAmount(rawAmount) : -parseAmount(rawAmount)
     const category = isRecarga ? 'income' : 'restaurant'


### PR DESCRIPTION
## Resumen

Cierra #101. Verifica que las categorías hardcoded del scraper de Edenred existen en `categories`.

**Resultado de la investigación:** ✅ existen. `'restaurant'` (expense) e `'income'` (income) están sembradas en [`supabase/migrations/20260509000000_categories_type.sql`](supabase/migrations/20260509000000_categories_type.sql) como datos de referencia compartidos. La rama aplicable es **"Si existen → documentar"**.

La matview `transactions_monthly_summary` hace **INNER JOIN** sobre `categories`, así que un `category` con un `id` desconocido excluiría la tx de las agregaciones **sin error**. De ahí el valor de blindar la dependencia.

## Cambios

1. **Documentación** — comentario en `app/api/edenred/route.ts` explicando que `category` debe coincidir con un `id` del seed y la consecuencia silenciosa del INNER JOIN.
2. **Test de regresión** — `app/api/edenred/categories.test.ts` lee el seed y verifica que `'restaurant'` e `'income'` existen; una futura ruptura falla en CI.
3. **Aclaración en el scraper** — comentario en `scripts/edenred-scrape.mjs`: la RECARGA es el top-up del ticket restaurante que carga la empresa, una retribución que forma parte de la nómina → categoría `'income'` (se mantiene).

> El naming del `id` `'income'` (name "Nómina") es confuso porque colisiona con `type = 'income'`; el rename a `'payroll'` se trata en un issue aparte.

## Validación

- \`pnpm test\` → 230 passed
- \`pnpm lint\` → sin errores
- \`pnpm build\` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)