### PR TITLE
test(edenred): tests unitarios para parseAmount y parseDate (#102)

### DIFF
--- a/scripts/edenred-scrape.mjs
+++ b/scripts/edenred-scrape.mjs
@@ -21,6 +21,7 @@ import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
 
 import { LOCAL_STORAGE_PATH, EDENRED_ACCOUNT_URL } from './lib/edenred-config.mjs'
+import { parseAmount, parseDate } from './lib/edenred-parsers.mjs'
 
 // Cuando se invoca desde launchd (EDENRED_CRON=1) se usa un marker diario
 // para tolerar que el Mac estuviera dormido: el plist define varios slots a
@@ -150,30 +151,6 @@ function requireEnv(name) {
 function resolveStorageStatePath() {
   if (existsSync(LOCAL_STORAGE_PATH)) return LOCAL_STORAGE_PATH
   die(1, `No hay storage-state. Ejecuta: pnpm scrape:edenred:login`)
-}
-
-// Parsea importes en formato español ("12,50 €" o "-12,50 €") a number.
-function parseAmount(raw) {
-  const cleaned = raw.replace(/[^0-9,.\-]/g, '').replace(/\./g, '').replace(',', '.')
-  const n = Number.parseFloat(cleaned)
-  if (Number.isNaN(n)) throw new Error(`No se pudo parsear importe: "${raw}"`)
-  return n
-}
-
-// "15/05/2026" o "15 may 2026" → "2026-05-15".
-function parseDate(raw) {
-  const m = raw.trim().match(/(\d{1,2})[\/\s-](\d{1,2}|[a-záéíóú]+)[\/\s-](\d{4})/i)
-  if (!m) throw new Error(`No se pudo parsear fecha: "${raw}"`)
-  const day = m[1].padStart(2, '0')
-  const monthRaw = m[2].toLowerCase()
-  const months = {
-    ene: '01', feb: '02', mar: '03', abr: '04', may: '05', jun: '06',
-    jul: '07', ago: '08', sep: '09', oct: '10', nov: '11', dic: '12',
-  }
-  const month = /^\d+$/.test(monthRaw)
-    ? monthRaw.padStart(2, '0')
-    : months[monthRaw.slice(0, 3)] || die(4, `Mes desconocido: "${monthRaw}"`)
-  return `${m[3]}-${month}-${day}`
 }
 
 async function isSessionInvalid(page) {

--- a/scripts/lib/edenred-parsers.mjs
+++ b/scripts/lib/edenred-parsers.mjs
@@ -1,0 +1,31 @@
+// Parsers puros del scraper de Edenred. Sin dependencias de Playwright ni de
+// process.exit: así son testeables de forma aislada (ver edenred-parsers.test.mjs).
+// Las usa scripts/edenred-scrape.mjs.
+
+// Parsea importes en formato español ("12,50 €" o "-12,50 €") a number.
+export function parseAmount(raw) {
+  const cleaned = raw.replace(/[^0-9,.\-]/g, '').replace(/\./g, '').replace(',', '.')
+  const n = Number.parseFloat(cleaned)
+  if (Number.isNaN(n)) throw new Error(`No se pudo parsear importe: "${raw}"`)
+  return n
+}
+
+// "15/05/2026" o "15 may 2026" → "2026-05-15".
+export function parseDate(raw) {
+  const m = raw.trim().match(/(\d{1,2})[\/\s-](\d{1,2}|[a-záéíóú]+)[\/\s-](\d{4})/i)
+  if (!m) throw new Error(`No se pudo parsear fecha: "${raw}"`)
+  const day = m[1].padStart(2, '0')
+  const monthRaw = m[2].toLowerCase()
+  const months = {
+    ene: '01', feb: '02', mar: '03', abr: '04', may: '05', jun: '06',
+    jul: '07', ago: '08', sep: '09', oct: '10', nov: '11', dic: '12',
+  }
+  let month
+  if (/^\d+$/.test(monthRaw)) {
+    month = monthRaw.padStart(2, '0')
+  } else {
+    month = months[monthRaw.slice(0, 3)]
+    if (!month) throw new Error(`Mes desconocido: "${monthRaw}"`)
+  }
+  return `${m[3]}-${month}-${day}`
+}

--- a/scripts/lib/edenred-parsers.test.mjs
+++ b/scripts/lib/edenred-parsers.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { parseAmount, parseDate } from './edenred-parsers.mjs'
+
+describe('parseAmount', () => {
+  it('parsea importes con coma decimal', () => {
+    expect(parseAmount('12,50 €')).toBe(12.5)
+  })
+
+  it('parsea importes negativos', () => {
+    expect(parseAmount('-12,50 €')).toBe(-12.5)
+  })
+
+  it('parsea importes con separador de miles', () => {
+    expect(parseAmount('1.234,56 €')).toBe(1234.56)
+  })
+
+  it('parsea el cero', () => {
+    expect(parseAmount('0,00 €')).toBe(0)
+  })
+
+  it('lanza error si no hay número', () => {
+    expect(() => parseAmount('abc')).toThrow()
+  })
+})
+
+describe('parseDate', () => {
+  it('parsea fechas con barras', () => {
+    expect(parseDate('15/05/2026')).toBe('2026-05-15')
+  })
+
+  it('parsea fechas con mes abreviado en castellano', () => {
+    expect(parseDate('15 may 2026')).toBe('2026-05-15')
+  })
+
+  it('rellena con ceros día y mes de un dígito', () => {
+    expect(parseDate('5/1/2026')).toBe('2026-01-05')
+  })
+
+  it('es insensible a mayúsculas en el mes', () => {
+    expect(parseDate('15 MAY 2026')).toBe('2026-05-15')
+  })
+
+  it('lanza error ante un mes desconocido', () => {
+    expect(() => parseDate('15 xxx 2026')).toThrow()
+  })
+
+  it('lanza error si no es una fecha', () => {
+    expect(() => parseDate('no es fecha')).toThrow()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
-    include: ['app/**/*.test.ts', 'hooks/**/*.test.ts', 'lib/**/*.test.ts', 'tests/**/*.test.ts'],
+    include: ['app/**/*.test.ts', 'hooks/**/*.test.ts', 'lib/**/*.test.ts', 'tests/**/*.test.ts', 'scripts/**/*.test.mjs'],
     clearMocks: true,
   },
 })


### PR DESCRIPTION
Closes #102

## Qué

Extrae las dos funciones más frágiles del scraper de Edenred (`parseAmount` y `parseDate`) a un módulo puro y las cubre con tests unitarios.

## Cambios

- **`scripts/lib/edenred-parsers.mjs`** (nuevo): módulo puro, sin Playwright ni `process.exit`, con `parseAmount` y `parseDate` exportadas.
- **`scripts/lib/edenred-parsers.test.mjs`** (nuevo): tests Vitest cubriendo todos los casos de la issue (coma decimal, negativos, miles, cero, mes abreviado, padding, case-insensitive, y errores).
- **`scripts/edenred-scrape.mjs`**: elimina las definiciones inline y las importa del nuevo módulo.
- **`vitest.config.ts`**: añade el patrón `scripts/**/*.test.mjs` al `include` (si no, los tests `.mjs` bajo `scripts/` no se ejecutarían).

## Nota de comportamiento

`parseDate` ahora lanza `Error` ante un mes desconocido en vez de `die(4, ...)` (que llamaba a `process.exit`). El efecto neto en el scraper se mantiene: el error sube por `extractTransactions` → `main().catch` → `process.exit(4)`, el mismo exit code de antes.

## Verificación

- ✅ `pnpm test` — 241 tests, 15 ficheros (incluye los nuevos)
- ✅ `pnpm lint`
- ✅ `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)