### PR TITLE
feat(edenred): RunAtLoad + scrape:edenred:force para ergonomía del cron (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,22 @@ Desde la raíz del proyecto:
 El script:
 
 1. Genera `~/Library/LaunchAgents/com.fin-app.edenred-scraper.plist` apuntando al directorio actual del proyecto y al `pnpm` que tenga tu shell en el `PATH`.
-2. Lo registra con `launchctl load` para que se ejecute cada día a las 07:00 hora local.
+2. Lo registra con `launchctl load`. Se ejecuta en varios slots diarios (07, 10, 13, 16, 19, 22 hora local) y, gracias a `RunAtLoad`, también intenta un scrape **inmediato** al instalar el agente o al reiniciar el Mac — así ves el resultado en segundos sin esperar al siguiente slot. El marker diario (`~/Library/Logs/fin-app/edenred-last-success.YYYY-MM-DD`) evita que se ejecute dos veces el mismo día.
 3. Crea `~/Library/Logs/fin-app/` para los logs (`edenred-scraper.out.log` y `edenred-scraper.err.log`).
 
 ### Verificar y operar
 
 ```bash
 launchctl list | grep edenred-scraper      # confirma que está cargado
-launchctl start com.fin-app.edenred-scraper # dispararlo a mano (sin esperar a las 07:00)
+launchctl start com.fin-app.edenred-scraper # dispararlo a mano (no-op si ya hubo éxito hoy)
 tail -f ~/Library/Logs/fin-app/edenred-scraper.out.log
 tail -f ~/Library/Logs/fin-app/edenred-scraper.err.log
+```
+
+Para **forzar** un re-scrape aunque ya exista el marker del día (sin borrar ficheros ni desexportar `EDENRED_CRON`):
+
+```bash
+pnpm scrape:edenred:force
 ```
 
 Tras una ejecución exitosa:
@@ -101,4 +107,5 @@ El run falla con código HTTP no-2xx solo si el endpoint devuelve 5xx (DB inalca
 - `pnpm build` — compilar para producción
 - `pnpm test` — tests Vitest
 - `pnpm scrape:edenred` — ejecutar el scraper (requiere `storage-state.json` válido)
+- `pnpm scrape:edenred:force` — ejecutar el scraper ignorando el marker diario (re-ejecuta aunque ya haya corrido hoy)
 - `pnpm scrape:edenred:login` — regenerar `storage-state.json` con login manual

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest",
     "icons:generate": "node scripts/generate-icons.mjs",
     "scrape:edenred": "node --env-file-if-exists=.env.local scripts/edenred-scrape.mjs",
+    "scrape:edenred:force": "EDENRED_SKIP_MARKER=1 pnpm scrape:edenred",
     "scrape:edenred:login": "node --env-file=.env.local scripts/edenred-login.mjs",
     "cron:edenred:status": "node scripts/edenred-status.mjs",
     "push:test": "node --env-file=.env.local scripts/send-test-push.mjs"

--- a/scripts/edenred-scrape.mjs
+++ b/scripts/edenred-scrape.mjs
@@ -2,7 +2,8 @@
 // Edenred scraper — Playwright headless.
 //
 // Uso:
-//   pnpm scrape:edenred
+//   pnpm scrape:edenred         (respeta el marker diario si EDENRED_CRON=1)
+//   pnpm scrape:edenred:force   (EDENRED_SKIP_MARKER=1: ignora el marker)
 //
 // Se ejecuta en local (launchd en el Mac). Edenred bindea la sesión por IP
 // residencial, así que correr esto desde GitHub Actions invalida el state.
@@ -26,7 +27,9 @@ import { parseAmount, parseDate } from './lib/edenred-parsers.mjs'
 // Cuando se invoca desde launchd (EDENRED_CRON=1) se usa un marker diario
 // para tolerar que el Mac estuviera dormido: el plist define varios slots a
 // lo largo del día y el primero que pille la máquina despierta ejecuta; los
-// siguientes salen no-op porque encuentran el marker.
+// siguientes salen no-op porque encuentran el marker. EDENRED_SKIP_MARKER=1
+// (vía pnpm scrape:edenred:force) salta ese guard para forzar un re-disparo
+// aunque ya haya marker del día, sin tocar ficheros ni desexportar EDENRED_CRON.
 const CRON_MODE = process.env.EDENRED_CRON === '1'
 const CRON_LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
 const CRON_MARKER_PREFIX = 'edenred-last-success.'
@@ -241,7 +244,7 @@ async function postToWebhook({ balance, transactions }) {
 }
 
 async function main() {
-  if (CRON_MODE && cronMarkerExists()) {
+  if (CRON_MODE && !process.env.EDENRED_SKIP_MARKER && cronMarkerExists()) {
     console.log(`[edenred-scrape] skip: ya hubo ejecución correcta hoy`)
     return
   }

--- a/scripts/install-edenred-launchd.sh
+++ b/scripts/install-edenred-launchd.sh
@@ -3,7 +3,8 @@
 # una vez al día. Define varios slots horarios para tolerar que el Mac esté
 # dormido en algunos: el primero que pille la máquina despierta ejecuta el
 # scraper; los siguientes salen no-op gracias al guard EDENRED_CRON=1 del
-# script, que usa un marker diario en ~/Library/Logs/fin-app.
+# script, que usa un marker diario en ~/Library/Logs/fin-app. Además, RunAtLoad
+# dispara un intento inmediato al instalar el agente o reiniciar el Mac.
 #
 # Uso:
 #   ./scripts/install-edenred-launchd.sh             # instalar
@@ -58,8 +59,11 @@ cat > "$PLIST" <<EOF
     <dict><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
     <dict><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
   </array>
+  <!-- Intento inmediato al instalar/reiniciar: feedback en segundos sin esperar
+       al siguiente slot. El guard del marker diario (EDENRED_CRON=1) hace no-op
+       si ya hubo un éxito hoy, así que no se ejecuta dos veces. -->
   <key>RunAtLoad</key>
-  <false/>
+  <true/>
   <key>StandardOutPath</key>
   <string>$LOG_DIR/edenred-scraper.out.log</string>
   <key>StandardErrorPath</key>


### PR DESCRIPTION
Closes #103.

## Contexto
Dos fricciones operativas del cron de Edenred (launchd local):
1. Reinstalar el agente o reiniciar el Mac fuera de horario obligaba a esperar al siguiente slot (7, 10, 13, 16, 19, 22) para ver si el cron funciona.
2. Forzar un re-disparo tras un éxito requería borrar el marker `edenred-last-success.YYYY-MM-DD` a mano o hacer `unset EDENRED_CRON`.

## Cambios
- **`RunAtLoad: true`** en el plist ([scripts/install-edenred-launchd.sh](scripts/install-edenred-launchd.sh)): intento inmediato al instalar/reiniciar. El guard del marker diario hace no-op si ya hubo éxito hoy → no se ejecuta dos veces.
- **`EDENRED_SKIP_MARKER`** en el guard de [scripts/edenred-scrape.mjs](scripts/edenred-scrape.mjs) + nuevo script **`scrape:edenred:force`** en `package.json`: fuerza el re-scrape aunque exista marker, sin tocar ficheros ni desexportar `EDENRED_CRON`.
- **Docs**: README (instalación, operación, comandos) y comentarios de los scripts.

## Lo que NO cambia
- Slots horarios del `StartCalendarInterval`.
- Lógica de markers, notificaciones y dumps de fallo.
- El cron normal sigue idempotente: no corre dos veces el mismo día.

## Validación
- `pnpm test` → 241 passed
- `pnpm lint` → limpio
- `pnpm build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)