### PR TITLE
feat(transactions): movimientos no leídos — badge, dot, gestos y sección fijada (#149)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { AppHeader } from '@/components/app-header'
 import { BottomNav } from '@/components/bottom-nav'
 import { SyncStatusProvider } from '@/components/sync/SyncStatusProvider'
+import { UnreadProvider } from '@/components/transactions/UnreadProvider'
 import { getConsentBannerData } from '@/lib/accounts'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
@@ -25,19 +26,28 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     .eq('is_active', true)
   const consentBanner = getConsentBannerData(ebAccounts ?? [])
 
+  // Conteo de movimientos no leídos para el badge de la tabBar (issue #149). RLS
+  // limita la consulta al hogar del usuario. `head: true` evita traer filas.
+  const { count: unreadCount } = await supabase
+    .from('transactions')
+    .select('*', { count: 'exact', head: true })
+    .eq('is_read', false)
+
   return (
     <div className="relative mx-auto w-full max-w-105 min-h-screen overflow-clip bg-background">
       <SyncStatusProvider>
-        <AppHeader
-          email={user.email ?? ''}
-          avatarUrl={avatarUrl}
-          fullName={fullName}
-          consentBanner={consentBanner}
-        />
-        <main className="pb-22.5 animate-fade-in">
-          {children}
-        </main>
-        <BottomNav />
+        <UnreadProvider initialCount={unreadCount ?? 0}>
+          <AppHeader
+            email={user.email ?? ''}
+            avatarUrl={avatarUrl}
+            fullName={fullName}
+            consentBanner={consentBanner}
+          />
+          <main className="pb-22.5 animate-fade-in">
+            {children}
+          </main>
+          <BottomNav />
+        </UnreadProvider>
       </SyncStatusProvider>
     </div>
   )

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -138,6 +138,10 @@ export async function POST(req: Request) {
     // un `id` desconocido excluiría la tx de las agregaciones SIN error. El
     // scraper sólo emite 'restaurant' e 'income', y el fallback de aquí es
     // 'restaurant'; ambos están garantizados por ese seed. Ver issue #101.
+    // `is_read` se omite a propósito (issue #149): los inserts nuevos toman el
+    // DEFAULT false (nacen "no leídos"), y como el upsert usa
+    // `ignoreDuplicates: false` (actualiza filas existentes), NO incluirlo evita
+    // que un re-sync reescriba el estado de lectura de un movimiento ya leído.
     const rows = payload.transactions.map(tx => ({
       user_id: userId,
       household_id: householdId,

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -34,15 +34,33 @@ export async function PATCH(
 
   const { id } = await params
   const body = await request.json()
-  const { category_manual } = body
+  const { category_manual, is_read } = body
 
-  if (category_manual !== null && !VALID_CATEGORIES.includes(category_manual)) {
-    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+  // Update parcial: solo se tocan los campos presentes en el body. `category_manual`
+  // (incluido null para "sin categoría") y `is_read` son independientes.
+  const update: { category_manual?: CategoryId | null; is_read?: boolean } = {}
+
+  if ('category_manual' in body) {
+    if (category_manual !== null && !VALID_CATEGORIES.includes(category_manual)) {
+      return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+    }
+    update.category_manual = category_manual
+  }
+
+  if ('is_read' in body) {
+    if (typeof is_read !== 'boolean') {
+      return NextResponse.json({ error: 'Invalid is_read' }, { status: 400 })
+    }
+    update.is_read = is_read
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
   }
 
   const { data, error } = await supabase
     .from('transactions')
-    .update({ category_manual })
+    .update(update)
     .eq('id', id)
     .eq('household_id', householdId)
     .select()

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -32,6 +32,10 @@ export async function POST(request: NextRequest) {
       date,
       category_manual: category_manual ?? null,
       source: 'manual',
+      // Un movimiento que crea el propio usuario no es una novedad que deba
+      // notificarse: nace leído (issue #149). El DEFAULT false de la columna solo
+      // aplica a los inserts de sincronización.
+      is_read: true,
     })
     .select('*, account:accounts(id, name, color)')
     .single()

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -7,9 +7,11 @@ import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import { PERIOD_LABELS } from '@/lib/analytics'
 import type { CategoryId, CategoryPeriodData, TransactionWithAccount } from '@/types'
+import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { TxRow } from '@/components/transactions/TxRow'
 import { TxModal } from '@/components/transactions/TxModal'
 import { CategoryPicker } from '@/components/transactions/CategoryPicker'
+import { useUnread } from '@/components/transactions/UnreadProvider'
 import GranularityPicker from './GranularityPicker'
 import CategoryBarChart from './CategoryBarChart'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -55,9 +57,31 @@ export default function CategoryDetailClient({ categoryId }: Props) {
   const [loadingTxs, setLoadingTxs] = useState(true)
   const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
   const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
-  const [swipedTxId, setSwipedTxId] = useState<string | null>(null)
+  const [swiped, setSwiped] = useState<{ id: string; side: SwipeSide } | null>(null)
+  const { increment, decrement } = useUnread()
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
+
+  // Marca leído/no leído optimista, ajustando el badge (UnreadProvider). Estilo
+  // best-effort coherente con handleDelete de este fichero: rollback + log si falla.
+  function setRead(tx: TransactionWithAccount, isRead: boolean) {
+    if (tx.is_read === isRead) return
+    setTransactions(prev => prev.map(t => (t.id === tx.id ? { ...t, is_read: isRead } : t)))
+    if (isRead) decrement()
+    else increment()
+    fetch(`/api/transactions/${tx.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_read: isRead }),
+    })
+      .then(res => { if (!res.ok) throw new Error('PATCH is_read failed') })
+      .catch(err => {
+        setTransactions(prev => prev.map(t => (t.id === tx.id ? { ...t, is_read: tx.is_read } : t)))
+        if (isRead) increment()
+        else decrement()
+        console.error('[CategoryDetailClient.setRead]', err)
+      })
+  }
 
   // Mark loading during render when inputs change (React 19: setState in effect body is disallowed)
   const periodsKey = `${granularity}|${categoryId}`
@@ -286,10 +310,12 @@ export default function CategoryDetailClient({ categoryId }: Props) {
                       <TxRow
                         key={tx.id}
                         tx={tx}
-                        swipedId={swipedTxId}
-                        onSwipe={setSwipedTxId}
-                        onRecategorize={tx => { setCatPickerTx(tx); setSwipedTxId(null) }}
-                        onTap={tx => { setSelectedTxId(tx.id); setSwipedTxId(null) }}
+                        openSide={swiped?.id === tx.id ? swiped.side : null}
+                        onOpenSwipe={(id, side) => setSwiped({ id, side })}
+                        onCloseSwipe={() => setSwiped(null)}
+                        onRecategorize={tx => { setCatPickerTx(tx); setSwiped(null) }}
+                        onToggleRead={tx => { setSwiped(null); setRead(tx, !tx.is_read) }}
+                        onTap={tx => { setSelectedTxId(tx.id); setSwiped(null); if (!tx.is_read) setRead(tx, true) }}
                       />
                     ))}
                   </div>

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Home, List, Wallet, BarChart2 } from 'lucide-react'
+import { useUnread } from '@/components/transactions/UnreadProvider'
 import { cn } from '@/lib/utils'
 
 const NAV_ITEMS = [
@@ -14,6 +15,7 @@ const NAV_ITEMS = [
 
 export function BottomNav({ alwaysShow = false }: { alwaysShow?: boolean } = {}) {
   const pathname = usePathname()
+  const { count: unreadCount } = useUnread()
   if (!alwaysShow && pathname.startsWith('/analytics/category/')) return null
 
   return (
@@ -25,6 +27,7 @@ export function BottomNav({ alwaysShow = false }: { alwaysShow?: boolean } = {})
       <div className="flex pt-2.5">
         {NAV_ITEMS.map(({ href, label, Icon }) => {
           const active = pathname === href
+          const showBadge = href === '/transactions' && unreadCount > 0
           return (
             <Link
               key={href}
@@ -36,11 +39,20 @@ export function BottomNav({ alwaysShow = false }: { alwaysShow?: boolean } = {})
             >
               <span
                 className={cn(
-                  'flex items-center justify-center rounded-xl px-4 py-1 transition-colors duration-200',
+                  'relative flex items-center justify-center rounded-xl px-4 py-1 transition-colors duration-200',
                   active && 'bg-accent'
                 )}
               >
                 <Icon className="size-5" strokeWidth={active ? 2 : 1.8} />
+                {showBadge && (
+                  <span
+                    className="absolute -top-0.5 right-2 flex h-4 min-w-4 items-center justify-center
+                               rounded-full bg-primary px-1 text-[9px] font-bold leading-none text-primary-foreground"
+                    aria-label={`${unreadCount} movimientos no leídos`}
+                  >
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </span>
+                )}
               </span>
               {label}
             </Link>

--- a/components/transactions/TransactionsClient.tsx
+++ b/components/transactions/TransactionsClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
 import { CategoryPicker } from './CategoryPicker'
@@ -24,9 +25,29 @@ interface TransactionsClientProps {
 }
 
 export function TransactionsClient({ initialTransactions, initialCursor, accounts, manualAccountId, initialAccountIds }: TransactionsClientProps) {
-  const { transactions, addTx, appendTxs, deleteTx, recategorize } = useTxMutations(initialTransactions)
+  const { transactions, addTx, appendTxs, deleteTx, recategorize, markRead, markUnread } = useTxMutations(initialTransactions)
   const pagination = useTxPagination({ initialCursor, appendTxs })
   const filters = useTransactionsFilters(transactions, initialAccountIds)
+
+  // Membresía CONGELADA de la sección «No leídos»: un movimiento entra en la
+  // sección si era no leído la primera vez que apareció en la lista (snapshot
+  // inicial o página paginada), y permanece aunque luego se marque leído. Así el
+  // dot se apaga al instante pero la fila no salta. Al volver/recargar el
+  // componente se remonta y la membresía se recalcula desde datos frescos.
+  //
+  // Se modela con estado (no refs) y se actualiza durante el render —patrón
+  // recomendado por React— al detectar ids nuevos respecto a los ya vistos.
+  const [seenIds, setSeenIds] = useState<Set<string>>(
+    () => new Set(initialTransactions.map(t => t.id))
+  )
+  const [pinnedIds, setPinnedIds] = useState<Set<string>>(
+    () => new Set(initialTransactions.filter(t => !t.is_read).map(t => t.id))
+  )
+  const freshIds = transactions.filter(t => !seenIds.has(t.id))
+  if (freshIds.length > 0) {
+    setSeenIds(prev => new Set([...prev, ...freshIds.map(t => t.id)]))
+    setPinnedIds(prev => new Set([...prev, ...freshIds.filter(t => !t.is_read).map(t => t.id)]))
+  }
 
   // `?account=` solo actúa como deep-link de entrada: lo consumimos en el server
   // para inicializar el filtro y aquí limpiamos la URL para evitar que mienta
@@ -40,21 +61,39 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
 
   const [showAccountFilter, setShowAccountFilter] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)
-  const [swipedTxId, setSwipedTxId] = useState<string | null>(null)
+  const [swiped, setSwiped] = useState<{ id: string; side: SwipeSide } | null>(null)
   const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
   const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
-  const groups = useMemo(() => groupTxByDate(filters.filtered), [filters.filtered])
+
+  // Partición de la vista filtrada: arriba los «No leídos» (membresía congelada,
+  // lista plana por fecha desc) y debajo el resto agrupado por día como siempre.
+  const pinnedUnread = useMemo(
+    () => filters.filtered.filter(t => pinnedIds.has(t.id)),
+    [filters.filtered, pinnedIds]
+  )
+  const groups = useMemo(
+    () => groupTxByDate(filters.filtered.filter(t => !pinnedIds.has(t.id))),
+    [filters.filtered, pinnedIds]
+  )
 
   function handleTxTap(tx: TransactionWithAccount) {
     setSelectedTxId(tx.id)
-    setSwipedTxId(null)
+    setSwiped(null)
+    // Abrir el detalle marca leído aunque no se edite nada (issue #149).
+    if (!tx.is_read) void markRead(tx.id)
   }
 
   function handleRecategorize(tx: TransactionWithAccount) {
     setCatPickerTx(tx)
-    setSwipedTxId(null)
+    setSwiped(null)
+  }
+
+  function handleToggleRead(tx: TransactionWithAccount) {
+    setSwiped(null)
+    if (tx.is_read) void markUnread(tx.id)
+    else void markRead(tx.id)
   }
 
   async function handleDelete(txId: string) {
@@ -78,9 +117,12 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
 
       <TransactionsList
         groups={groups}
-        swipedTxId={swipedTxId}
-        onSwipe={setSwipedTxId}
+        pinnedUnread={pinnedUnread}
+        swiped={swiped}
+        onOpenSwipe={(id, side) => setSwiped({ id, side })}
+        onCloseSwipe={() => setSwiped(null)}
         onRecategorize={handleRecategorize}
+        onToggleRead={handleToggleRead}
         onTap={handleTxTap}
         onLoadMore={pagination.loadMore}
         hasMore={pagination.hasMore}

--- a/components/transactions/TransactionsList.tsx
+++ b/components/transactions/TransactionsList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { TxRow } from './TxRow'
+import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { Skeleton } from '@/components/ui/skeleton'
 import { fmt } from '@/lib/formatting'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
@@ -9,9 +10,13 @@ import type { TransactionWithAccount } from '@/types'
 
 interface TransactionsListProps {
   groups: TxDayGroup[]
-  swipedTxId: string | null
-  onSwipe: (id: string | null) => void
+  /** Movimientos no leídos fijados arriba (lista plana por fecha desc). */
+  pinnedUnread: TransactionWithAccount[]
+  swiped: { id: string; side: SwipeSide } | null
+  onOpenSwipe: (id: string, side: SwipeSide) => void
+  onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
+  onToggleRead: (tx: TransactionWithAccount) => void
   onTap: (tx: TransactionWithAccount) => void
   onLoadMore: () => void
   hasMore: boolean
@@ -21,9 +26,12 @@ interface TransactionsListProps {
 
 export function TransactionsList({
   groups,
-  swipedTxId,
-  onSwipe,
+  pinnedUnread,
+  swiped,
+  onOpenSwipe,
+  onCloseSwipe,
   onRecategorize,
+  onToggleRead,
   onTap,
   onLoadMore,
   hasMore,
@@ -31,6 +39,16 @@ export function TransactionsList({
   loadMoreError,
 }: TransactionsListProps) {
   const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  const rowProps = (tx: TransactionWithAccount) => ({
+    tx,
+    openSide: swiped?.id === tx.id ? swiped.side : null,
+    onOpenSwipe,
+    onCloseSwipe,
+    onRecategorize,
+    onToggleRead,
+    onTap,
+  })
 
   // El sentinel se monta siempre al final, incluso con lista filtrada vacía,
   // para que la auto-paginación dispare búsquedas que solo matcheen en
@@ -49,10 +67,26 @@ export function TransactionsList({
     return () => observer.disconnect()
   }, [hasMore, loadingMore, loadMoreError, onLoadMore])
 
-  const isEmpty = groups.length === 0
+  const isEmpty = groups.length === 0 && pinnedUnread.length === 0
 
   return (
     <div className="flex flex-col gap-4">
+      {pinnedUnread.length > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center justify-between px-3 pb-1">
+            <span className="text-xs font-bold uppercase tracking-wide text-primary">
+              No leídos
+            </span>
+            <span className="text-xs font-bold text-primary">{pinnedUnread.length}</span>
+          </div>
+          <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+            {pinnedUnread.map(tx => (
+              <TxRow key={tx.id} {...rowProps(tx)} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {isEmpty ? (
         <div className="flex items-center justify-center py-16">
           <p className="text-sm text-muted-foreground text-center">
@@ -77,14 +111,7 @@ export function TransactionsList({
 
               <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
                 {group.transactions.map(tx => (
-                  <TxRow
-                    key={tx.id}
-                    tx={tx}
-                    swipedId={swipedTxId}
-                    onSwipe={onSwipe}
-                    onRecategorize={onRecategorize}
-                    onTap={onTap}
-                  />
+                  <TxRow key={tx.id} {...rowProps(tx)} />
                 ))}
               </div>
             </div>

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { Edit3 } from 'lucide-react'
-import { useHorizontalSwipe } from '@/hooks/useHorizontalSwipe'
+import { Edit3, Check, X } from 'lucide-react'
+import { useHorizontalSwipe, type SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { CATEGORY_META, UNCATEGORIZED } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
 import { cn } from '@/lib/utils'
@@ -9,52 +9,55 @@ import type { CategoryId, TransactionWithAccount } from '@/types'
 
 interface TxRowProps {
   tx: TransactionWithAccount
-  swipedId: string | null
-  onSwipe: (id: string | null) => void
+  /** Lado del panel de acción abierto para ESTA fila (`null` si está cerrada). */
+  openSide: SwipeSide | null
+  onOpenSwipe: (id: string, side: SwipeSide) => void
+  onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
+  onToggleRead: (tx: TransactionWithAccount) => void
   onTap: (tx: TransactionWithAccount) => void
 }
 
 const ACTION_WIDTH = 120
 
-export function TxRow({ tx, swipedId, onSwipe, onRecategorize, onTap }: TxRowProps) {
+export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize, onToggleRead, onTap }: TxRowProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category) as CategoryId | null
   const meta = effectiveCategory ? (CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other) : UNCATEGORIZED
   const Icon = meta.Icon
 
-  const isOpen = swipedId === tx.id
   const { bind, currentX, isAnimating, didMoveRef } = useHorizontalSwipe({
     actionWidth: ACTION_WIDTH,
-    isOpen,
-    onOpen: () => onSwipe(tx.id),
-    onClose: () => onSwipe(null),
+    openSide,
+    onOpen: side => onOpenSwipe(tx.id, side),
+    onClose: onCloseSwipe,
   })
 
   const absAmount = fmt(Math.abs(tx.amount), 2)
   const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
 
   return (
-    // overflow-hidden recorta el panel de acción cuando está fuera de la fila
+    // overflow-hidden recorta los paneles de acción cuando están fuera de la fila
     <div className="overflow-hidden">
       {/*
-       * Slider flex único: [panel acción][contenido]
-       * En reposo: translateX(-ACTION_WIDTH) → panel fuera por la izquierda, contenido visible
-       * Abierto:   translateX(0)             → panel visible, contenido desplazado a la derecha
+       * Slider flex único: [panel izq][contenido][panel der]
+       * En reposo: translateX(-ACTION_WIDTH) → ambos paneles fuera, contenido visible
+       * Abierto izq: translateX(0)              → panel izquierdo visible (swipe →)
+       * Abierto der: translateX(-2·ACTION_WIDTH) → panel derecho visible (swipe ←)
        */}
       <div
-        className="flex items-stretch w-[calc(100%+120px)]"
+        className="flex items-stretch w-[calc(100%+240px)]"
         style={{
           transform: `translateX(${currentX - ACTION_WIDTH}px)`,
           transition: isAnimating ? 'transform 0.25s' : 'none',
         }}
         {...bind}
       >
-        {/* Panel de acción — oculto a la izquierda hasta que se hace swipe */}
+        {/* Panel izquierdo — «Categoría» (swipe →) */}
         <div className="flex w-30 shrink-0 items-center justify-center bg-primary">
           <button
             className={cn(
               'flex items-center gap-1.5 rounded-[10px] bg-white/20 px-3 py-1.5 text-xs font-bold text-white',
-              !isOpen && 'pointer-events-none'
+              openSide !== 'left' && 'pointer-events-none'
             )}
             onClick={() => onRecategorize(tx)}
           >
@@ -68,10 +71,15 @@ export function TxRow({ tx, swipedId, onSwipe, onRecategorize, onTap }: TxRowPro
           className="flex flex-1 min-w-0 items-center gap-3 px-3 py-2.5 bg-card"
           onClick={() => {
             if (didMoveRef.current) { didMoveRef.current = false; return }
-            if (isOpen) onSwipe(null)
+            if (openSide) onCloseSwipe()
             else onTap(tx)
           }}
         >
+          {/* Dot de no leído (gutter reservado para que las filas no se descuadren) */}
+          <span className="flex w-2 shrink-0 items-center justify-center">
+            {!tx.is_read && <span className="h-2 w-2 rounded-full bg-primary" aria-label="No leído" />}
+          </span>
+
           <div
             className="flex items-center justify-center rounded-[14px] shrink-0 h-10.5 w-10.5"
             style={{ background: meta.color + '18' }}
@@ -95,6 +103,29 @@ export function TxRow({ tx, swipedId, onSwipe, onRecategorize, onTap }: TxRowPro
           >
             {amountStr}
           </span>
+        </div>
+
+        {/* Panel derecho — toggle «Leído» / «No leído» (swipe ←) */}
+        <div className="flex w-30 shrink-0 items-center justify-center bg-primary">
+          <button
+            className={cn(
+              'flex items-center gap-1.5 rounded-[10px] bg-white/20 px-3 py-1.5 text-xs font-bold text-white',
+              openSide !== 'right' && 'pointer-events-none'
+            )}
+            onClick={() => onToggleRead(tx)}
+          >
+            {tx.is_read ? (
+              <>
+                <X size={13} strokeWidth={2.5} color="white" />
+                No leído
+              </>
+            ) : (
+              <>
+                <Check size={13} strokeWidth={2.5} color="white" />
+                Leído
+              </>
+            )}
+          </button>
         </div>
       </div>
     </div>

--- a/components/transactions/UnreadProvider.tsx
+++ b/components/transactions/UnreadProvider.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+interface UnreadValue {
+  /** Nº de movimientos no leídos (alimenta el badge de la tabBar). */
+  count: number
+  /** Ajuste optimista: marcar uno como leído. */
+  decrement: () => void
+  /** Ajuste optimista: marcar uno como no leído (o rollback de un decrement). */
+  increment: () => void
+  /** Fija el contador (p.ej. al recibir un count fresco del servidor). */
+  setCount: (n: number) => void
+}
+
+// Default no-op: la tabBar (`BottomNav`) también se renderiza en /~offline, fuera
+// del grupo (app) y por tanto sin provider. Allí el badge simplemente no aparece
+// (count 0) en vez de romper.
+const UnreadContext = createContext<UnreadValue>({
+  count: 0,
+  decrement: () => {},
+  increment: () => {},
+  setCount: () => {},
+})
+
+export function UnreadProvider({
+  initialCount,
+  children,
+}: {
+  initialCount: number
+  children: React.ReactNode
+}) {
+  const [count, setCountState] = useState(initialCount)
+
+  // El layout (server component) recomputa `initialCount` tras un router.refresh()
+  // (p.ej. después de una sincronización que trae movimientos nuevos no leídos).
+  // useState ignora los cambios de prop, así que sincronizamos al valor fresco del
+  // servidor —autoritativo— ajustando durante el render cuando cambia (patrón
+  // recomendado por React frente a un effect). No interfiere con los ajustes
+  // optimistas de marcar leído/no leído, que no disparan refresh del layout.
+  const [prevInitial, setPrevInitial] = useState(initialCount)
+  if (initialCount !== prevInitial) {
+    setPrevInitial(initialCount)
+    setCountState(initialCount)
+  }
+
+  const decrement = useCallback(() => setCountState(c => Math.max(0, c - 1)), [])
+  const increment = useCallback(() => setCountState(c => c + 1), [])
+  const setCount = useCallback((n: number) => setCountState(Math.max(0, n)), [])
+
+  const value = useMemo<UnreadValue>(
+    () => ({ count, decrement, increment, setCount }),
+    [count, decrement, increment, setCount]
+  )
+
+  return <UnreadContext.Provider value={value}>{children}</UnreadContext.Provider>
+}
+
+export function useUnread(): UnreadValue {
+  return useContext(UnreadContext)
+}

--- a/components/transactions/useTxMutations.ts
+++ b/components/transactions/useTxMutations.ts
@@ -2,11 +2,13 @@
 
 import { useCallback, useState } from 'react'
 import { useSyncStatus } from '@/components/sync/SyncStatusProvider'
+import { useUnread } from '@/components/transactions/UnreadProvider'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
 export function useTxMutations(initial: TransactionWithAccount[]) {
   const [transactions, setTransactions] = useState(initial)
   const { showToast } = useSyncStatus()
+  const { increment, decrement } = useUnread()
 
   const addTx = useCallback((tx: TransactionWithAccount) => {
     setTransactions(prev => [tx, ...prev])
@@ -73,5 +75,41 @@ export function useTxMutations(initial: TransactionWithAccount[]) {
     })()
   }, [showToast])
 
-  return { transactions, addTx, appendTxs, deleteTx, recategorize }
+  // Marca leído/no leído de forma optimista, ajustando además el contador del badge
+  // (UnreadProvider). El contador solo se toca si el estado realmente cambia, para
+  // que un re-toggle redundante no lo descuadre. Rollback simétrico + toast.
+  const setRead = useCallback((id: string, isRead: boolean) => {
+    return (async function attempt() {
+      let changed = false
+      let snapshot: TransactionWithAccount[] = []
+      setTransactions(prev => {
+        snapshot = prev
+        changed = prev.some(t => t.id === id && t.is_read !== isRead)
+        return prev.map(t => (t.id === id ? { ...t, is_read: isRead } : t))
+      })
+      if (!changed) return
+      // Leído → un no leído menos; no leído → uno más.
+      if (isRead) decrement()
+      else increment()
+      try {
+        const res = await fetch(`/api/transactions/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ is_read: isRead }),
+        })
+        if (!res.ok) throw new Error(await res.text())
+      } catch (err) {
+        setTransactions(snapshot)
+        if (isRead) increment()
+        else decrement()
+        console.error('[useTxMutations.setRead] Error marcando leído/no leído:', err)
+        showToast('No se pudo actualizar el movimiento', () => { void attempt() })
+      }
+    })()
+  }, [showToast, increment, decrement])
+
+  const markRead = useCallback((id: string) => setRead(id, true), [setRead])
+  const markUnread = useCallback((id: string) => setRead(id, false), [setRead])
+
+  return { transactions, addTx, appendTxs, deleteTx, recategorize, markRead, markUnread }
 }

--- a/components/transactions/useTxMutations.ts
+++ b/components/transactions/useTxMutations.ts
@@ -80,14 +80,15 @@ export function useTxMutations(initial: TransactionWithAccount[]) {
   // que un re-toggle redundante no lo descuadre. Rollback simétrico + toast.
   const setRead = useCallback((id: string, isRead: boolean) => {
     return (async function attempt() {
-      let changed = false
+      // El estado real ya cambia: no reenviar ni descuadrar el contador. Se
+      // comprueba contra `transactions` (estado actual en el closure), NO dentro
+      // del updater de setState —que React no ejecuta de forma síncrona—.
+      if (!transactions.some(t => t.id === id && t.is_read !== isRead)) return
       let snapshot: TransactionWithAccount[] = []
       setTransactions(prev => {
         snapshot = prev
-        changed = prev.some(t => t.id === id && t.is_read !== isRead)
         return prev.map(t => (t.id === id ? { ...t, is_read: isRead } : t))
       })
-      if (!changed) return
       // Leído → un no leído menos; no leído → uno más.
       if (isRead) decrement()
       else increment()
@@ -106,7 +107,7 @@ export function useTxMutations(initial: TransactionWithAccount[]) {
         showToast('No se pudo actualizar el movimiento', () => { void attempt() })
       }
     })()
-  }, [showToast, increment, decrement])
+  }, [transactions, showToast, increment, decrement])
 
   const markRead = useCallback((id: string) => setRead(id, true), [setRead])
   const markUnread = useCallback((id: string) => setRead(id, false), [setRead])

--- a/hooks/useHorizontalSwipe.test.ts
+++ b/hooks/useHorizontalSwipe.test.ts
@@ -20,50 +20,87 @@ describe('isTap', () => {
   })
 })
 
-describe('decideCommit', () => {
-  it('abre cuando dx supera el umbral positivo', () => {
-    expect(decideCommit(COMMIT_THRESHOLD + 1)).toBe('open')
+describe('decideCommit (cerrado)', () => {
+  it('abre el panel izquierdo al arrastrar a la derecha', () => {
+    expect(decideCommit(COMMIT_THRESHOLD + 1, null)).toBe('left')
   })
 
-  it('cierra cuando dx supera el umbral negativo', () => {
-    expect(decideCommit(-(COMMIT_THRESHOLD + 1))).toBe('close')
+  it('abre el panel derecho al arrastrar a la izquierda', () => {
+    expect(decideCommit(-(COMMIT_THRESHOLD + 1), null)).toBe('right')
   })
 
   it('no hace nada dentro del umbral', () => {
-    expect(decideCommit(0)).toBe('noop')
-    expect(decideCommit(COMMIT_THRESHOLD)).toBe('noop')
-    expect(decideCommit(-COMMIT_THRESHOLD)).toBe('noop')
+    expect(decideCommit(0, null)).toBe('noop')
+    expect(decideCommit(COMMIT_THRESHOLD, null)).toBe('noop')
+    expect(decideCommit(-COMMIT_THRESHOLD, null)).toBe('noop')
+  })
+})
+
+describe('decideCommit (abierto)', () => {
+  it('cierra el panel izquierdo al arrastrar a la izquierda', () => {
+    expect(decideCommit(-(COMMIT_THRESHOLD + 1), 'left')).toBe('close')
+  })
+
+  it('mantiene el panel izquierdo si no se supera el umbral o se arrastra a la derecha', () => {
+    expect(decideCommit(-COMMIT_THRESHOLD, 'left')).toBe('noop')
+    expect(decideCommit(COMMIT_THRESHOLD + 1, 'left')).toBe('noop')
+  })
+
+  it('cierra el panel derecho al arrastrar a la derecha', () => {
+    expect(decideCommit(COMMIT_THRESHOLD + 1, 'right')).toBe('close')
+  })
+
+  it('mantiene el panel derecho si no se supera el umbral o se arrastra a la izquierda', () => {
+    expect(decideCommit(COMMIT_THRESHOLD, 'right')).toBe('noop')
+    expect(decideCommit(-(COMMIT_THRESHOLD + 1), 'right')).toBe('noop')
   })
 })
 
 describe('computeDragX (cerrado)', () => {
-  const actionWidth = 120
+  const W = 120
 
-  it('ignora movimientos hacia la izquierda', () => {
-    expect(computeDragX(-50, false, actionWidth)).toBe(0)
+  it('sigue el dedo hacia la derecha (revela panel izquierdo)', () => {
+    expect(computeDragX(50, null, W)).toBe(50)
   })
 
-  it('sigue el dedo hacia la derecha', () => {
-    expect(computeDragX(50, false, actionWidth)).toBe(50)
+  it('sigue el dedo hacia la izquierda (revela panel derecho)', () => {
+    expect(computeDragX(-50, null, W)).toBe(-50)
   })
 
-  it('clampa al ancho del panel', () => {
-    expect(computeDragX(200, false, actionWidth)).toBe(actionWidth)
+  it('clampa a ±ancho del panel', () => {
+    expect(computeDragX(200, null, W)).toBe(W)
+    expect(computeDragX(-200, null, W)).toBe(-W)
   })
 })
 
-describe('computeDragX (abierto)', () => {
-  const actionWidth = 120
+describe('computeDragX (panel izquierdo abierto)', () => {
+  const W = 120
 
-  it('ignora movimientos hacia la derecha', () => {
-    expect(computeDragX(50, true, actionWidth)).toBe(0)
+  it('ignora movimientos hacia la derecha (ya abierto)', () => {
+    expect(computeDragX(50, 'left', W)).toBe(W)
   })
 
   it('cierra parcialmente al mover a la izquierda', () => {
-    expect(computeDragX(-50, true, actionWidth)).toBe(70)
+    expect(computeDragX(-50, 'left', W)).toBe(70)
   })
 
-  it('clampa cuando se excede el ancho del panel', () => {
-    expect(computeDragX(-200, true, actionWidth)).toBe(0)
+  it('clampa a cerrado al exceder el ancho', () => {
+    expect(computeDragX(-200, 'left', W)).toBe(0)
+  })
+})
+
+describe('computeDragX (panel derecho abierto)', () => {
+  const W = 120
+
+  it('ignora movimientos hacia la izquierda (ya abierto)', () => {
+    expect(computeDragX(-50, 'right', W)).toBe(-W)
+  })
+
+  it('cierra parcialmente al mover a la derecha', () => {
+    expect(computeDragX(50, 'right', W)).toBe(-70)
+  })
+
+  it('clampa a cerrado al exceder el ancho', () => {
+    expect(computeDragX(200, 'right', W)).toBe(0)
   })
 })

--- a/hooks/useHorizontalSwipe.ts
+++ b/hooks/useHorizontalSwipe.ts
@@ -5,28 +5,55 @@ import { useRef, useState, type MutableRefObject, type TouchEvent } from 'react'
 export const MOVE_THRESHOLD = 8
 export const COMMIT_THRESHOLD = 60
 
+/**
+ * Lado del panel de acción abierto.
+ * - `left`  → panel a la izquierda, se revela arrastrando hacia la derecha (swipe →).
+ * - `right` → panel a la derecha, se revela arrastrando hacia la izquierda (swipe ←).
+ */
+export type SwipeSide = 'left' | 'right'
+
 export function isTap(dx: number): boolean {
   return Math.abs(dx) <= MOVE_THRESHOLD
 }
 
-export function computeDragX(dx: number, isOpen: boolean, actionWidth: number): number {
-  if (!isOpen && dx > 0) return Math.min(dx, actionWidth)
-  if (isOpen && dx < 0) return actionWidth + Math.max(dx, -actionWidth)
-  return 0
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v))
 }
 
-export type CommitDecision = 'open' | 'close' | 'noop'
+/**
+ * Desplazamiento (con signo) del contenido respecto al reposo, en px.
+ * `+actionWidth` = panel izquierdo totalmente abierto; `-actionWidth` = panel
+ * derecho totalmente abierto; `0` = cerrado. El render aplica
+ * `translateX(currentX - actionWidth)` sobre el slider `[left][contenido][right]`.
+ */
+export function computeDragX(dx: number, openSide: SwipeSide | null, actionWidth: number): number {
+  // Abierto a la izquierda: solo se permite cerrar (arrastrar hacia la izquierda).
+  if (openSide === 'left') return clamp(actionWidth + Math.min(0, dx), 0, actionWidth)
+  // Abierto a la derecha: solo se permite cerrar (arrastrar hacia la derecha).
+  if (openSide === 'right') return clamp(-actionWidth + Math.max(0, dx), -actionWidth, 0)
+  // Cerrado: el contenido sigue al dedo en ambos sentidos hasta el ancho del panel.
+  return clamp(dx, -actionWidth, actionWidth)
+}
 
-export function decideCommit(dx: number): CommitDecision {
-  if (dx > COMMIT_THRESHOLD) return 'open'
-  if (dx < -COMMIT_THRESHOLD) return 'close'
+export type CommitDecision = SwipeSide | 'close' | 'noop'
+
+/**
+ * Decide la transición al soltar, en función del desplazamiento y del lado ya
+ * abierto. Cerrado: superar el umbral abre el panel del lado correspondiente.
+ * Abierto: superar el umbral en sentido contrario lo cierra.
+ */
+export function decideCommit(dx: number, openSide: SwipeSide | null): CommitDecision {
+  if (openSide === 'left') return dx < -COMMIT_THRESHOLD ? 'close' : 'noop'
+  if (openSide === 'right') return dx > COMMIT_THRESHOLD ? 'close' : 'noop'
+  if (dx > COMMIT_THRESHOLD) return 'left'
+  if (dx < -COMMIT_THRESHOLD) return 'right'
   return 'noop'
 }
 
 interface Options {
   actionWidth: number
-  isOpen: boolean
-  onOpen: () => void
+  openSide: SwipeSide | null
+  onOpen: (side: SwipeSide) => void
   onClose: () => void
 }
 
@@ -44,9 +71,11 @@ interface Result {
   didMoveRef: MutableRefObject<boolean>
 }
 
-export function useHorizontalSwipe({ actionWidth, isOpen, onOpen, onClose }: Options): Result {
+export function useHorizontalSwipe({ actionWidth, openSide, onOpen, onClose }: Options): Result {
   const startX = useRef<number | null>(null)
   const didMoveRef = useRef(false)
+  // `dragX === 0` significa "no se está arrastrando" (reposo): en ese caso el
+  // contenido se posiciona según `openSide` y se anima la transición.
   const [dragX, setDragX] = useState(0)
 
   const onTouchStart = (e: TouchEvent) => {
@@ -58,14 +87,14 @@ export function useHorizontalSwipe({ actionWidth, isOpen, onOpen, onClose }: Opt
     if (startX.current === null) return
     const dx = e.touches[0].clientX - startX.current
     if (!isTap(dx)) didMoveRef.current = true
-    setDragX(computeDragX(dx, isOpen, actionWidth))
+    setDragX(computeDragX(dx, openSide, actionWidth))
   }
 
   const onTouchEnd = (e: TouchEvent) => {
     if (startX.current === null) return
     const dx = e.changedTouches[0].clientX - startX.current
-    const decision = decideCommit(dx)
-    if (decision === 'open') onOpen()
+    const decision = decideCommit(dx, openSide)
+    if (decision === 'left' || decision === 'right') onOpen(decision)
     else if (decision === 'close') onClose()
     setDragX(0)
     startX.current = null
@@ -77,9 +106,11 @@ export function useHorizontalSwipe({ actionWidth, isOpen, onOpen, onClose }: Opt
     setDragX(0)
   }
 
+  const settledX = openSide === 'left' ? actionWidth : openSide === 'right' ? -actionWidth : 0
+
   return {
     bind: { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel },
-    currentX: isOpen ? actionWidth : dragX,
+    currentX: dragX !== 0 ? dragX : settledX,
     isAnimating: dragX === 0,
     didMoveRef,
   }

--- a/supabase/migrations/20260606000000_transactions_is_read.sql
+++ b/supabase/migrations/20260606000000_transactions_is_read.sql
@@ -1,0 +1,33 @@
+-- Issue #149: estado leído / no leído por movimiento.
+--
+-- Un movimiento que entra por sincronización (Enable Banking / scraper Edenred)
+-- nace `is_read = false` para que el usuario sepa de un vistazo que hay novedades
+-- (badge en la tabBar + sección "No leídos" en la lista). Los movimientos creados
+-- manualmente por el usuario nacen leídos (lo fija el endpoint POST, no esta
+-- migración).
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- 1. Nueva columna (DEFAULT false → solo afecta a inserciones futuras)
+-- ============================================================
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS is_read BOOLEAN NOT NULL DEFAULT false;
+
+-- ============================================================
+-- 2. Backfill: todo el histórico se marca como leído.
+-- ============================================================
+-- El DEFAULT false dejaría cientos de movimientos antiguos como "no leídos" e
+-- inundaría el badge. Marcamos como leído todo lo existente en el momento de la
+-- migración; el "no leído" queda reservado para lo que entre a partir de ahora.
+UPDATE transactions SET is_read = true;
+
+-- ============================================================
+-- 3. Índice parcial para que el conteo de no leídos sea barato.
+-- ============================================================
+-- El badge cuenta `is_read = false` filtrando por hogar; un índice parcial sobre
+-- (household_id) WHERE NOT is_read mantiene ese conteo y la sección "No leídos"
+-- eficientes sin penalizar el resto de consultas.
+CREATE INDEX IF NOT EXISTS idx_transactions_unread
+  ON transactions(household_id)
+  WHERE is_read = false;

--- a/types/index.ts
+++ b/types/index.ts
@@ -98,6 +98,7 @@ export interface Transaction {
   source: DataSource
   external_id: string | null
   notes: string | null
+  is_read: boolean
   created_at: string
 }
 


### PR DESCRIPTION
Closes #149.

## Qué hace
Introduce el estado **leído / no leído** por movimiento, con sus puntos de contacto en la UI.

### Modelo de datos
- Migración `20260606000000_transactions_is_read.sql`: columna `is_read BOOLEAN NOT NULL DEFAULT false`, **backfill** del histórico a `true` (no inundar el badge) e **índice parcial** `WHERE is_read = false` para conteo barato.
- `is_read` añadido al tipo `Transaction`.

### Inserción
- **Manual** (`POST /api/transactions`): nace `is_read = true`.
- **Edenred** (`POST /api/edenred`): omite `is_read` a propósito → los inserts nuevos toman el `DEFAULT false` y un re-sync (`ignoreDuplicates: false`) **no** reescribe el estado de un movimiento ya leído.
- **Enable Banking**: sin cambios (`ignoreDuplicates: true`, basta el default).

### Badge en la tabBar
- `UnreadProvider` (patrón `SyncStatusProvider`) montado en el layout (app) con el count inicial calculado en el servidor; se re-sincroniza al valor del servidor tras `router.refresh()`.
- Globo con el número sobre la pestaña *Movimientos*, oculto si `0`, **`99+`** por encima de 99.

### Gestos
- `useHorizontalSwipe` extendido a **dos paneles**: swipe → «Categoría» (sin cambios), swipe ← botón único que **alterna** «Leído» / «No leído».

### Lista
- **Dot de no leído** en la fila (acento, gutter reservado para no descuadrar).
- **Marcar leído al abrir** el detalle (aunque no se edite).
- **Sección «No leídos» fijada arriba** con **membresía congelada**: al marcar leído el dot se apaga al instante pero la fila **no salta**; baja a su grupo de fecha al recargar/volver (remontaje).
- Mutaciones `markRead`/`markUnread` optimistas con rollback + toast, que ajustan el contador del badge. `CategoryDetailClient` adaptado al nuevo contrato de `TxRow`.

## Verificación
- `pnpm test` ✓ (248, incl. 18 del swipe bidireccional) · `pnpm lint` ✓ · `pnpm build` ✓
- **Requiere aplicar la migración** en Supabase antes de desplegar.

## Notas
- El prototipo `docs/finanzas-app.jsx` no contemplaba el estado no-leído; el dot se diseñó siguiendo su lenguaje visual (acento `--primary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)