### PR TITLE
feat(sabadell): scraper de tarjetas de crédito con Playwright (#147)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ EDENRED_USER=              # solo para regenerar storage-state localmente
 EDENRED_PASS=              # solo para regenerar storage-state localmente
 APP_URL=http://localhost:3000   # destino del webhook (lo usan scrape:edenred y el workflow de Enable Banking)
 
+# Sabadell scraper — tarjetas de crédito (#147). Corre en local HEADED (Sabadell
+# bloquea Chrome headless vía WAF) con perfil persistente de Chrome real.
+SABADELL_WEBHOOK_SECRET=   # genera con: openssl rand -hex 32 (auth del webhook /api/sabadell)
+SABADELL_USER=             # DNI/NIF de acceso a BS Online (login automático del scraper)
+SABADELL_PASS=             # PIN de 8 dígitos de BS Online
+
 # App
 NEXT_PUBLIC_APP_URL=https://fin-app-tawny.vercel.app
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ next-env.d.ts
 scripts/storage-state.json
 scripts/storage-state.json.*
 
+# sabadell scraper — sesión/perfil Playwright y volcados de investigación
+scripts/sabadell-storage-state.json
+scripts/sabadell-storage-state.json.*
+scripts/.sabadell-userdata/
+scripts/.sabadell-*.local.*
+
 # serwist — service worker generado en build
 public/sw.js
 public/sw.js.map

--- a/app/api/sabadell/route.test.ts
+++ b/app/api/sabadell/route.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createServiceClient } from '@/lib/supabase/service'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+
+const { POST } = await import('./route')
+
+const SECRET = 'test-secret'
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000a1'
+const ACCOUNT_A = '00000000-0000-0000-0000-000000000aaa'
+const ACCOUNT_B = '00000000-0000-0000-0000-000000000bbb'
+
+type AccountResult = { data: { id: string } | null; error?: unknown }
+
+type MockOpts = {
+  userConfig?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
+  // Una entrada por tarjeta (el handler itera): select previo e insert posterior.
+  accountSelects?: AccountResult[]
+  accountInserts?: AccountResult[]
+  rules?: { data: Array<{ pattern: string; field: string; category_id: string }> }
+  txUpsert?: { error?: unknown }
+}
+
+function buildMockDb(opts: MockOpts = {}) {
+  const insertSpy = vi.fn()
+  const updateSpy = vi.fn()
+  const upsertSpy = vi.fn()
+  const rpcSpy = vi.fn()
+
+  const userConfigBuilder: Record<string, unknown> = {}
+  Object.assign(userConfigBuilder, {
+    select: vi.fn(() => userConfigBuilder),
+    limit: vi.fn(() => userConfigBuilder),
+    maybeSingle: vi.fn(() => Promise.resolve(opts.userConfig ?? { data: null, error: null })),
+  })
+
+  const rulesBuilder: Record<string, unknown> = {}
+  Object.assign(rulesBuilder, {
+    select: vi.fn(() => rulesBuilder),
+    eq: vi.fn(() => rulesBuilder),
+    order: vi.fn(() => Promise.resolve(opts.rules ?? { data: [] })),
+  })
+
+  // `accounts` se consulta una vez por tarjeta. Se crea un builder fresco en cada
+  // from('accounts') ligado al índice de tarjeta, para no arrastrar estado entre
+  // iteraciones (a diferencia del mock de Edenred, de una sola cuenta).
+  let accountsCall = -1
+  function makeAccountsBuilder(idx: number) {
+    const sel = opts.accountSelects?.[idx] ?? { data: null, error: null }
+    const ins = opts.accountInserts?.[idx] ?? { data: null, error: null }
+    const b: Record<string, unknown> & { _afterInsert: boolean; _afterUpdate: boolean } = {
+      _afterInsert: false,
+      _afterUpdate: false,
+    }
+    Object.assign(b, {
+      select: vi.fn(() => {
+        if (b._afterInsert) return { single: vi.fn(() => Promise.resolve(ins)) }
+        return b
+      }),
+      eq: vi.fn(() => {
+        if (b._afterUpdate) return Promise.resolve({ error: null })
+        return b
+      }),
+      maybeSingle: vi.fn(() => Promise.resolve(sel)),
+      insert: vi.fn((payload: unknown) => {
+        insertSpy(payload)
+        b._afterInsert = true
+        return b
+      }),
+      update: vi.fn((payload: unknown) => {
+        updateSpy(payload)
+        b._afterUpdate = true
+        return b
+      }),
+    })
+    return b
+  }
+
+  const txBuilder = {
+    upsert: vi.fn((rows: unknown, options: unknown) => {
+      upsertSpy(rows, options)
+      return Promise.resolve(opts.txUpsert ?? { error: null })
+    }),
+  }
+
+  // El handler llama a from('accounts') dos veces por tarjeta (select + luego
+  // insert/update). Se reutiliza el mismo builder en ese par y se avanza de
+  // índice (siguiente tarjeta) sólo cuando el anterior ya mutó.
+  let currentAccounts: ReturnType<typeof makeAccountsBuilder> | null = null
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === 'user_config') return userConfigBuilder
+      if (table === 'categorization_rules') return rulesBuilder
+      if (table === 'accounts') {
+        if (!currentAccounts || currentAccounts._afterInsert || currentAccounts._afterUpdate) {
+          accountsCall++
+          currentAccounts = makeAccountsBuilder(accountsCall)
+        }
+        return currentAccounts
+      }
+      if (table === 'transactions') return txBuilder
+      throw new Error(`Unmocked table: ${table}`)
+    }),
+    rpc: vi.fn((fn: string) => {
+      rpcSpy(fn)
+      return Promise.resolve({ error: null })
+    }),
+  }
+
+  return { db, insertSpy, updateSpy, upsertSpy, rpcSpy }
+}
+
+function callRoute(body: unknown, opts: { auth?: string | null; rawBody?: string } = {}) {
+  const headers: Record<string, string> = {}
+  if (opts.auth !== null) headers.authorization = opts.auth ?? `Bearer ${SECRET}`
+  return POST(
+    new Request('http://test/api/sabadell', {
+      method: 'POST',
+      headers,
+      body: opts.rawBody ?? JSON.stringify(body),
+    })
+  )
+}
+
+const validPayload = {
+  last_synced_at: '2026-06-06T10:00:00Z',
+  cards: [
+    {
+      card_id: '4106________4014',
+      name: 'Sabadell VISA •••• 4014',
+      number: '4106 •••• 4014',
+      balance: -156.2,
+      transactions: [
+        { external_id: 'ref-1', amount: -156.2, description: 'Zara.com', transaction_date: '2026-05-25' },
+      ],
+    },
+    {
+      card_id: '4106________5011',
+      name: 'Sabadell VISA •••• 5011',
+      number: '4106 •••• 5011',
+      balance: -14.99,
+      transactions: [
+        { external_id: 'ref-2', amount: -14.99, description: 'Pago sin patrón', transaction_date: '2026-05-20' },
+      ],
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.stubEnv('SABADELL_WEBHOOK_SECRET', SECRET)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /api/sabadell — auth', () => {
+  it('rechaza con 401 si falta el header Authorization', async () => {
+    const { db } = buildMockDb()
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    const res = await callRoute(validPayload, { auth: null })
+    expect(res.status).toBe(401)
+    expect(db.from).not.toHaveBeenCalled()
+  })
+
+  it('rechaza con 401 si el Bearer es incorrecto', async () => {
+    const { db } = buildMockDb()
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    const res = await callRoute(validPayload, { auth: 'Bearer wrong' })
+    expect(res.status).toBe(401)
+    expect(db.from).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/sabadell — configuración', () => {
+  it('devuelve 500 si falta SABADELL_WEBHOOK_SECRET', async () => {
+    vi.unstubAllEnvs()
+    delete process.env.SABADELL_WEBHOOK_SECRET
+    const { db } = buildMockDb()
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    const res = await callRoute(validPayload)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Server misconfigured' })
+  })
+})
+
+describe('POST /api/sabadell — validación de body', () => {
+  it.each<[string, string | object]>([
+    ['JSON no parseable', 'not-json{'],
+    ['falta cards', { last_synced_at: '2026-06-06T10:00:00Z' }],
+    ['cards no es array', { last_synced_at: 'x', cards: 'oops' }],
+    ['card sin card_id', { last_synced_at: 'x', cards: [{ name: 'n', balance: 0, transactions: [] }] }],
+    [
+      'tx con amount string',
+      {
+        last_synced_at: 'x',
+        cards: [
+          {
+            card_id: 'c1',
+            name: 'n',
+            balance: 0,
+            transactions: [{ external_id: 'a', amount: 'mal', description: 'x', transaction_date: '2026-05-18' }],
+          },
+        ],
+      },
+    ],
+  ])('devuelve 400 cuando %s', async (_label, body) => {
+    const { db } = buildMockDb()
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    const res = typeof body === 'string' ? await callRoute(null, { rawBody: body }) : await callRoute(body)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid body' })
+  })
+})
+
+describe('POST /api/sabadell — user_config', () => {
+  it('devuelve 500 si user_config está vacío', async () => {
+    const { db } = buildMockDb({ userConfig: { data: null, error: null } })
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    const res = await callRoute(validPayload)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'No user configured' })
+  })
+})
+
+describe('POST /api/sabadell — primer POST (crea cuentas)', () => {
+  it('inserta una cuenta de tarjeta por cada card y upsertea sus txns', async () => {
+    const { db, insertSpy, upsertSpy, rpcSpy } = buildMockDb({
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      accountSelects: [{ data: null }, { data: null }],
+      accountInserts: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
+    })
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+
+    const res = await callRoute(validPayload)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ cards: 2, created_accounts: 2, upserted: 2 })
+
+    expect(insertSpy).toHaveBeenCalledTimes(2)
+    expect(insertSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      household_id: HOUSEHOLD_ID,
+      name: 'Sabadell VISA •••• 4014',
+      type: 'card',
+      source: 'scraper',
+      is_liability: true,
+      balance: -156.2,
+      external_id: '4106________4014',
+      number: '4106 •••• 4014',
+      currency: 'EUR',
+    }))
+
+    const [rows] = upsertSpy.mock.calls[0]
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({ account_id: ACCOUNT_A, external_id: 'ref-1', source: 'scraper' })
+    expect(rows[1]).toMatchObject({ account_id: ACCOUNT_B, external_id: 'ref-2' })
+    // Auto-categorización: "Zara.com" → clothing; sin patrón → null
+    expect(rows[0].category).toBe('clothing')
+    expect(rows[1].category).toBeNull()
+    // is_read no se envía (preserva estado de lectura en re-syncs)
+    expect(rows[0]).not.toHaveProperty('is_read')
+    // Refresca la matview
+    expect(rpcSpy).toHaveBeenCalledWith('refresh_monthly_summary')
+  })
+})
+
+describe('POST /api/sabadell — POST siguiente (actualiza cuentas)', () => {
+  it('actualiza balance/last_synced/name de cada cuenta existente sin insertar', async () => {
+    const { db, insertSpy, updateSpy } = buildMockDb({
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      accountSelects: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
+    })
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+
+    const res = await callRoute(validPayload)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ cards: 2, created_accounts: 0, upserted: 2 })
+    expect(insertSpy).not.toHaveBeenCalled()
+    expect(updateSpy).toHaveBeenCalledTimes(2)
+    expect(updateSpy).toHaveBeenNthCalledWith(1, {
+      balance: -156.2,
+      last_synced: validPayload.last_synced_at,
+      name: 'Sabadell VISA •••• 4014',
+    })
+  })
+})
+
+describe('POST /api/sabadell — idempotencia', () => {
+  it('upsert con onConflict="household_id,external_id" e ignoreDuplicates=false', async () => {
+    const { db, upsertSpy } = buildMockDb({
+      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      accountSelects: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
+    })
+    vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
+    await callRoute(validPayload)
+    const [, options] = upsertSpy.mock.calls[0]
+    expect(options).toEqual({ onConflict: 'household_id,external_id', ignoreDuplicates: false })
+  })
+})

--- a/app/api/sabadell/route.ts
+++ b/app/api/sabadell/route.ts
@@ -1,0 +1,218 @@
+import { NextResponse } from 'next/server'
+import { timingSafeEqual } from 'node:crypto'
+import { createServiceClient } from '@/lib/supabase/service'
+import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
+
+type SabadellTx = {
+  external_id: string
+  amount: number
+  description: string
+  transaction_date: string
+}
+
+type SabadellCard = {
+  // Identidad estable de la tarjeta: PAN enmascarado (p.ej. "4106________4014").
+  // Las dos tarjetas comparten descripción ("VISA CLASSIC BSAB"), así que el
+  // número es lo único que las distingue. Se usa como accounts.external_id.
+  card_id: string
+  name: string
+  number?: string
+  // Saldo de la cuenta de tarjeta (pasivo): deuda pendiente en negativo.
+  balance: number
+  transactions: SabadellTx[]
+}
+
+type SabadellPayload = {
+  last_synced_at: string
+  cards: SabadellCard[]
+}
+
+function isValidTx(tx: unknown): tx is SabadellTx {
+  if (!tx || typeof tx !== 'object') return false
+  const t = tx as SabadellTx
+  if (typeof t.external_id !== 'string' || t.external_id === '') return false
+  if (typeof t.amount !== 'number' || !Number.isFinite(t.amount)) return false
+  if (typeof t.description !== 'string') return false
+  if (typeof t.transaction_date !== 'string') return false
+  return true
+}
+
+function isValidPayload(data: unknown): data is SabadellPayload {
+  if (!data || typeof data !== 'object') return false
+  const p = data as Record<string, unknown>
+  if (typeof p.last_synced_at !== 'string') return false
+  if (!Array.isArray(p.cards)) return false
+  return p.cards.every(card => {
+    if (!card || typeof card !== 'object') return false
+    const c = card as SabadellCard
+    if (typeof c.card_id !== 'string' || c.card_id === '') return false
+    if (typeof c.name !== 'string') return false
+    if (c.number !== undefined && typeof c.number !== 'string') return false
+    if (typeof c.balance !== 'number' || !Number.isFinite(c.balance)) return false
+    if (!Array.isArray(c.transactions)) return false
+    return c.transactions.every(isValidTx)
+  })
+}
+
+function safeBearerMatch(header: string | null, secret: string): boolean {
+  if (!header) return false
+  const expected = `Bearer ${secret}`
+  const a = Buffer.from(header)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export async function POST(req: Request) {
+  const secret = process.env.SABADELL_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[sabadell] SABADELL_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+  if (!isValidPayload(payload)) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+
+  const db = createServiceClient()
+
+  // El webhook no tiene sesión: se resuelve el hogar (y un user_id de
+  // creador/auditoría) leyendo el único registro de user_config. App personal
+  // con un único hogar (mismo patrón que /api/edenred).
+  const { data: userRow, error: userErr } = await db
+    .from('user_config')
+    .select('user_id, household_id')
+    .limit(1)
+    .maybeSingle()
+  if (userErr || !userRow || !userRow.household_id) {
+    console.error('[sabadell] no user_config/household:', userErr)
+    return NextResponse.json({ error: 'No user configured' }, { status: 500 })
+  }
+  const userId = userRow.user_id as string
+  const householdId = userRow.household_id as string
+
+  // Reglas de categorización del hogar (mismo criterio que la sync de Enable
+  // Banking): las tarjetas de crédito son compras en comercios variados, así que
+  // se auto-categoriza por descripción en vez de un valor fijo como Edenred.
+  const { data: rulesData } = await db
+    .from('categorization_rules')
+    .select('pattern, field, category_id')
+    .eq('household_id', householdId)
+    .eq('is_active', true)
+    .order('priority', { ascending: false })
+  const dbRules: DbCategorizationRule[] = (rulesData ?? []) as DbCategorizationRule[]
+
+  let createdAccounts = 0
+  // Una sola tabla de filas con las transacciones de todas las tarjetas; cada
+  // fila lleva su account_id resuelto. Se hace un único upsert al final.
+  const txRows: Array<{
+    user_id: string
+    household_id: string
+    account_id: string
+    date: string
+    amount: number
+    description: string
+    category: string | null
+    source: 'scraper'
+    external_id: string
+  }> = []
+
+  for (const card of payload.cards) {
+    // Identidad de la cuenta por external_id (no por nombre), para tolerar
+    // renombrados y porque ambas tarjetas comparten descripción.
+    const { data: existingAccount, error: accSelErr } = await db
+      .from('accounts')
+      .select('id')
+      .eq('household_id', householdId)
+      .eq('source', 'scraper')
+      .eq('external_id', card.card_id)
+      .maybeSingle()
+    if (accSelErr) {
+      console.error('[sabadell] select account:', accSelErr)
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+
+    let accountId: string
+    if (existingAccount) {
+      accountId = existingAccount.id as string
+      const { error: updErr } = await db
+        .from('accounts')
+        .update({ balance: card.balance, last_synced: payload.last_synced_at, name: card.name })
+        .eq('id', accountId)
+      if (updErr) {
+        console.error('[sabadell] update account:', updErr)
+        return NextResponse.json({ error: 'DB error' }, { status: 500 })
+      }
+    } else {
+      const { data: inserted, error: insErr } = await db
+        .from('accounts')
+        .insert({
+          user_id: userId,
+          household_id: householdId,
+          name: card.name,
+          type: 'card',
+          source: 'scraper',
+          is_liability: true,
+          balance: card.balance,
+          number: card.number ?? null,
+          external_id: card.card_id,
+          last_synced: payload.last_synced_at,
+          currency: 'EUR',
+        })
+        .select('id')
+        .single()
+      if (insErr || !inserted) {
+        console.error('[sabadell] insert account:', insErr)
+        return NextResponse.json({ error: 'DB error' }, { status: 500 })
+      }
+      accountId = inserted.id as string
+      createdAccounts++
+    }
+
+    for (const tx of card.transactions) {
+      txRows.push({
+        user_id: userId,
+        household_id: householdId,
+        account_id: accountId,
+        date: tx.transaction_date,
+        amount: tx.amount,
+        description: tx.description,
+        category: categorizeWithRules(dbRules, tx.description),
+        source: 'scraper',
+        external_id: tx.external_id,
+      })
+    }
+  }
+
+  let upserted = 0
+  if (txRows.length > 0) {
+    // `is_read` se omite a propósito (igual que Edenred, issue #149): los inserts
+    // nuevos toman el DEFAULT false (nacen "no leídos") y, como el upsert usa
+    // `ignoreDuplicates: false`, un re-sync NO reescribe el estado de lectura.
+    const { error: upsertErr } = await db
+      .from('transactions')
+      .upsert(txRows, { onConflict: 'household_id,external_id', ignoreDuplicates: false })
+    if (upsertErr) {
+      console.error('[sabadell] upsert transactions:', upsertErr)
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+    upserted = txRows.length
+
+    // Refresca la matview de analítica (CONCURRENTLY) para que los gastos de
+    // tarjeta entren en las agregaciones sin esperar a la sync de Enable Banking.
+    const { error: refreshError } = await db.rpc('refresh_monthly_summary')
+    if (refreshError) console.error('[sabadell] refresh_monthly_summary:', refreshError)
+  }
+
+  return NextResponse.json({ cards: payload.cards.length, created_accounts: createdAccounts, upserted })
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "scrape:edenred:force": "EDENRED_SKIP_MARKER=1 pnpm scrape:edenred",
     "scrape:edenred:login": "node --env-file=.env.local scripts/edenred-login.mjs",
     "cron:edenred:status": "node scripts/edenred-status.mjs",
+    "scrape:sabadell": "node --env-file-if-exists=.env.local scripts/sabadell-scrape.mjs",
+    "scrape:sabadell:force": "SABADELL_SKIP_MARKER=1 pnpm scrape:sabadell",
+    "scrape:sabadell:login": "node --env-file-if-exists=.env.local scripts/sabadell-login.mjs",
+    "cron:sabadell:status": "node scripts/sabadell-status.mjs",
     "push:test": "node --env-file=.env.local scripts/send-test-push.mjs"
   },
   "dependencies": {

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ export async function proxy(request: NextRequest) {
   // Webhooks públicos con auth Bearer: saltar el chequeo de sesión.
   if (
     pathname.startsWith('/api/edenred') ||
+    pathname.startsWith('/api/sabadell') ||
     pathname === '/api/sync/enablebanking/cron'
   ) {
     return NextResponse.next({ request })

--- a/scripts/install-sabadell-launchd.sh
+++ b/scripts/install-sabadell-launchd.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Instala (o desinstala) el agente launchd que ejecuta el scraper de Sabadell
+# una vez al día. Define varios slots horarios para tolerar que el Mac esté
+# dormido en algunos: el primero que pille la máquina despierta ejecuta; los
+# siguientes salen no-op gracias al guard SABADELL_CRON=1 (marker diario en
+# ~/Library/Logs/fin-app), SIN abrir Chrome. RunAtLoad dispara un intento al
+# instalar/reiniciar.
+#
+# IMPORTANTE: el scraper corre HEADED (Sabadell bloquea Chrome headless vía WAF),
+# así que el agente abre una ventana de Chrome en la sesión gráfica del usuario.
+# Requisito previo (una vez): `pnpm scrape:sabadell:login` para enrolar el
+# dispositivo de confianza (login con OTP). Luego el cron entra solo (DNI+PIN).
+#
+# Uso:
+#   ./scripts/install-sabadell-launchd.sh             # instalar
+#   ./scripts/install-sabadell-launchd.sh --uninstall # desinstalar
+
+set -euo pipefail
+
+LABEL="com.fin-app.sabadell-scraper"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/fin-app"
+
+if [[ "${1:-}" == "--uninstall" ]]; then
+  if [[ -f "$PLIST" ]]; then
+    launchctl unload "$PLIST" 2>/dev/null || true
+    rm "$PLIST"
+    echo "Desinstalado: $PLIST"
+  else
+    echo "No estaba instalado."
+  fi
+  exit 0
+fi
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PNPM_BIN="$(command -v pnpm || true)"
+if [[ -z "$PNPM_BIN" ]]; then
+  echo "Error: pnpm no está en el PATH. Instálalo antes (https://pnpm.io/installation)." >&2
+  exit 1
+fi
+
+mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PNPM_BIN</string>
+    <string>scrape:sabadell</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$PROJECT_DIR</string>
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Hour</key><integer>16</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Hour</key><integer>19</integer><key>Minute</key><integer>30</integer></dict>
+    <dict><key>Hour</key><integer>22</integer><key>Minute</key><integer>30</integer></dict>
+  </array>
+  <!-- Intento inmediato al instalar/reiniciar. El guard del marker diario
+       (SABADELL_CRON=1) hace no-op si ya hubo un éxito hoy, sin abrir Chrome. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$LOG_DIR/sabadell-scraper.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG_DIR/sabadell-scraper.err.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>$(dirname "$PNPM_BIN"):/usr/local/bin:/usr/bin:/bin</string>
+    <key>SABADELL_CRON</key>
+    <string>1</string>
+  </dict>
+</dict>
+</plist>
+EOF
+
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+
+echo "Instalado: $PLIST"
+echo "Verificar: launchctl list | grep $LABEL"
+echo "Logs: $LOG_DIR/sabadell-scraper.{out,err}.log"
+echo "Estado: pnpm cron:sabadell:status"
+echo "Disparar manualmente: launchctl start $LABEL"
+echo "Desinstalar: $0 --uninstall"

--- a/scripts/lib/sabadell-config.mjs
+++ b/scripts/lib/sabadell-config.mjs
@@ -1,0 +1,53 @@
+// Configuración compartida entre sabadell-login.mjs y sabadell-scrape.mjs.
+// Mantener selectores, rutas y opciones de navegador en un único sitio evita
+// que el script de login y el de scraping se desincronicen.
+
+// Sesión Playwright de Sabadell. A diferencia de Edenred (storage-state suelto),
+// la banca online liga la sesión a un fingerprint de dispositivo, así que usamos
+// un PERFIL PERSISTENTE de Chrome (userDataDir): conserva cookies, localStorage e
+// indexedDB entre ejecuciones, que es lo que mantiene viva la sesión del banco.
+// El storage-state JSON se exporta sólo para validar/inspeccionar cookies.
+export const USER_DATA_DIR = 'scripts/.sabadell-userdata'
+export const LOCAL_STORAGE_PATH = 'scripts/sabadell-storage-state.json'
+export const LOCAL_STORAGE_BACKUP_PATH = 'scripts/sabadell-storage-state.json.bak'
+
+// URL de la página de login de BS Online particulares. Configurable por si
+// cambia. Se puede sobreescribir con SABADELL_LOGIN_URL en .env.local.
+export const SABADELL_LOGIN_URL =
+  process.env.SABADELL_LOGIN_URL || 'https://www.bancsabadell.com/bsnacional/es/particulares/login/'
+
+// Home logueado tras el login (sirve para detectar sesión válida y como punto
+// de partida para navegar a tarjetas).
+export const SABADELL_HOME_URL = 'https://www.bancsabadell.com/bsnacional/es/particulares/'
+
+// Selectores del formulario de login (DNI + PIN de 8 dígitos). El form visible lo
+// construye formconstructor.js dentro del web component <bs-login-classics>
+// (light DOM): campos #username y #password. OJO: existe además una plantilla
+// OCULTA con name="userDNI"/"pinDNI" (#input-placeholder) — NO usar esa.
+// Capturado en Fase 0 (#147). Si Sabadell cambia el front, revisar con el login.
+export const LOGIN_SELECTORS = {
+  user: '#username',
+  pass: '#password',
+  submit: '#login-button',
+  // Indicador de que aún se pide credencial (login no completado).
+  passwordVisible: '#password',
+  otp: 'input[name="otp"], input[autocomplete="one-time-code"], input[name*="sms" i], input[name*="codigo" i], input[id*="otp" i]',
+}
+
+// Anti-detección: la banca online detecta navegadores automatizados (el tell más
+// obvio es navigator.webdriver === true) y bloquea el login "por seguridad".
+// Lanzar el Chrome REAL del sistema (channel 'chrome', no el Chromium de
+// Playwright) + desactivar la bandera AutomationControlled + ocultar webdriver
+// elimina las señales más comunes sin recurrir todavía a playwright-extra/stealth
+// (decisión de #147: empezar sin stealth y escalar sólo si hay bloqueo).
+export const CHROME_CHANNEL = 'chrome'
+export const CHROME_ARGS = ['--disable-blink-features=AutomationControlled']
+export const STEALTH_INIT_SCRIPT =
+  "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"
+
+// Considera el state "sano" si tiene al menos una cookie del dominio Sabadell.
+export function isStorageStateValid(state) {
+  if (!state || typeof state !== 'object') return false
+  const cookies = Array.isArray(state.cookies) ? state.cookies : []
+  return cookies.some(c => typeof c?.domain === 'string' && c.domain.includes('sabadell'))
+}

--- a/scripts/lib/sabadell-parsers.mjs
+++ b/scripts/lib/sabadell-parsers.mjs
@@ -1,0 +1,33 @@
+// Parsers del scraper de Sabadell.
+//
+// A diferencia de Edenred (que muestra los importes/fechas sólo como texto en
+// español), las celdas de movimiento de Sabadell exponen el valor en formato
+// máquina dentro del atributo `abbr`:
+//   - fecha:   <td headers="fecha" abbr="2026-05-25"> 25/05 </td>   (ISO)
+//   - importe: <td headers="amount" abbr="156.20"> 156,20&nbsp;€ </td> (punto decimal)
+// Por eso el scraper lee `abbr` y estos parsers son finos, pero se mantienen
+// tolerantes por si Sabadell cambiara el front (fallback al texto en español).
+
+// "156.20" | "-156.20" | "1234.56" (formato `abbr`, punto decimal, sin miles) →
+// número. Fallback: texto español "1.234,56 €" → 1234.56.
+export function parseAmount(raw) {
+  if (raw == null) return NaN
+  let s = String(raw).replace(/&nbsp;/gi, ' ').replace(/[€\s]/g, '').trim()
+  if (s === '') return NaN
+  // Formato español (coma decimal): hay coma → los puntos son separador de miles.
+  if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(',', '.')
+  }
+  const n = Number(s)
+  return Number.isFinite(n) ? n : NaN
+}
+
+// "2026-05-25" (atributo `abbr`, ya ISO) → "2026-05-25". Valida el formato y lo
+// normaliza; devuelve null si no es una fecha ISO reconocible.
+export function parseDate(raw) {
+  if (raw == null) return null
+  const s = String(raw).trim()
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!m) return null
+  return `${m[1]}-${m[2]}-${m[3]}`
+}

--- a/scripts/lib/sabadell-parsers.test.mjs
+++ b/scripts/lib/sabadell-parsers.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { parseAmount, parseDate } from './sabadell-parsers.mjs'
+
+describe('parseAmount', () => {
+  it('parsea el valor máquina del atributo abbr (punto decimal)', () => {
+    expect(parseAmount('156.20')).toBe(156.2)
+  })
+
+  it('parsea importes negativos (abonos)', () => {
+    expect(parseAmount('-156.20')).toBe(-156.2)
+  })
+
+  it('parsea importes grandes sin separador de miles', () => {
+    expect(parseAmount('1234.56')).toBe(1234.56)
+  })
+
+  it('fallback: texto español con coma y separador de miles', () => {
+    expect(parseAmount('1.234,56 €')).toBe(1234.56)
+  })
+
+  it('fallback: texto español con &nbsp; y símbolo', () => {
+    expect(parseAmount('156,20&nbsp;€')).toBe(156.2)
+  })
+
+  it('parsea el cero', () => {
+    expect(parseAmount('0.00')).toBe(0)
+  })
+
+  it('devuelve NaN si no hay número', () => {
+    expect(parseAmount('abc')).toBeNaN()
+    expect(parseAmount('')).toBeNaN()
+    expect(parseAmount(null)).toBeNaN()
+  })
+})
+
+describe('parseDate', () => {
+  it('normaliza la fecha ISO del atributo abbr', () => {
+    expect(parseDate('2026-05-25')).toBe('2026-05-25')
+  })
+
+  it('ignora la parte horaria si la hubiera', () => {
+    expect(parseDate('2026-05-25T10:00:00')).toBe('2026-05-25')
+  })
+
+  it('devuelve null ante formato no ISO', () => {
+    expect(parseDate('25/05/2026')).toBeNull()
+    expect(parseDate('no es fecha')).toBeNull()
+    expect(parseDate(null)).toBeNull()
+  })
+})

--- a/scripts/sabadell-login.mjs
+++ b/scripts/sabadell-login.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Sabadell login — registro de dispositivo / regeneración de sesión.
+//
+// Uso:
+//   pnpm scrape:sabadell:login
+//
+// Requiere en .env.local: SABADELL_USER (DNI), SABADELL_PASS (PIN de 8 dígitos).
+//
+// Lanza el Chrome real del sistema (HEADED — Sabadell bloquea headless vía WAF)
+// con un perfil persistente y señales de automatización ocultas. Auto-rellena
+// DNI+PIN y envía. Después detecta si el banco PIDE OTP o entra directo (device
+// recordado). El usuario completa el OTP a mano si aparece. La sesión y el
+// "dispositivo de confianza" quedan en el perfil persistente. Cierra la ventana
+// para guardar.
+
+import { chromium } from 'playwright'
+import { existsSync, readFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+
+import {
+  USER_DATA_DIR,
+  LOCAL_STORAGE_PATH,
+  SABADELL_LOGIN_URL,
+  CHROME_CHANNEL,
+  CHROME_ARGS,
+  STEALTH_INIT_SCRIPT,
+  LOGIN_SELECTORS,
+  isStorageStateValid,
+} from './lib/sabadell-config.mjs'
+
+const SNAPSHOT_INTERVAL_MS = 4000
+
+function dumpStamp() {
+  const d = new Date()
+  const p = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+}
+
+function activePage(context) {
+  const pages = context.pages()
+  return pages[pages.length - 1]
+}
+
+async function tryAutofill(page) {
+  const user = process.env.SABADELL_USER
+  const pass = process.env.SABADELL_PASS
+  if (!user || !pass) {
+    console.log('[sabadell-login] sin SABADELL_USER/SABADELL_PASS: completa el login a mano.')
+    return
+  }
+  try {
+    await page.locator(LOGIN_SELECTORS.user).first().waitFor({ timeout: 8000 })
+    await page.locator(LOGIN_SELECTORS.user).first().fill(user)
+    await page.locator(LOGIN_SELECTORS.pass).first().fill(pass)
+    await page.locator(LOGIN_SELECTORS.pass).first().press('Enter')
+    console.log('[sabadell-login] DNI+PIN auto-rellenados y enviados.')
+  } catch (err) {
+    console.log(`[sabadell-login] auto-fill best-effort falló (${err.message}). Sigue a mano.`)
+    return
+  }
+  // Tras enviar, ¿pide OTP o entra directo? Diagnóstico para decidir el modelo
+  // de cron (device recordado vs OTP por login). No bloquea el guardado.
+  await page.waitForLoadState('networkidle', { timeout: 12000 }).catch(() => {})
+  const otpVisible = await page.locator(LOGIN_SELECTORS.otp).first().isVisible().catch(() => false)
+  const stillPwd = await page.locator(LOGIN_SELECTORS.pass).first().isVisible().catch(() => false)
+  if (otpVisible) {
+    console.log('[sabadell-login] >>> El banco PIDE OTP. Complétalo en la ventana. (cron desatendido NO viable)')
+  } else if (stillPwd) {
+    console.log('[sabadell-login] >>> Sigue en login (¿credenciales incorrectas o error?).')
+  } else {
+    console.log('[sabadell-login] >>> Entró SIN OTP (dispositivo recordado). cron headed automático viable.')
+  }
+}
+
+async function main() {
+  const context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    headless: false,
+    channel: CHROME_CHANNEL,
+    args: CHROME_ARGS,
+    viewport: null,
+  })
+  await context.addInitScript(STEALTH_INIT_SCRIPT)
+
+  const page = context.pages()[0] ?? (await context.newPage())
+  console.log(`[sabadell-login] abriendo ${SABADELL_LOGIN_URL} …`)
+  await page.goto(SABADELL_LOGIN_URL, { waitUntil: 'domcontentloaded' }).catch(() => {})
+
+  await tryAutofill(page)
+
+  console.log(
+    '\n→ Si pide OTP, complétalo en la ventana de Chrome.\n' +
+    '→ Cuando estés dentro de la cuenta, CIERRA la ventana para guardar la sesión.\n'
+  )
+
+  // Snapshots automáticos (investigación) + exporta sesión en cada tick.
+  let lastKey = ''
+  const tick = async () => {
+    try {
+      const pg = activePage(context)
+      if (!pg) return
+      const url = pg.url()
+      if (url.startsWith('about:') || url === 'chrome://newtab/') return
+      const html = await pg.content()
+      const key = `${url}|${html.length}`
+      if (key !== lastKey) {
+        lastKey = key
+        await writeFile(`scripts/.sabadell-dom-${dumpStamp()}.local.html`, html)
+        console.log(`[sabadell-login] snapshot (${url})`)
+      }
+      await context.storageState({ path: LOCAL_STORAGE_PATH, indexedDB: true })
+    } catch {}
+  }
+  const timer = setInterval(tick, SNAPSHOT_INTERVAL_MS)
+
+  await new Promise(resolve => context.on('close', resolve))
+  clearInterval(timer)
+
+  const saved = existsSync(LOCAL_STORAGE_PATH)
+    ? JSON.parse(readFileSync(LOCAL_STORAGE_PATH, 'utf-8'))
+    : null
+  if (!isStorageStateValid(saved)) {
+    console.error('[sabadell-login] aviso: el state guardado no tiene cookies de Sabadell. ¿Login incompleto?')
+    process.exit(2)
+  }
+  console.log(`[sabadell-login] [ok] sesión guardada: perfil=${USER_DATA_DIR}`)
+  process.exit(0)
+}
+
+main().catch(err => {
+  console.error('[sabadell-login] error:', err)
+  process.exit(1)
+})

--- a/scripts/sabadell-scrape.mjs
+++ b/scripts/sabadell-scrape.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+// Sabadell scraper — tarjetas de crédito (#147). Playwright HEADED (Sabadell
+// bloquea headless vía WAF Akamai) con Chrome real + perfil persistente enrolado
+// como dispositivo de confianza (sin OTP en logins posteriores).
+//
+// Uso:
+//   pnpm scrape:sabadell          (respeta el marker diario si SABADELL_CRON=1)
+//   pnpm scrape:sabadell:force    (SABADELL_SKIP_MARKER=1: ignora el marker)
+//
+// Flags de desarrollo:
+//   SABADELL_DRY_RUN=1   no hace POST; imprime el payload
+//   SABADELL_DEBUG=1     vuelca DOM en cada paso a ~/Library/Logs/fin-app
+//
+// Exit codes:
+//   0 éxito · 1 falta config · 2 sesión/OTP (re-enrolar con scrape:sabadell:login)
+//   3 error webhook · 4 error de scraping (navegación/selectores)
+
+import { chromium } from 'playwright'
+import { existsSync, readdirSync, unlinkSync, closeSync, openSync, writeFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+import {
+  USER_DATA_DIR, SABADELL_LOGIN_URL,
+  CHROME_CHANNEL, CHROME_ARGS, STEALTH_INIT_SCRIPT, LOGIN_SELECTORS,
+} from './lib/sabadell-config.mjs'
+import { parseAmount, parseDate } from './lib/sabadell-parsers.mjs'
+
+const CRON_MODE = process.env.SABADELL_CRON === '1'
+const DRY_RUN = process.env.SABADELL_DRY_RUN === '1'
+const DEBUG = process.env.SABADELL_DEBUG === '1'
+const LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
+const MARKER_PREFIX = 'sabadell-last-success.'
+const NOTIFY_PREFIX = 'sabadell-notified.'
+const FAILURE_PREFIX = 'sabadell-failure-'
+const FAILURE_KEEP = 5
+
+// Las 2 tarjetas de crédito a sincronizar, por sus últimos 4 dígitos (#147).
+// Configurable por si cambian. Las de débito (5402…) se ignoran.
+const TARGET_CARD_LAST4 = (process.env.SABADELL_CARDS || '4014,5011').split(',').map(s => s.trim())
+
+function stamp() {
+  const d = new Date()
+  const p = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+}
+function markerPath() { return join(LOG_DIR, `${MARKER_PREFIX}${new Date().toISOString().slice(0, 10)}`) }
+function notifyPath() { return join(LOG_DIR, `${NOTIFY_PREFIX}${new Date().toISOString().slice(0, 10)}`) }
+function writeMarker() {
+  mkdirSync(LOG_DIR, { recursive: true })
+  closeSync(openSync(markerPath(), 'a'))
+  for (const name of readdirSync(LOG_DIR)) {
+    const staleSuccess = name.startsWith(MARKER_PREFIX) && join(LOG_DIR, name) !== markerPath()
+    if (staleSuccess || name.startsWith(NOTIFY_PREFIX)) {
+      try { unlinkSync(join(LOG_DIR, name)) } catch {}
+    }
+  }
+}
+function notifySessionExpired() {
+  try {
+    if (existsSync(notifyPath())) return
+    execFileSync('osascript', ['-e',
+      `display notification ${JSON.stringify('Ejecuta pnpm scrape:sabadell:login para re-enrolar el dispositivo.')} with title ${JSON.stringify('Sabadell: sesión caducada')}`,
+    ])
+    mkdirSync(LOG_DIR, { recursive: true })
+    closeSync(openSync(notifyPath(), 'a'))
+  } catch {}
+}
+function rotateFailures() {
+  try {
+    for (const ext of ['.png', '.html']) {
+      const files = readdirSync(LOG_DIR).filter(n => n.startsWith(FAILURE_PREFIX) && n.endsWith(ext)).sort()
+      for (const name of files.slice(0, -FAILURE_KEEP)) { try { unlinkSync(join(LOG_DIR, name)) } catch {} }
+    }
+  } catch {}
+}
+async function dump(page, tag) {
+  try {
+    mkdirSync(LOG_DIR, { recursive: true })
+    const base = join(LOG_DIR, `${FAILURE_PREFIX}${stamp()}-${tag}`)
+    await page.screenshot({ fullPage: true, path: `${base}.png` })
+    writeFileSync(`${base}.html`, await page.content())
+    console.error(`[sabadell-scrape] dump: ${base}.{png,html}`)
+    rotateFailures()
+  } catch {}
+}
+function die(code, msg) {
+  console.error(`[sabadell-scrape] ${msg}`)
+  if (code === 2 && CRON_MODE) notifySessionExpired()
+  process.exit(code)
+}
+function requireEnv(name) {
+  const v = process.env[name]
+  if (!v) die(1, `Falta env var: ${name}`)
+  return v
+}
+
+async function acceptCookies(page) {
+  // El banner OneTrust tapa el formulario de login (campo DNI queda "hidden").
+  const btn = page.locator('#onetrust-accept-btn-handler')
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click().catch(() => {})
+    await page.waitForTimeout(500)
+  }
+}
+
+async function login(page) {
+  const user = requireEnv('SABADELL_USER')
+  const pass = requireEnv('SABADELL_PASS')
+
+  await page.goto(SABADELL_LOGIN_URL, { waitUntil: 'domcontentloaded' })
+  await acceptCookies(page)
+
+  const userInput = page.locator(LOGIN_SELECTORS.user).first()
+  try {
+    await userInput.waitFor({ state: 'visible', timeout: 15000 })
+  } catch {
+    await dump(page, 'login-no-field')
+    die(4, 'No apareció el campo de DNI en el login (¿cambió el front o el banner de cookies?)')
+  }
+  await userInput.fill(user)
+  await page.locator(LOGIN_SELECTORS.pass).first().fill(pass)
+  await page.locator(LOGIN_SELECTORS.submit).first().click()
+  await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {})
+
+  if (await page.locator(LOGIN_SELECTORS.otp).first().isVisible().catch(() => false)) {
+    await dump(page, 'login-otp')
+    die(2, 'Sabadell pide OTP: el dispositivo no está enrolado. Ejecuta pnpm scrape:sabadell:login')
+  }
+  if (await page.locator(LOGIN_SELECTORS.pass).first().isVisible().catch(() => false)) {
+    await dump(page, 'login-failed')
+    die(2, 'Login no completado (¿credenciales incorrectas?)')
+  }
+  if (DEBUG) await dump(page, 'after-login')
+}
+
+// Navega a la lista de tarjetas (#cardAccountTable) clicando el enlace del menú
+// que apunta a TJMovementsQueryDebt.init.bs (deep-link directo bloqueado por WAF).
+// Funciona tanto desde la posición global (tras login) como desde la página de
+// movimientos de una tarjeta (ambas tienen ese enlace en el menú).
+async function gotoCardsList(page) {
+  // Reintentos: la navegación de vuelta (tras ver una tarjeta) es sensible a
+  // timing en este webflow legacy; clicar el enlace y esperar la tabla puede
+  // necesitar un segundo intento.
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const link = page.locator('a[href*="TJMovementsQueryDebt.init.bs"]').first()
+    if (!(await link.count().catch(() => 0))) {
+      await page.waitForTimeout(1000)
+      continue
+    }
+    await link.click().catch(() => {})
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+    try {
+      await page.locator('#cardAccountTable').first().waitFor({ state: 'attached', timeout: 12000 })
+      if (DEBUG) await dump(page, 'cards-list')
+      return
+    } catch {
+      await page.waitForTimeout(1500)
+    }
+  }
+  await dump(page, 'no-cards-table')
+  die(4, 'No se encontró la tabla de tarjetas (#cardAccountTable)')
+}
+
+// Selecciona la tarjeta cuyo número contiene `last4` y abre sus movimientos.
+async function openCardMovements(page, last4) {
+  // La fila de la tarjeta en #cardAccountTable muestra el número enmascarado.
+  const row = page.locator(`#cardAccountTable tr`, { hasText: last4 }).first()
+  if (!(await row.isVisible().catch(() => false))) {
+    await dump(page, `card-${last4}-no-row`)
+    die(4, `No se encontró la fila de la tarjeta …${last4} en la lista`)
+  }
+  await row.click().catch(() => {})
+  // Botón de consulta de movimientos.
+  const submit = page.locator('input[name="aceptar"], input[value="Aceptar"]').first()
+  if (await submit.isVisible().catch(() => false)) {
+    await submit.click().catch(() => {})
+  }
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+  // Espera a que cargue la página de movimientos (input oculto card.number).
+  try {
+    await page.locator('input[name="card.number"]').first().waitFor({ state: 'attached', timeout: 15000 })
+  } catch {
+    await dump(page, `card-${last4}-no-movements`)
+    die(4, `No cargaron los movimientos de la tarjeta …${last4}`)
+  }
+  if (DEBUG) await dump(page, `card-${last4}-movements`)
+}
+
+// Extrae number, saldo y movimientos confirmados de la página de movimientos.
+async function extractCard(page) {
+  const data = await page.evaluate(() => {
+    const clean = s => (s || '').replace(/ /g, ' ').replace(/\s+/g, ' ').trim()
+    const cardNumber = document.querySelector('input[name="card.number"]')?.value || ''
+    const movements = []
+    // Confirmados: celda de fecha headers="fecha" (los pendientes usan "fechaNC").
+    document.querySelectorAll('td[headers="fecha"][abbr]').forEach(dateTd => {
+      const tr = dateTd.closest('tr'); if (!tr) return
+      const purposeTd = tr.querySelector('td[headers="purpose"]')
+      const description = clean(purposeTd?.getAttribute('alt') || purposeTd?.textContent)
+      const town = clean(tr.querySelector('td[headers="town"]')?.textContent)
+      const ref = clean(tr.querySelector('.bso-unique-movement-reference')?.textContent)
+      const amountAbbr = tr.querySelector('td[headers="amount"][abbr]')?.getAttribute('abbr') || ''
+      movements.push({ date: dateTd.getAttribute('abbr'), description, town, ref, amountAbbr })
+    })
+    return { cardNumber, movements, bodyText: clean(document.body.innerText) }
+  })
+
+  // Deuda (saldo de la cuenta de tarjeta, pasivo → negativo).
+  const debtMatch = data.bodyText.match(/IMPORTE TOTAL A LIQUIDAR:?\s*([\d.,]+)\s*€/i)
+  const debt = debtMatch ? parseAmount(debtMatch[1]) : 0
+  const balance = Number.isFinite(debt) ? -Math.abs(debt) : 0
+
+  const transactions = []
+  for (const m of data.movements) {
+    const date = parseDate(m.date)
+    const amountAbs = parseAmount(m.amountAbbr)
+    if (!date || !Number.isFinite(amountAbs)) continue
+    // Compras → gasto (negativo); abonos vienen con abbr negativo → positivo.
+    const amount = -amountAbs
+    const external_id = m.ref ? `sabadell-${m.ref}` : `sabadell-${data.cardNumber}-${date}-${amountAbs}-${m.description}`
+    // Añade la población sólo si parece un lugar real (tiene letras): el campo
+    // "town" a veces trae un teléfono (p.ej. APPLE.COM/BILL → 900812703).
+    const description = m.town && /[a-zA-Z]/.test(m.town) ? `${m.description} (${m.town})` : m.description
+    transactions.push({ external_id, amount, description, transaction_date: date })
+  }
+  return { cardNumber: data.cardNumber, balance, transactions }
+}
+
+async function postToWebhook(cards) {
+  const appUrl = requireEnv('APP_URL').replace(/\/$/, '')
+  const secret = requireEnv('SABADELL_WEBHOOK_SECRET')
+  const body = JSON.stringify({ last_synced_at: new Date().toISOString(), cards })
+  const res = await fetch(`${appUrl}/api/sabadell`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${secret}` },
+    body,
+  })
+  if (res.status !== 200) {
+    const text = await res.text().catch(() => '')
+    die(3, `Webhook respondió ${res.status}: ${text}`)
+  }
+  return res.json()
+}
+
+async function main() {
+  if (CRON_MODE && !process.env.SABADELL_SKIP_MARKER && existsSync(markerPath())) {
+    console.log('[sabadell-scrape] skip: ya hubo ejecución correcta hoy')
+    return
+  }
+  if (!existsSync(USER_DATA_DIR)) {
+    die(1, 'No hay perfil. Ejecuta: pnpm scrape:sabadell:login')
+  }
+
+  const context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    headless: false,
+    channel: CHROME_CHANNEL,
+    args: CHROME_ARGS,
+    viewport: null,
+  })
+  await context.addInitScript(STEALTH_INIT_SCRIPT)
+  try {
+    const page = context.pages()[0] ?? (await context.newPage())
+
+    await login(page)
+
+    const cards = []
+    for (const last4 of TARGET_CARD_LAST4) {
+      await gotoCardsList(page)
+      await openCardMovements(page, last4)
+      const card = await extractCard(page)
+      const cardLast4 = card.cardNumber.slice(-4)
+      cards.push({
+        card_id: card.cardNumber,
+        name: `Sabadell •••• ${cardLast4}`,
+        number: card.cardNumber,
+        balance: card.balance,
+        transactions: card.transactions,
+      })
+      console.log(`[sabadell-scrape] tarjeta …${cardLast4}: saldo=${card.balance} EUR, movs=${card.transactions.length}`)
+    }
+
+    if (DRY_RUN) {
+      console.log('[sabadell-scrape] DRY_RUN — payload:')
+      console.log(JSON.stringify({ last_synced_at: new Date().toISOString(), cards }, null, 2))
+      return
+    }
+
+    const result = await postToWebhook(cards)
+    console.log(`[sabadell-scrape] OK: ${JSON.stringify(result)}`)
+    if (CRON_MODE) writeMarker()
+  } finally {
+    await context.close()
+  }
+}
+
+main().catch(err => {
+  console.error('[sabadell-scrape] error inesperado:', err)
+  process.exit(4)
+})

--- a/scripts/sabadell-status.mjs
+++ b/scripts/sabadell-status.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Estado del cron de Sabadell — resumen del último éxito, últimos logs y
+// estado del agente launchd. Uso: pnpm cron:sabadell:status
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+const LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
+const OUT_LOG = join(LOG_DIR, 'sabadell-scraper.out.log')
+const ERR_LOG = join(LOG_DIR, 'sabadell-scraper.err.log')
+const MARKER_PREFIX = 'sabadell-last-success.'
+const FAILURE_PREFIX = 'sabadell-failure-'
+const AGENT_LABEL = 'com.fin-app.sabadell-scraper'
+
+const fmtDate = (d) =>
+  d.toLocaleString('es-ES', { dateStyle: 'short', timeStyle: 'medium' })
+
+const ageSince = (d) => {
+  const ms = Date.now() - d.getTime()
+  const m = Math.floor(ms / 60000)
+  if (m < 60) return `hace ${m} min`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `hace ${h} h ${m % 60} min`
+  return `hace ${Math.floor(h / 24)} d ${h % 24} h`
+}
+
+function lastMarker() {
+  if (!existsSync(LOG_DIR)) return null
+  const markers = readdirSync(LOG_DIR)
+    .filter((n) => n.startsWith(MARKER_PREFIX))
+    .sort()
+  if (markers.length === 0) return null
+  const name = markers[markers.length - 1]
+  return { date: name.slice(MARKER_PREFIX.length), mtime: statSync(join(LOG_DIR, name)).mtime }
+}
+
+function lastFailureDump() {
+  if (!existsSync(LOG_DIR)) return null
+  const dumps = readdirSync(LOG_DIR)
+    .filter((n) => n.startsWith(FAILURE_PREFIX) && n.endsWith('.png'))
+    .sort()
+  if (dumps.length === 0) return null
+  const name = dumps[dumps.length - 1]
+  return { name, mtime: statSync(join(LOG_DIR, name)).mtime }
+}
+
+function logSummary(path) {
+  if (!existsSync(path)) return { exists: false }
+  const s = statSync(path)
+  const tail = readFileSync(path, 'utf8').trimEnd().split('\n').slice(-8)
+  return { exists: true, size: s.size, mtime: s.mtime, tail }
+}
+
+function launchctlInfo() {
+  try {
+    const out = execFileSync('launchctl', ['list', AGENT_LABEL], { encoding: 'utf8' })
+    const pickInt = (re) => {
+      const m = out.match(re)
+      return m ? Number.parseInt(m[1], 10) : null
+    }
+    return {
+      loaded: true,
+      pid: pickInt(/"PID"\s*=\s*(\d+);/),
+      lastExitStatus: pickInt(/"LastExitStatus"\s*=\s*(-?\d+);/),
+    }
+  } catch {
+    return { loaded: false }
+  }
+}
+
+console.log(`Cron Sabadell — ${AGENT_LABEL}\n`)
+
+const agent = launchctlInfo()
+if (!agent.loaded) {
+  console.log('Agente: NO cargado en launchd')
+} else {
+  console.log(
+    `Agente: cargado` +
+      (agent.pid ? ` (corriendo, pid=${agent.pid})` : '') +
+      (agent.lastExitStatus != null ? ` · último exit=${agent.lastExitStatus}` : ''),
+  )
+}
+
+const marker = lastMarker()
+console.log(
+  !marker
+    ? '\nÚltimo éxito: (sin marker)'
+    : `\nÚltimo éxito: ${marker.date} · ${fmtDate(marker.mtime)} (${ageSince(marker.mtime)})`,
+)
+
+const out = logSummary(OUT_LOG)
+console.log(`\nstdout (${OUT_LOG})`)
+if (!out.exists) {
+  console.log('  (no existe)')
+} else {
+  console.log(`  ${fmtDate(out.mtime)} · ${out.size} B`)
+  for (const line of out.tail) console.log(`  | ${line}`)
+}
+
+const err = logSummary(ERR_LOG)
+console.log(`\nstderr (${ERR_LOG})`)
+if (!err.exists) {
+  console.log('  (no existe)')
+} else if (err.size === 0) {
+  console.log(`  ${fmtDate(err.mtime)} · vacío`)
+} else {
+  console.log(`  ${fmtDate(err.mtime)} · ${err.size} B`)
+  for (const line of err.tail) console.log(`  | ${line}`)
+}
+
+const dump = lastFailureDump()
+console.log(
+  !dump
+    ? '\nÚltimo dump de fallo: (ninguno)'
+    : `\nÚltimo dump de fallo: ${join(LOG_DIR, dump.name)} · ${fmtDate(dump.mtime)} (${ageSince(dump.mtime)})`,
+)


### PR DESCRIPTION
Cierra #147.

Scraper local de las **2 tarjetas de crédito de Banco Sabadell** (no disponibles vía PSD2/Enable Banking), siguiendo el patrón de Edenred: Playwright local → webhook autenticado → upsert idempotente en Supabase, disparado por launchd.

## Decisiones clave (descubiertas en investigación en vivo)
- **Headed obligatorio**: Sabadell bloquea Chrome headless vía WAF (Akamai) y también el deep-linking a URLs `.bs`. Se corre con Chrome real (`channel: 'chrome'`) + flags anti-automatización + perfil persistente; se navega clicando.
- **Sin OTP en el cron**: Sabadell permite registrar **dispositivo de confianza** (PSD2) → tras el enrolado inicial, los logins son solo DNI+PIN (sin OTP). Eso habilita el cron headed automático.
- **Auto-categorización por reglas** de BD (igual que Enable Banking), no categoría fija.

## Qué incluye
- **`app/api/sabadell/route.ts`** — webhook Bearer, payload multi-tarjeta `{ cards: [...] }`, una cuenta `type='card'`/`is_liability=true` por tarjeta (identidad por `external_id` = PAN enmascarado), auto-categorización, upsert por `(household_id, external_id)` con `ignoreDuplicates:false` (preserva `is_read`), refresco de la matview. Tests unitarios.
- **`scripts/sabadell-scrape.mjs`** — login auto (acepta OneTrust, DNI+PIN), itera ambas tarjetas, extrae movimientos confirmados (fecha `abbr` ISO, **referencia única BS** como `external_id`, importe `abbr`, población) y saldo dispuesto (deuda → balance negativo). Exit codes, marker diario, notificación de sesión caducada, volcados de diagnóstico. Flags `SABADELL_DRY_RUN` / `SABADELL_DEBUG`.
- **`scripts/sabadell-login.mjs`** — enrolado del dispositivo (headed, OTP a mano una vez).
- **`scripts/lib/sabadell-config.mjs`**, **`sabadell-parsers.mjs`** (+tests) — selectores documentados y parsers.
- **`scripts/install-sabadell-launchd.sh`** + **`sabadell-status.mjs`** — cron y diagnóstico.
- **`proxy.ts`** — `/api/sabadell` exento del gate de sesión.
- **`.env.example`** / scripts npm (`scrape:sabadell[:force|:login]`, `cron:sabadell:status`).

## Modelo de datos
Sin migración: el esquema ya soporta `card`/`is_liability`/`source='scraper'` con `external_id` por cuenta y dedup `(household_id, external_id)`.

## Validación
- `pnpm test` (270 ✓, incluye parsers + webhook), `pnpm lint`, `pnpm build` en verde.
- **Probado en vivo end-to-end**: `OK: {"cards":2,"created_accounts":2,"upserted":2}` — las 2 cuentas y sus movimientos creados en Supabase, categorizados (Zara→ropa, Apple→suscripciones) y como no leídos.

## Notas operativas
- Setup inicial (una vez): `pnpm scrape:sabadell:login` para enrolar el dispositivo de confianza.
- El cron abre una ventana de Chrome (headed) sólo en el primer slot del día (el marker diario hace no-op el resto sin abrir Chrome).
- Selectores documentados en el código; el scraper se romperá si Sabadell cambia el front (riesgo conocido).

🤖 Generated with [Claude Code](https://claude.com/claude-code)