### PR TITLE
feat(accounts): icono por tipo de cuenta en los badges

### DIFF
--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -48,7 +48,7 @@ async function TransactionsContent({
       .limit(INITIAL_PAGE_SIZE),
     supabase
       .from('accounts')
-      .select('id, name, color, number')
+      .select('id, name, color, number, type')
       .eq('is_active', true)
       .order('created_at', { ascending: true }),
     supabase

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
 import { fmt } from '@/lib/formatting'
 import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
+import { AccountIconBadge } from './AccountIconBadge'
 import { SyncButton } from './SyncButton'
 import { RenewBankButton } from './RenewBankButton'
 import type { Account } from '@/types'
@@ -66,7 +67,6 @@ function ConsentBadge({ consent }: { consent: ConsentInfo }) {
 }
 
 export function AccountCard({ account }: { account: Account }) {
-  const color = account.color ?? '#6366f1'
   const isNegative = (account.balance ?? 0) < 0
   const { label: syncLabel, color: syncColor, Icon: SyncIcon } = getSyncStatus(account.last_synced)
   const consent =
@@ -78,12 +78,7 @@ export function AccountCard({ account }: { account: Account }) {
     <div className="bg-card rounded-[20px] p-5 border border-border">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div
-            className="size-11 rounded-[14px] flex items-center justify-center"
-            style={{ background: color + '22' }}
-          >
-            <div className="size-4.5 rounded-[5px]" style={{ background: color }} />
-          </div>
+          <AccountIconBadge type={account.type} color={account.color} size="lg" />
           <div>
             <div className="text-[15px] font-bold text-foreground leading-tight">
               {account.name}

--- a/components/accounts/AccountIconBadge.tsx
+++ b/components/accounts/AccountIconBadge.tsx
@@ -1,0 +1,40 @@
+import { accountTypeIcon } from '@/lib/accounts'
+import type { Account } from '@/types'
+
+/**
+ * Presets de tamaño del badge (contenedor / radio / icono, en px).
+ * - `lg`: pantalla Cuentas (AccountCard)
+ * - `md`: filtro de cuentas en Movimientos
+ * - `sm`: rejilla del dashboard
+ */
+const SIZES = {
+  sm: { box: 32, radius: 10, icon: 16 },
+  md: { box: 34, radius: 10, icon: 17 },
+  lg: { box: 44, radius: 14, icon: 22 },
+} as const
+
+interface AccountIconBadgeProps {
+  type: Account['type']
+  color?: string | null
+  size?: keyof typeof SIZES
+  className?: string
+}
+
+/**
+ * Badge cuadrado redondeado con el icono del tipo de cuenta, teñido con el color
+ * de la cuenta sobre un fondo translúcido del mismo color. Fuente única de verdad
+ * para el icono de cuenta en dashboard, pantalla Cuentas y filtro de Movimientos.
+ */
+export function AccountIconBadge({ type, color, size = 'md', className }: AccountIconBadgeProps) {
+  const c = color ?? '#6366f1'
+  const Icon = accountTypeIcon[type]
+  const s = SIZES[size]
+  return (
+    <div
+      className={`flex items-center justify-center shrink-0 ${className ?? ''}`}
+      style={{ width: s.box, height: s.box, borderRadius: s.radius, background: c + '22' }}
+    >
+      <Icon size={s.icon} style={{ color: c }} strokeWidth={2} />
+    </div>
+  )
+}

--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { fmt } from '@/lib/formatting'
+import { AccountIconBadge } from '@/components/accounts/AccountIconBadge'
 import type { Account, AccountType } from '@/types'
 
 const typeLabel: Record<AccountType, string> = {
@@ -10,7 +11,6 @@ const typeLabel: Record<AccountType, string> = {
 }
 
 function AccountMiniCard({ account }: { account: Account }) {
-  const color = account.color ?? '#6366f1'
   const balance = account.balance ?? 0
   const isNegative = balance < 0
 
@@ -20,12 +20,7 @@ function AccountMiniCard({ account }: { account: Account }) {
       className="block bg-card rounded-2xl p-3.5 border border-border active:opacity-70 transition-opacity"
     >
       <div className="flex items-center justify-between mb-2.5">
-        <div
-          className="size-8 rounded-[10px] flex items-center justify-center"
-          style={{ background: color + '22' }}
-        >
-          <div className="size-3 rounded-[3px]" style={{ background: color }} />
-        </div>
+        <AccountIconBadge type={account.type} color={account.color} size="sm" />
         <span className="text-[9px] font-bold text-muted-foreground uppercase tracking-wide">
           {typeLabel[account.type]}
         </span>

--- a/components/transactions/AccountFilter.tsx
+++ b/components/transactions/AccountFilter.tsx
@@ -2,12 +2,13 @@
 
 import { Box } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { AccountIconBadge } from '@/components/accounts/AccountIconBadge'
 import type { Account } from '@/types'
 
 interface AccountFilterProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
+  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number' | 'type'>[]
   selectedIds: string[]
   onSelectionChange: (ids: string[]) => void
 }
@@ -69,7 +70,6 @@ export function AccountFilter({ open, onOpenChange, accounts, selectedIds, onSel
           {/* Account list */}
           {accounts.map(account => {
             const isSelected = selectedIds.includes(account.id)
-            const color = account.color ?? '#6366f1'
             const maskedNumber = account.number ? `•••• ${account.number.slice(-4)}` : null
 
             return (
@@ -82,12 +82,7 @@ export function AccountFilter({ open, onOpenChange, accounts, selectedIds, onSel
                 }}
                 onClick={() => toggleAccount(account.id)}
               >
-                <div
-                  className="flex items-center justify-center rounded-[10px] shrink-0"
-                  style={{ width: 34, height: 34, background: color + '22' }}
-                >
-                  <div className="rounded" style={{ width: 14, height: 14, background: color }} />
-                </div>
+                <AccountIconBadge type={account.type} color={account.color} size="md" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-foreground truncate">{account.name}</p>
                   {maskedNumber && (

--- a/components/transactions/TransactionsClient.tsx
+++ b/components/transactions/TransactionsClient.tsx
@@ -19,7 +19,7 @@ import type { Account, TransactionWithAccount } from '@/types'
 interface TransactionsClientProps {
   initialTransactions: TransactionWithAccount[]
   initialCursor: TransactionCursor | null
-  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number'>[]
+  accounts: Pick<Account, 'id' | 'name' | 'color' | 'number' | 'type'>[]
   manualAccountId: string
   initialAccountIds?: string[]
 }

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,4 +1,18 @@
-import type { Account } from '@/types'
+import { Landmark, CreditCard, UtensilsCrossed, Banknote } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import type { Account, AccountType } from '@/types'
+
+/**
+ * Icono Lucide que representa cada tipo de cuenta en los badges de la UI.
+ * `Banknote` (no `Wallet`) para `cash`, ya que `Wallet` identifica la sección
+ * "Cuentas" en la barra de navegación.
+ */
+export const accountTypeIcon: Record<AccountType, LucideIcon> = {
+  bank:    Landmark,
+  card:    CreditCard,
+  edenred: UtensilsCrossed,
+  cash:    Banknote,
+}
 
 /**
  * Estado de caducidad del consentimiento PSD2 de una cuenta (spec §9.2).


### PR DESCRIPTION
## Contexto

El "icono" que acompañaba a cada cuenta no era un icono real: era un cuadradito de color sólido (`account.color`) sobre un fondo translúcido del mismo color, idéntico en todos los tipos de cuenta. No había diferenciación visual entre banco, tarjeta, efectivo o Edenred.

## Cambios

- **Icono Lucide por `account.type`** mediante el nuevo mapa `accountTypeIcon` en `lib/accounts.ts`:
  - `bank` → Landmark · `card` → CreditCard · `edenred` → UtensilsCrossed · `cash` → Banknote
  - (`Banknote` para `cash` en vez de `Wallet`, que ya identifica la sección "Cuentas" en la barra de navegación)
- **Componente compartido `AccountIconBadge`** (`components/accounts/AccountIconBadge.tsx`) que centraliza la estructura del badge (contenedor redondeado + fondo translúcido + icono teñido) con presets de tamaño `sm`/`md`/`lg`. Evita replicar el markup en los tres sitios.
- Aplicado en los **tres** lugares donde aparece el badge:
  - Pantalla **Cuentas** — `AccountCard.tsx` (`lg`)
  - **Dashboard** — `DashboardAccountGrid.tsx` (`sm`)
  - Filtro de cuentas de **Movimientos** — `AccountFilter.tsx` (`md`)
- Propagado el campo `type` al selector de Movimientos (antes no se cargaba): `select` en `transactions/page.tsx` y tipos `Pick<Account, …>` en `TransactionsClient` y `AccountFilter`.

Los presets en px reproducen exactamente los tamaños previos (44/34/32 px), así que el único cambio visual es el icono. La opción "Todas las cuentas" del filtro conserva su icono genérico `Box`.

Sin cambios en base de datos, RLS ni agregaciones — es puramente UI.

## Validación

- ✅ `pnpm test` (270/270)
- ✅ `pnpm lint`
- ✅ `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)