### PR TITLE
feat(accounts): cards a ancho completo en la pantalla de Cuentas

### DIFF
--- a/app/(app)/accounts/page.tsx
+++ b/app/(app)/accounts/page.tsx
@@ -104,9 +104,9 @@ async function AccountsContent({
         </div>
       ) : (
         // Lista a ancho completo: -mx-4 cancela el padding lateral del wrapper para
-        // que las filas lleguen a los bordes; divide-y + border-y dan solo líneas
-        // horizontales (sin laterales ni esquinas redondeadas).
-        <div className="-mx-4 flex flex-col border-y border-border divide-y divide-border">
+        // que las filas lleguen a los bordes. Cada card lleva su border-y (solo
+        // líneas arriba/abajo, sin laterales ni esquinas) y el gap las separa.
+        <div className="-mx-4 flex flex-col gap-3">
           {(accounts ?? []).map((account: Account) => (
             <AccountCard key={account.id} account={account} />
           ))}

--- a/app/(app)/accounts/page.tsx
+++ b/app/(app)/accounts/page.tsx
@@ -103,9 +103,14 @@ async function AccountsContent({
           </div>
         </div>
       ) : (
-        (accounts ?? []).map((account: Account) => (
-          <AccountCard key={account.id} account={account} />
-        ))
+        // Lista a ancho completo: -mx-4 cancela el padding lateral del wrapper para
+        // que las filas lleguen a los bordes; divide-y + border-y dan solo líneas
+        // horizontales (sin laterales ni esquinas redondeadas).
+        <div className="-mx-4 flex flex-col border-y border-border divide-y divide-border">
+          {(accounts ?? []).map((account: Account) => (
+            <AccountCard key={account.id} account={account} />
+          ))}
+        </div>
       )}
 
       <ConnectBankButton />

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -75,7 +75,7 @@ export function AccountCard({ account }: { account: Account }) {
   const needsRenew = consent?.status === 'critical' || consent?.status === 'expired'
 
   return (
-    <div className="bg-card px-4 py-5">
+    <div className="bg-card px-4 py-5 border-y border-border">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <AccountIconBadge type={account.type} color={account.color} size="lg" />

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -75,7 +75,7 @@ export function AccountCard({ account }: { account: Account }) {
   const needsRenew = consent?.status === 'critical' || consent?.status === 'expired'
 
   return (
-    <div className="bg-card rounded-[20px] p-5 border border-border">
+    <div className="bg-card px-4 py-5">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
           <AccountIconBadge type={account.type} color={account.color} size="lg" />

--- a/components/accounts/AccountsSkeleton.tsx
+++ b/components/accounts/AccountsSkeleton.tsx
@@ -6,9 +6,9 @@ export function AccountsSkeleton() {
       {/* Título */}
       <Skeleton className="mb-2 h-7 w-28" />
       {/* Filas de cuenta a ancho completo (coincide con la lista real) */}
-      <div className="-mx-4 flex flex-col border-y border-border divide-y divide-border">
+      <div className="-mx-4 flex flex-col gap-3">
         {[0, 1, 2].map(i => (
-          <Skeleton key={i} className="h-47.5 rounded-none" />
+          <Skeleton key={i} className="h-47.5 rounded-none border-y border-border" />
         ))}
       </div>
       {/* Botón conectar banco */}

--- a/components/accounts/AccountsSkeleton.tsx
+++ b/components/accounts/AccountsSkeleton.tsx
@@ -5,10 +5,12 @@ export function AccountsSkeleton() {
     <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       {/* Título */}
       <Skeleton className="mb-2 h-7 w-28" />
-      {/* Tarjetas de cuenta */}
-      {[0, 1, 2].map(i => (
-        <Skeleton key={i} className="h-47.5 rounded-[20px]" />
-      ))}
+      {/* Filas de cuenta a ancho completo (coincide con la lista real) */}
+      <div className="-mx-4 flex flex-col border-y border-border divide-y divide-border">
+        {[0, 1, 2].map(i => (
+          <Skeleton key={i} className="h-47.5 rounded-none" />
+        ))}
+      </div>
       {/* Botón conectar banco */}
       <Skeleton className="h-12 rounded-2xl" />
     </div>


### PR DESCRIPTION
Closes #160

## Qué incluye

Rediseño de las cards de la pantalla de **Cuentas** para aprovechar el ancho en móvil:

- `AccountCard`: el root pasa de `bg-card rounded-[20px] p-5 border border-border` a `bg-card px-4 py-5` (sin redondeo ni bordes propios; conserva un único padding horizontal interno para que el texto no quede pegado al borde).
- Lista en `accounts/page.tsx`: las filas se sacan a ancho completo con `-mx-4` (cancela el padding lateral del wrapper) dentro de un contenedor `border-y border-border divide-y divide-border` → solo líneas horizontales, sin laterales ni esquinas. El heading, banners y el botón de conectar conservan su margen.
- `AccountsSkeleton` adaptado al nuevo estilo (filas full-width con divisores) para que el loading no salte.

> Nota: en vez de quitar `px-4` del wrapper y re-añadirlo a cada hijo (como planteaba el plan), se usa `-mx-4` solo en la lista — mismo resultado con menos churn. Alcance: **solo Cuentas** por ahora.

## Validación
- `pnpm test` ✅ · `pnpm lint` ✅ · `pnpm build` ✅
- Pendiente: revisión visual con `pnpm build && pnpm start` en viewport móvil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)