### PR TITLE
feat(transactions): cards a ancho completo en Movimientos (#165)

### DIFF
--- a/components/transactions/TransactionsList.tsx
+++ b/components/transactions/TransactionsList.tsx
@@ -70,16 +70,16 @@ export function TransactionsList({
   const isEmpty = groups.length === 0 && pinnedUnread.length === 0
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="-mx-4 flex flex-col gap-4">
       {pinnedUnread.length > 0 && (
         <div className="flex flex-col gap-0.5">
-          <div className="flex items-center justify-between px-3 pb-1">
+          <div className="flex items-center justify-between px-4 pb-1">
             <span className="text-xs font-bold uppercase tracking-wide text-primary">
               No leídos
             </span>
             <span className="text-xs font-bold text-primary">{pinnedUnread.length}</span>
           </div>
-          <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+          <div className="flex flex-col bg-card border-y border-border divide-y divide-border/40">
             {pinnedUnread.map(tx => (
               <TxRow key={tx.id} {...rowProps(tx)} />
             ))}
@@ -100,7 +100,7 @@ export function TransactionsList({
 
           return (
             <div key={group.date} className="flex flex-col gap-0.5">
-              <div className="flex items-center justify-between px-3 pb-1">
+              <div className="flex items-center justify-between px-4 pb-1">
                 <span className="text-xs font-bold text-muted-foreground uppercase tracking-wide">
                   {formatDayLabel(group.date)}
                 </span>
@@ -109,7 +109,7 @@ export function TransactionsList({
                 </span>
               </div>
 
-              <div className="flex flex-col bg-card rounded-2xl overflow-clip divide-y divide-border/40">
+              <div className="flex flex-col bg-card border-y border-border divide-y divide-border/40">
                 {group.transactions.map(tx => (
                   <TxRow key={tx.id} {...rowProps(tx)} />
                 ))}
@@ -124,7 +124,7 @@ export function TransactionsList({
       {loadingMore && (
         <div className="flex flex-col gap-2">
           {[0, 1, 2].map(i => (
-            <Skeleton key={i} className="h-15.5 rounded-2xl" />
+            <Skeleton key={i} className="h-15.5 rounded-none border-y border-border" />
           ))}
         </div>
       )}

--- a/components/transactions/TransactionsSkeleton.tsx
+++ b/components/transactions/TransactionsSkeleton.tsx
@@ -5,11 +5,20 @@ export function TransactionsSkeleton() {
     <div className="px-4 pt-3 pb-6 flex flex-col gap-4">
       {/* Título */}
       <Skeleton className="h-7 w-40" />
-      {/* Toolbar (búsqueda + filtros) */}
-      <Skeleton className="h-10 rounded-xl" />
-      {/* 5 filas a ancho completo con la misma altura que TxRow (coincide con la lista real) */}
+      {/* Búsqueda */}
+      <Skeleton className="h-10 rounded-[14px]" />
+      {/* Selector de cuenta (ancho completo) */}
+      <Skeleton className="h-10 rounded-[14px]" />
+      {/* Pills de tipo (Todos / Ingresos / Gastos / No Computable) */}
+      <div className="flex items-center gap-2">
+        {['w-16', 'w-20', 'w-16', 'w-32'].map((w, i) => (
+          <Skeleton key={i} className={`h-7 rounded-full ${w}`} />
+        ))}
+      </div>
+      {/* Filas a ancho completo con la misma altura que TxRow (coincide con la
+          lista real). Suficientes para llenar la pantalla hasta abajo. */}
       <div className="-mx-4 flex flex-col gap-2">
-        {[0, 1, 2, 3, 4].map(i => (
+        {Array.from({ length: 12 }).map((_, i) => (
           <Skeleton key={i} className="h-15.5 rounded-none border-y border-border" />
         ))}
       </div>

--- a/components/transactions/TransactionsSkeleton.tsx
+++ b/components/transactions/TransactionsSkeleton.tsx
@@ -7,10 +7,10 @@ export function TransactionsSkeleton() {
       <Skeleton className="h-7 w-40" />
       {/* Toolbar (búsqueda + filtros) */}
       <Skeleton className="h-10 rounded-xl" />
-      {/* 5 filas con la misma altura que TxRow */}
-      <div className="flex flex-col gap-2">
+      {/* 5 filas a ancho completo con la misma altura que TxRow (coincide con la lista real) */}
+      <div className="-mx-4 flex flex-col gap-2">
         {[0, 1, 2, 3, 4].map(i => (
-          <Skeleton key={i} className="h-15.5 rounded-2xl" />
+          <Skeleton key={i} className="h-15.5 rounded-none border-y border-border" />
         ))}
       </div>
     </div>

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -68,17 +68,22 @@ export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize,
 
         {/* Contenido principal de la fila */}
         <div
-          className="flex flex-1 min-w-0 items-center gap-3 px-3 py-2.5 bg-card"
+          className="relative flex flex-1 min-w-0 items-center gap-3 px-4 py-2.5 bg-card"
           onClick={() => {
             if (didMoveRef.current) { didMoveRef.current = false; return }
             if (openSide) onCloseSwipe()
             else onTap(tx)
           }}
         >
-          {/* Dot de no leído (gutter reservado para que las filas no se descuadren) */}
-          <span className="flex w-2 shrink-0 items-center justify-center">
-            {!tx.is_read && <span className="h-2 w-2 rounded-full bg-primary" aria-label="No leído" />}
-          </span>
+          {/* Dot de no leído: posición absoluta dentro del padding izquierdo, así
+              no desplaza el contenido (las filas no se descuadran haya dot o no) y
+              el icono queda alineado al borde como en el resto de la app. */}
+          {!tx.is_read && (
+            <span
+              className="absolute left-1.5 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-primary"
+              aria-label="No leído"
+            />
+          )}
 
           <div
             className="flex items-center justify-center rounded-[14px] shrink-0 h-10.5 w-10.5"


### PR DESCRIPTION
## Objetivo

Cierra #165. Extiende a **Movimientos** el rediseño full-width aplicado a Cuentas en #160/PR #162: los grupos de día y la sección «No leídos» pasan de cajas redondeadas con margen lateral a filas a ancho completo con solo líneas arriba/abajo, sin esquinas redondeadas, manteniendo separación entre grupos.

## Cambios

- **`TransactionsList.tsx`** — contenedor de la lista con `-mx-4` (cancela el `px-4` del wrapper); cada card (grupo de día y «No leídos») pasa de `bg-card rounded-2xl overflow-clip` a `bg-card border-y border-border` (se conserva `divide-y` entre filas); cabeceras a `px-4` para alinear con el contenido; skeletons de `loadingMore` full-width.
- **`TransactionsSkeleton.tsx`** — filas del loading inicial a ancho completo (`-mx-4`, `rounded-none border-y border-border`), igual que `AccountsSkeleton`.
- **`TxRow.tsx`** — padding interno a `px-4` y el dot de «no leído» pasa a posición absoluta dentro del padding izquierdo. Así el icono queda alineado al borde (16px), **simétrico con el importe**, y las filas no se descuadran haya dot o no. (Componente compartido con la pantalla Detalle de categoría, que se alineará en su propia issue del roll-out.)

Toolbar y filtro de cuenta conservan su caja/margen lateral.

## Verificación

- `pnpm test` (271 ✓), `pnpm lint` y `pnpm build` en verde.
- Revisado en viewport móvil: grupos a ancho completo con separación clara, icono/importe simétricos, swipe (Categoría / Leído) y estados de carga correctos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)