### PR TITLE
feat(analytics): cards a ancho completo en Análisis (#166)

### DIFF
--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -41,7 +41,7 @@ function CalendarIcon() {
 }
 
 function CardSkeleton({ height = 120 }: { height?: number }) {
-  return <Skeleton className="rounded-[20px]" style={{ height }} />
+  return <Skeleton className="-mx-4 rounded-none border-y border-border" style={{ height }} />
 }
 
 interface PageState {
@@ -125,29 +125,30 @@ export default function AnalyticsClient() {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-4 px-4 py-3">
+      <div className="flex flex-col gap-3 px-4 py-3">
         {/* KPI row */}
         {loading || !activeBar ? (
-          <div className="flex gap-2.5">
-            <CardSkeleton />
-            <CardSkeleton />
-          </div>
+          <CardSkeleton />
         ) : (
-          <div className="flex gap-2.5">
-            <KpiCard
-              type="income"
-              value={activeBar.income}
-              deltaVsPrev={deltaVsPrevIncome}
-              deltaVsYear={deltaVsYearIncome}
-              deltaRef={deltaRef}
-            />
-            <KpiCard
-              type="expense"
-              value={activeBar.expense}
-              deltaVsPrev={deltaVsPrevExpense}
-              deltaVsYear={deltaVsYearExpense}
-              deltaRef={deltaRef}
-            />
+          <div className="-mx-4 flex border-y border-border bg-secondary px-4 py-5">
+            <div className="flex-1 pr-4">
+              <KpiCard
+                type="income"
+                value={activeBar.income}
+                deltaVsPrev={deltaVsPrevIncome}
+                deltaVsYear={deltaVsYearIncome}
+                deltaRef={deltaRef}
+              />
+            </div>
+            <div className="flex-1 border-l border-border pl-4">
+              <KpiCard
+                type="expense"
+                value={activeBar.expense}
+                deltaVsPrev={deltaVsPrevExpense}
+                deltaVsYear={deltaVsYearExpense}
+                deltaRef={deltaRef}
+              />
+            </div>
           </div>
         )}
 
@@ -155,9 +156,9 @@ export default function AnalyticsClient() {
         {loading || !data ? (
           <CardSkeleton height={220} />
         ) : (
-          <div style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20 }}>
+          <div className="-mx-4 border-y border-border bg-secondary px-4 py-5">
             <div className="mb-3 flex items-center justify-between">
-              <span className="text-[15px] font-bold text-foreground">Evolución de gastos</span>
+              <span className="text-[15px] font-bold text-foreground">Ingresos y gastos</span>
               <button
                 onClick={toggleShowYoY}
                 className="rounded-full px-2.5 py-1 text-[10px] font-bold transition-all"

--- a/components/analytics/AnalyticsSkeleton.tsx
+++ b/components/analytics/AnalyticsSkeleton.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from '@/components/ui/skeleton'
 
 function CardSkeleton({ height = 120 }: { height?: number }) {
-  return <Skeleton className="rounded-[20px]" style={{ height }} />
+  return <Skeleton className="-mx-4 rounded-none border-y border-border" style={{ height }} />
 }
 
 /**
@@ -28,12 +28,9 @@ export function AnalyticsSkeleton() {
       </div>
 
       {/* Content */}
-      <div className="flex flex-col gap-4 px-4 py-3">
+      <div className="flex flex-col gap-3 px-4 py-3">
         {/* KPI row */}
-        <div className="flex gap-2.5">
-          <CardSkeleton />
-          <CardSkeleton />
-        </div>
+        <CardSkeleton />
         {/* Chart card */}
         <CardSkeleton height={220} />
         {/* Category breakdown */}

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -127,7 +127,7 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
           </div>
 
           {/* Category rows */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
             {items.map((item, i) => {
               const isSelected = effectiveIdx === i
               const isDimmed = effectiveIdx !== null && !isSelected
@@ -145,32 +145,32 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
                   }}
                   style={{ cursor: 'pointer', opacity: isDimmed ? 0.35 : 1, transition: 'opacity 0.25s' }}
                 >
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <div className="flex items-center gap-2">
+                  <div className="mb-2 flex items-center justify-between">
+                    <div className="flex items-center gap-2.5">
                       <div style={{
-                        width: 24, height: 24, borderRadius: 7, flexShrink: 0,
+                        width: 30, height: 30, borderRadius: 9, flexShrink: 0,
                         background: isSelected ? item.color : `${item.color}22`,
                         display: 'flex', alignItems: 'center', justifyContent: 'center',
                         transition: 'background 0.2s',
                       }}>
-                        <Icon size={13} color={isSelected ? 'white' : item.color} />
+                        <Icon size={16} color={isSelected ? 'white' : item.color} />
                       </div>
-                      <span style={{ fontSize: 13, color: 'var(--foreground)', fontWeight: isSelected ? 700 : 500 }}>
+                      <span style={{ fontSize: 15, color: 'var(--foreground)', fontWeight: isSelected ? 700 : 500 }}>
                         {item.label}
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span style={{ fontSize: 12, color: 'var(--muted-foreground)' }}>
+                      <span style={{ fontSize: 13, color: 'var(--muted-foreground)' }}>
                         {Math.round(item.pct)}%
                       </span>
-                      <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--foreground)' }}>
+                      <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--foreground)' }}>
                         {fmt(item.amount)} €
                       </span>
-                      {isNavigable && <span style={{ fontSize: 11, color: accentColor }}>›</span>}
+                      {isNavigable && <span style={{ fontSize: 13, color: accentColor }}>›</span>}
                     </div>
                   </div>
                   <div style={{
-                    height: 6, borderRadius: 3,
+                    height: 7, borderRadius: 3.5,
                     background: 'color-mix(in srgb, currentColor 6%, transparent)',
                     overflow: 'hidden',
                   }}>

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -82,7 +82,7 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
   }
 
   return (
-    <div style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20 }}>
+    <div className="-mx-4 border-y border-border bg-secondary px-4 py-5">
       {/* Header + toggle */}
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[15px] font-bold text-foreground">Desglose por categoría</span>

--- a/components/analytics/DonutChart.tsx
+++ b/components/analytics/DonutChart.tsx
@@ -21,11 +21,11 @@ interface DonutChartProps {
   onSelect: (idx: number | null) => void
 }
 
-const SIZE = 220
-const CX = 110
-const CY = 110
-const R = 72
-const STROKE_W = 22
+const SIZE = 260
+const CX = 130
+const CY = 130
+const R = 86
+const STROKE_W = 26
 const CIRC = 2 * Math.PI * R
 const ICON_R = R + STROKE_W / 2 + 18
 
@@ -88,12 +88,12 @@ export default function DonutChart({ items, selectedIdx, accentColor, onSelect }
         })}
 
         {/* Center label */}
-        <text x={CX} y={CY - 8} textAnchor="middle" fontSize={10} fill="currentColor" fillOpacity={0.45}>
+        <text x={CX} y={CY - 10} textAnchor="middle" fontSize={12} fill="currentColor" fillOpacity={0.45}>
           {centerLabel}
         </text>
 
         {/* Center value */}
-        <text x={CX} y={CY + 10} textAnchor="middle" fontSize={15} fontWeight={800} fill={centerColor}>
+        <text x={CX} y={CY + 14} textAnchor="middle" fontSize={22} fontWeight={800} fill={centerColor}>
           {centerValue}
         </text>
       </svg>
@@ -109,10 +109,10 @@ export default function DonutChart({ items, selectedIdx, accentColor, onSelect }
             onClick={() => onSelect(selectedIdx === i ? null : i)}
             style={{
               position: 'absolute',
-              left: ix - 11,
-              top: iy - 11,
-              width: 22,
-              height: 22,
+              left: ix - 13,
+              top: iy - 13,
+              width: 26,
+              height: 26,
               borderRadius: '50%',
               background: isSelected ? item.color : `${item.color}33`,
               display: 'flex',
@@ -123,7 +123,7 @@ export default function DonutChart({ items, selectedIdx, accentColor, onSelect }
               transition: 'opacity 0.25s, background 0.2s',
             }}
           >
-            <Icon size={12} color={isSelected ? 'white' : item.color} />
+            <Icon size={14} color={isSelected ? 'white' : item.color} />
           </div>
         )
       })}

--- a/components/analytics/KpiCard.tsx
+++ b/components/analytics/KpiCard.tsx
@@ -31,10 +31,7 @@ export default function KpiCard({
   const fontSize = value >= 10000 ? 20 : 28
 
   return (
-    <div
-      className="flex flex-1 flex-col"
-      style={{ background: 'var(--secondary)', borderRadius: 20, padding: 20 }}
-    >
+    <div className="flex flex-1 flex-col">
       {/* Header row */}
       <div className="mb-1.5">
         <span className="text-xs text-muted-foreground">{label}</span>

--- a/components/analytics/SavingsCard.tsx
+++ b/components/analytics/SavingsCard.tsx
@@ -17,12 +17,9 @@ export default function SavingsCard({ income, savings, granularity }: SavingsCar
   const bg = isNegative
     ? 'linear-gradient(135deg, #ef4444, #dc2626)'
     : 'linear-gradient(135deg, #059669, #10b981)'
-  const shadow = isNegative
-    ? '0 10px 40px rgba(239,68,68,0.25)'
-    : '0 10px 40px rgba(16,185,129,0.25)'
 
   return (
-    <div style={{ background: bg, borderRadius: 20, padding: 20, boxShadow: shadow }}>
+    <div className="-mx-4 px-4 py-5" style={{ background: bg }}>
       <p style={{ fontSize: 13, color: 'rgba(255,255,255,0.7)', marginBottom: 4 }}>
         Ahorro · {PERIOD_LABELS[granularity]}
       </p>


### PR DESCRIPTION
## Objetivo

Cierra #166. Extiende a **Análisis** el patrón _full-width_ aplicado a Cuentas en #160 (PR #162): cards a ancho completo, sin esquinas redondeadas, con solo líneas arriba/abajo y separación entre ellas.

## Cambios

- **KPI (Ingresos/Gastos)** → una sola banda con dos columnas separadas por divisor vertical (`border-l`). Se mantiene la comparación lado a lado; `KpiCard` pierde su `bg`/`radius`/`padding` propios (los aporta la banda).
- **Gráfico de evolución** y **desglose por categoría** → bandas `-mx-4 border-y border-border bg-secondary px-4 py-5`, sin redondeo.
- **Card de ahorro** → banda gradiente a ancho completo, sin `borderRadius` ni `boxShadow` (el gradiente la separa del fondo).
- **Skeletons** (`AnalyticsSkeleton.tsx` + inline en `AnalyticsClient`) actualizados a `-mx-4 rounded-none border-y border-border` y fila KPI como banda única, sin salto de layout.
- **Header sticky y GranularityPicker:** sin cambios (conservan margen lateral).
- Renombrado el título del gráfico **"Evolución de gastos" → "Ingresos y gastos"**, ya que muestra ambos.

## Decisiones de diseño
El gradiente de ahorro se conserva como identidad de su banda (solo se aplana: fuera sombra y redondeo). Se mantiene `bg-secondary` en las demás bandas (el rediseño es de forma, no de color).

## Verificación
- `pnpm test` (271 ✓), `pnpm lint` y `pnpm build` en verde.
- Pendiente prueba manual `pnpm build && pnpm start` en viewport móvil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)