### PR TITLE
feat(dashboard): cards a ancho completo en el Dashboard (#164)

### DIFF
--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -10,14 +10,14 @@ const typeLabel: Record<AccountType, string> = {
   cash:     'Efectivo',
 }
 
-function AccountMiniCard({ account }: { account: Account }) {
+function AccountCell({ account, className }: { account: Account; className?: string }) {
   const balance = account.balance ?? 0
   const isNegative = balance < 0
 
   return (
     <Link
       href="/accounts"
-      className="block bg-card rounded-2xl p-3.5 border border-border active:opacity-70 transition-opacity"
+      className={`block px-4 py-4 active:opacity-70 transition-opacity ${className ?? ''}`}
     >
       <div className="flex items-center justify-between mb-2.5">
         <AccountIconBadge type={account.type} color={account.color} size="sm" />
@@ -49,9 +49,18 @@ export function DashboardAccountGrid({ accounts }: DashboardAccountGridProps) {
   return (
     <div>
       <div className="text-[13px] font-semibold text-muted-foreground mb-3">Mis cuentas</div>
-      <div className="grid grid-cols-2 gap-3">
-        {accounts.map(account => (
-          <AccountMiniCard key={account.id} account={account} />
+      {/* Bloque a ancho completo con divisores internos (sin cajas redondeadas),
+          al estilo de las tarjetas de Ingresos/Gastos de Análisis. */}
+      <div className="-mx-4 grid grid-cols-2 bg-secondary border-y border-border">
+        {accounts.map((account, i) => (
+          <AccountCell
+            key={account.id}
+            account={account}
+            className={[
+              i % 2 === 1 ? 'border-l border-border' : '',
+              i >= 2 ? 'border-t border-border' : '',
+            ].join(' ')}
+          />
         ))}
       </div>
     </div>

--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -10,14 +10,14 @@ const typeLabel: Record<AccountType, string> = {
   cash:     'Efectivo',
 }
 
-function AccountCell({ account, className }: { account: Account; className?: string }) {
+function AccountCell({ account }: { account: Account }) {
   const balance = account.balance ?? 0
   const isNegative = balance < 0
 
   return (
     <Link
       href="/accounts"
-      className={`block px-4 py-4 active:opacity-70 transition-opacity ${className ?? ''}`}
+      className="block bg-secondary px-4 py-4 border-r border-b border-border active:opacity-70 transition-opacity"
     >
       <div className="flex items-center justify-between mb-2.5">
         <AccountIconBadge type={account.type} color={account.color} size="sm" />
@@ -46,22 +46,20 @@ interface DashboardAccountGridProps {
 export function DashboardAccountGrid({ accounts }: DashboardAccountGridProps) {
   if (accounts.length === 0) return null
 
+  // Cada celda enmarcada con border-r/border-b y el contenedor aporta border-t/border-l:
+  // así toda card tiene sus 4 lados (también las del borde derecho/inferior) con líneas
+  // uniformes de 1px y sin solapamientos. Si el total es impar, un placeholder completa
+  // la última fila para que el marco no quede roto.
+  const needsPlaceholder = accounts.length % 2 === 1
+
   return (
     <div>
       <div className="text-[13px] font-semibold text-muted-foreground mb-3">Mis cuentas</div>
-      {/* Bloque a ancho completo con divisores internos (sin cajas redondeadas),
-          al estilo de las tarjetas de Ingresos/Gastos de Análisis. */}
-      <div className="-mx-4 grid grid-cols-2 bg-secondary border-y border-border">
-        {accounts.map((account, i) => (
-          <AccountCell
-            key={account.id}
-            account={account}
-            className={[
-              i % 2 === 1 ? 'border-l border-border' : '',
-              i >= 2 ? 'border-t border-border' : '',
-            ].join(' ')}
-          />
+      <div className="-mx-4 grid grid-cols-2 border-t border-l border-border">
+        {accounts.map(account => (
+          <AccountCell key={account.id} account={account} />
         ))}
+        {needsPlaceholder && <div className="bg-secondary border-r border-b border-border" aria-hidden />}
       </div>
     </div>
   )

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -17,10 +17,9 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
 
   return (
     <div
-      className="rounded-3xl overflow-hidden relative"
+      className="-mx-4 overflow-hidden relative"
       style={{
         background: 'linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a78bfa 100%)',
-        boxShadow: '0 20px 60px rgba(99,102,241,0.35)',
       }}
     >
       {/* Decorative bubbles */}
@@ -34,7 +33,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
       />
 
       {/* Content */}
-      <div className="relative z-10 px-6 pt-6">
+      <div className="relative z-10 px-4 pt-6">
         <div className="text-[12px] font-medium mb-1.5" style={{ color: 'rgba(255,255,255,0.7)' }}>
           Balance total
         </div>

--- a/components/dashboard/DashboardSkeleton.tsx
+++ b/components/dashboard/DashboardSkeleton.tsx
@@ -10,16 +10,9 @@ export function DashboardSkeleton() {
       {/* Bloque de cuentas 2 col con divisores internos (coincide con el real) */}
       <div>
         <Skeleton className="mb-3 h-4 w-24" />
-        <div className="-mx-4 grid grid-cols-2 border-y border-border">
+        <div className="-mx-4 grid grid-cols-2 border-t border-l border-border">
           {[0, 1, 2, 3].map(i => (
-            <div
-              key={i}
-              className={[
-                'px-4 py-4',
-                i % 2 === 1 ? 'border-l border-border' : '',
-                i >= 2 ? 'border-t border-border' : '',
-              ].join(' ')}
-            >
+            <div key={i} className="bg-secondary px-4 py-4 border-r border-b border-border">
               <Skeleton className="mb-2.5 size-8 rounded-[10px]" />
               <Skeleton className="mb-1.5 h-3 w-20" />
               <Skeleton className="h-4 w-16" />

--- a/components/dashboard/DashboardSkeleton.tsx
+++ b/components/dashboard/DashboardSkeleton.tsx
@@ -3,16 +3,27 @@ import { Skeleton } from '@/components/ui/skeleton'
 export function DashboardSkeleton() {
   return (
     <div className="flex flex-col gap-4 px-4 pt-3 pb-6">
-      {/* Balance card */}
-      <Skeleton className="h-47.5 rounded-3xl" />
-      {/* Patrimonio chart */}
-      <Skeleton className="h-45 rounded-3xl" />
-      {/* Account grid */}
+      {/* Balance banner a sangre completa */}
+      <Skeleton className="-mx-4 h-47.5 rounded-none" />
+      {/* Patrimonio chart full-width */}
+      <Skeleton className="-mx-4 h-45 rounded-none border-y border-border" />
+      {/* Bloque de cuentas 2 col con divisores internos (coincide con el real) */}
       <div>
         <Skeleton className="mb-3 h-4 w-24" />
-        <div className="grid grid-cols-2 gap-3">
+        <div className="-mx-4 grid grid-cols-2 border-y border-border">
           {[0, 1, 2, 3].map(i => (
-            <Skeleton key={i} className="h-26.25 rounded-2xl" />
+            <div
+              key={i}
+              className={[
+                'px-4 py-4',
+                i % 2 === 1 ? 'border-l border-border' : '',
+                i >= 2 ? 'border-t border-border' : '',
+              ].join(' ')}
+            >
+              <Skeleton className="mb-2.5 size-8 rounded-[10px]" />
+              <Skeleton className="mb-1.5 h-3 w-20" />
+              <Skeleton className="h-4 w-16" />
+            </div>
           ))}
         </div>
       </div>

--- a/components/dashboard/NetWorthChart.tsx
+++ b/components/dashboard/NetWorthChart.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export function NetWorthChart({ data, annualDelta }: Props) {
   return (
-    <div className="bg-card rounded-3xl p-6 border border-border">
+    <div className="bg-secondary -mx-4 px-4 py-5 border-y border-border">
       <div className="flex justify-between items-center mb-1">
         <span className="text-[15px] font-bold">Patrimonio neto</span>
         {annualDelta !== null ? (

--- a/components/dashboard/NetWorthChart.tsx
+++ b/components/dashboard/NetWorthChart.tsx
@@ -40,7 +40,7 @@ export function NetWorthChart({ data, annualDelta }: Props) {
           </defs>
           <XAxis
             dataKey="label"
-            tick={{ fontSize: 9, fill: 'rgba(0,0,0,0.35)' }}
+            tick={{ fontSize: 9, fill: 'var(--muted-foreground)' }}
             tickLine={false}
             axisLine={false}
             interval="preserveStartEnd"


### PR DESCRIPTION
Cierra #164.

Extiende al Dashboard el rediseño full-width ya aplicado a Cuentas (#160), Movimientos (#165) y Análisis (#166).

## Cambios
- **DashboardBalanceCard** → banner a sangre completa (`-mx-4`), manteniendo el degradado pero sin `rounded-3xl` ni `boxShadow`. Gutter del contenido alineado a 16px (`px-4`).
- **NetWorthChart** → bloque full-width `-mx-4 border-y` sobre `bg-secondary` (sin caja redondeada).
- **DashboardAccountGrid** → en vez de mini-cards redondeadas sueltas, un único bloque a ancho completo en 2 columnas con **divisores internos** (vertical entre columnas, horizontal entre filas), al estilo de las KPI cards de Ingresos/Gastos de Análisis.
- **DashboardSkeleton** → actualizado para coincidir con el nuevo layout (banner, gráfica y bloque de cuentas).

## Decisiones de diseño
El issue pedía decidir qué elementos pasan a full-width. Tras iterar con el resultado visual: los tres bloques pasan a full-width; el grid de cuentas se mantiene en **2 columnas** pero como un bloque con divisores internos (no cajas individuales), para aprovechar el ancho sin perder el resumen compacto.

## Verificación
- `pnpm test` (271 ✓), `pnpm lint` y `pnpm build` en verde.
- Pendiente revisión visual en viewport móvil (`pnpm build && pnpm start`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)