### PR TITLE
fix(analytics): conservar el período seleccionado al abrir el detalle de categoría (#172)

### DIFF
--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -189,7 +189,7 @@ export default function AnalyticsClient() {
         {loading || !activeBar ? (
           <CardSkeleton height={420} />
         ) : (
-          <CategoryBreakdownSection byCategory={activeBar.byCategory} />
+          <CategoryBreakdownSection byCategory={activeBar.byCategory} periodStart={activeBar.start} />
         )}
 
         {/* Savings card */}

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -14,9 +14,11 @@ const REST_COLOR = '#94a3b8'
 
 interface CategoryBreakdownSectionProps {
   byCategory: CategoryBreakdown[]
+  /** Inicio (ISO) del período activo en Análisis; se propaga al detalle para abrirlo en el mismo período. */
+  periodStart: string
 }
 
-export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdownSectionProps) {
+export default function CategoryBreakdownSection({ byCategory, periodStart }: CategoryBreakdownSectionProps) {
   const router = useRouter()
   const [catView, setCatView] = useState<'gastos' | 'ingresos'>('gastos')
   // Tracked by key instead of index — auto-deselects when byCategory changes and the
@@ -138,7 +140,7 @@ export default function CategoryBreakdownSection({ byCategory }: CategoryBreakdo
                   key={item.key}
                   onClick={() => {
                     if (isNavigable) {
-                      router.push(`/analytics/category/${item.categoryId}`)
+                      router.push(`/analytics/category/${item.categoryId}?period=${periodStart}`)
                     } else {
                       handleSelect(effectiveIdx === i ? null : i)
                     }

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useAnalytics } from '@/contexts/AnalyticsContext'
 import { CATEGORY_META } from '@/lib/theme'
 import { fmt } from '@/lib/formatting'
@@ -46,6 +46,9 @@ interface Props {
 
 export default function CategoryDetailClient({ categoryId }: Props) {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  // Período de origen (inicio ISO) al llegar desde Análisis; abrimos el detalle en él.
+  const periodParam = searchParams.get('period')
   const { granularity, setShowPicker } = useAnalytics()
   const meta = CATEGORY_META[categoryId]
   const { Icon, label, color } = meta
@@ -98,13 +101,17 @@ export default function CategoryDetailClient({ categoryId }: Props) {
       .then(r => r.json())
       .then(d => {
         if (!cancelled) {
-          setPeriods(d.periods ?? [])
-          setSelectedBarIdx(5)
+          const ps: CategoryPeriodData[] = d.periods ?? []
+          // Selecciona el período de origen si está en la ventana; si no (más
+          // antiguo que los últimos mostrados) o sin param, el más reciente.
+          const fromParam = periodParam ? ps.findIndex(p => p.start === periodParam) : -1
+          setPeriods(ps)
+          setSelectedBarIdx(fromParam >= 0 ? fromParam : ps.length - 1)
           setLoadingPeriods(false)
         }
       })
     return () => { cancelled = true }
-  }, [granularity, categoryId])
+  }, [granularity, categoryId, periodParam])
 
   const selectedPeriodForKey = periods[selectedBarIdx]
   const txsKey = selectedPeriodForKey


### PR DESCRIPTION
## Problema

Cierra #172. Al navegar de **Análisis** al **Detalle de categoría**, el detalle se abría siempre en el último período en vez de en el que el usuario tenía seleccionado.

## Causa

La navegación no transmitía el período activo y `CategoryDetailClient` seleccionaba por defecto la última barra. La granularidad sí se conserva (vive en `AnalyticsContext`); faltaba el período concreto.

## Cambios

- **`AnalyticsClient.tsx`**: pasa `periodStart={activeBar.start}` a `CategoryBreakdownSection`.
- **`CategoryBreakdownSection.tsx`**: al navegar a una categoría incluye `?period=<startISO>`.
- **`CategoryDetailClient.tsx`**: lee `period` con `useSearchParams` y, al cargar sus períodos, selecciona la barra cuyo `start` coincide; si no está en su ventana de 6 (período más antiguo que los mostrados) o no hay param, cae al más reciente. Matching por fecha → robusto frente a la diferencia de tamaños de ventana entre Análisis y el detalle.

## Verificación

- `pnpm test` (271 ✓), `pnpm lint` y `pnpm build` en verde.
- Manual: en Análisis, seleccionar un período anterior (dentro de las últimas 6) y pulsar una categoría → el detalle abre en ese período; período fuera de las últimas 6 → abre en el más reciente sin romper.

> Toca `CategoryDetailClient.tsx` igual que #167 (PR #171) pero en regiones distintas; ambas PRs deberían mezclar a `develop` sin conflicto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)