### PR TITLE
feat(categories): revisión del catálogo y reescritura de AUTO_RULES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ scripts/scrapers/sabadell-visa/*.local.*
 # serwist — service worker generado en build
 public/sw.js
 public/sw.js.map
+
+# historical data
+historical_data

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -8,13 +8,14 @@ const VALID_CATEGORIES: CategoryId[] = [
   'groceries', 'restaurant', 'transport', 'fuel', 'parking', 'vehicle',
   'mortgage', 'community_fees', 'electricity', 'gas', 'water', 'internet',
   'home', 'clothing', 'shopping', 'electronics', 'health', 'pharmacy',
-  'leisure', 'sports', 'subscriptions', 'travel', 'education', 'insurance',
+  'leisure', 'sports', 'subscriptions', 'travel', 'education',
+  'insurance_health', 'insurance_home', 'insurance_auto', 'domestic_help',
   'beauty', 'gifts', 'charity', 'memberships', 'taxes', 'loans', 'cash',
   'fees', 'other',
   // Ingresos
   'income', 'returns', 'reimbursement', 'other_income',
   // No Computable
-  'investment', 'savings', 'transfer', 'loan_payment',
+  'investment', 'savings', 'transfer', 'loan_payment', 'card_payment',
 ]
 
 export async function PATCH(

--- a/lib/categories.test.ts
+++ b/lib/categories.test.ts
@@ -63,7 +63,16 @@ describe('categorize', () => {
       ['Carrefour', 'groceries'],
       ['Dia 23/05', 'groceries'],
       ['Eroski', 'groceries'],
+      ['Panet Av.Montserrat', 'groceries'],
     ] as const)('groceries matchea %j', (description, expected) => {
+      expect(categorize(description)).toBe(expected)
+    })
+
+    it.each([
+      ['McDonalds', 'restaurant'],
+      ['Bar Stadium', 'restaurant'],
+      ['Gumen Catering', 'restaurant'],
+    ] as const)('restaurant matchea %j', (description, expected) => {
       expect(categorize(description)).toBe(expected)
     })
 

--- a/lib/categories.test.ts
+++ b/lib/categories.test.ts
@@ -31,7 +31,9 @@ const positiveCases: ReadonlyArray<readonly [string, CategoryId]> = [
   ['Pago Netflix.com', 'subscriptions'],
   ['Booking.com reserva hotel', 'travel'],
   ['Udemy curso online', 'education'],
-  ['Recibo seguro Mapfre', 'insurance'],
+  ['Recibo Sanitas cuota salud', 'insurance_health'],
+  ['Seguro hogar Mapfre anual', 'insurance_home'],
+  ['Seguro auto Linea Directa', 'insurance_auto'],
   ['Recibo varios 23/05', 'fees'],
   ['Pago hacienda IRPF', 'taxes'],
   ['Nomina mayo empresa', 'income'],
@@ -40,6 +42,11 @@ const positiveCases: ReadonlyArray<readonly [string, CategoryId]> = [
   ['Cajero ATM Banco', 'cash'],
   ['Bizum a Juan', 'other'],
   ['MyInvestor compra fondo', 'investment'],
+  ['Prestamos adeudo cuota N.123', 'loans'],
+  ['Aportacion periodica plan ahorro', 'savings'],
+  ['Donacion Cruz Roja', 'charity'],
+  ['Cuota asociacion de vecinos', 'memberships'],
+  ['Tarjeta credito Victor Sales Barbera', 'card_payment'],
 ]
 
 describe('categorize', () => {
@@ -110,8 +117,24 @@ describe('categorize', () => {
   })
 
   describe('prioridad de orden', () => {
-    it('"Recibo seguro Mapfre" → insurance (precede a fees)', () => {
-      expect(categorize('Recibo seguro Mapfre')).toBe('insurance')
+    it('"ADEUDO RECIBO AJ. EL PRAT" → taxes (las específicas preceden al recibo genérico)', () => {
+      expect(categorize('ADEUDO RECIBO AJ. EL PRAT DE LLOBREGAT')).toBe('taxes')
+    })
+
+    it('"ADEUDO RECIBO CDAD GENERAL Y PARQUING" → community_fees (precede al recibo genérico)', () => {
+      expect(categorize('ADEUDO RECIBO CDAD GENERAL Y PARQUING')).toBe('community_fees')
+    })
+
+    it('"REINTEGRO CAJERO AUTOMATICO" → cash (precede al reembolso por "reintegro")', () => {
+      expect(categorize('REINTEGRO CAJERO AUTOMATICO 5402XXXXXXXX2017')).toBe('cash')
+    })
+
+    it('"Recibo Gas Natural" → gas (precede a electricidad por "naturgy")', () => {
+      expect(categorize('Recibo Gas Natural distribucion')).toBe('gas')
+    })
+
+    it('"Prime Video" → subscriptions (precede al amazon genérico de Compras)', () => {
+      expect(categorize('Prime Video *LV9MI3ZH5')).toBe('subscriptions')
     })
 
     it('"El Corte Ingles hogar muebles" → home (precede a shopping)', () => {

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -2,79 +2,94 @@ import type { CategoryId } from '@/types'
 
 type RuleField = 'description' | 'merchant'
 
+// IMPORTANTE: el orden importa — se devuelve la PRIMERA regla que casa. Las reglas
+// específicas van primero y los catch-all genéricos (`recibo`, `bizum`) van al FINAL.
 export const AUTO_RULES: { pattern: RegExp; category: CategoryId; field?: RuleField }[] = [
-  // Supermercado
-  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor/i, category: 'groceries' },
-  // Restaurantes
-  { pattern: /restaurante|mcdonalds|burger.?king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter/i, category: 'restaurant' },
+  // Supermercado (incluye cadenas locales catalanas, panaderías y carnicerías)
+  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor|caprabo|bonpreu|esclat|condis|sorli|ametller|la sirena|prat supermercat|superverd|supermercat|supermercado|granier|\bfornet\b|pastisseri|carniceri|cooperativa agricola/i, category: 'groceries' },
+  // Restaurantes, bares y cafeterías
+  { pattern: /restaurante|mcdonalds|burger.?king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter|\bbar\b|\bcafe\b|barbacoa|braseri|\bgranja\b|tapeo/i, category: 'restaurant' },
   // Comida a domicilio
   { pattern: /glovo|deliveroo|just.?eat|uber.?eats/i, category: 'restaurant' },
+  // Gasolina (E.S. = estación de servicio)
+  { pattern: /repsol|cepsa|bp\b|galp|campsa|shell\b|gasolinera|carburante|e\.s\.|cedipsa|estacion de servicio/i, category: 'fuel' },
   // Transporte público
-  { pattern: /renfe|metro|emt\b|avlo|ouigo|blablacar|cabify|uber\b|bolt\b|transporte/i, category: 'transport' },
-  // Gasolina
-  { pattern: /repsol|cepsa|bp\b|galp|campsa|shell\b|gasolinera|carburante/i, category: 'fuel' },
+  { pattern: /renfe|metro|emt\b|avlo|ouigo|blablacar|cabify|uber\b|bolt\b|transporte|\btaxi\b|t.?mobilitat/i, category: 'transport' },
   // Parking y Peaje
   { pattern: /parking|aparcamiento|peaje|autopista|via\.t|telepeaje/i, category: 'parking' },
-  // Vehículo
-  { pattern: /taller|itv\b|neumatico|concesionario|mapfre auto|adeslas auto|midas|norauto/i, category: 'vehicle' },
+  // Vehículo (taller, ITV…)
+  { pattern: /taller|itv\b|neumatico|concesionario|midas|norauto/i, category: 'vehicle' },
   // Hipoteca / Alquiler
   { pattern: /hipoteca|prestamo hipotecario|alquiler|arrendamiento/i, category: 'mortgage' },
   // Amortización de préstamo
-  { pattern: /cuota prestamo|cuota credito|amortizacion prestamo|pago prestamo/i, category: 'loan_payment' },
-  // Comunidad de propietarios
-  { pattern: /comunidad de propietarios|comunidad vecinos|administrador fincas/i, category: 'community_fees' },
+  { pattern: /amortizacion prestamo|cuota prestamo|cuota credito|pago prestamo/i, category: 'loan_payment' },
+  // Préstamos / financiación (financieras, adeudo de cuotas)
+  { pattern: /prestamos adeudo|adeudo cuota|cetelem|cofidis|financiera\b/i, category: 'loans' },
+  // Comunidad de propietarios (CDAD = comunidad)
+  { pattern: /comunidad de propietarios|comunidad vecinos|administrador fincas|cdad\b/i, category: 'community_fees' },
+  // Gas natural (antes que electricidad: "naturgy gas" debe ganar a "naturgy")
+  { pattern: /gas natural|naturgy gas|repsol gas\b|madrile.a de gas/i, category: 'gas' },
   // Electricidad
   { pattern: /endesa|iberdrola|naturgy|holaluz|octopus energy|luz\b|electricidad/i, category: 'electricity' },
-  // Gas natural
-  { pattern: /naturgy gas|gas natural|repsol gas\b|madrile.a de gas/i, category: 'gas' },
   // Agua
   { pattern: /canal de isabel|aguas de|abastecimiento|suministro agua/i, category: 'water' },
   // Internet / Telefonía
   { pattern: /movistar|vodafone|orange\b|jazztel|masmovil|pepephone|digi\b|yoigo|simyo|telefonica|internet/i, category: 'internet' },
+  // Seguro salud
+  { pattern: /sanitas|adeslas|asisa|\bdkv\b|cigna|caser salud|mapfre salud|seguro salud/i, category: 'insurance_health' },
+  // Seguro hogar (fiatc: multirramo ambiguo → mejor conjetura)
+  { pattern: /seguro hogar|mapfre hogar|fiatc/i, category: 'insurance_home' },
+  // Seguro auto
+  { pattern: /seguro auto|seguro coche|linea directa|mutua madrilena|mapfre auto/i, category: 'insurance_auto' },
   // Hogar (reformas, muebles)
-  { pattern: /ikea|leroy merlin|brico|amazon home|el corte ingles hogar|zara home/i, category: 'home' },
+  { pattern: /ikea|leroy merlin|brico|amazon home|el corte ingles hogar|zara home|reformes|reforma/i, category: 'home' },
   // Ropa
-  { pattern: /zara\b|mango\b|hm\b|h&m|pull.and.bear|bershka|stradivarius|primark|lefties|el corte ingles moda/i, category: 'clothing' },
+  { pattern: /zara\b|mango\b|h&m|pull.and.bear|bershka|stradivarius|primark|lefties|el corte ingles moda|zeeman/i, category: 'clothing' },
   // Electrónica
-  { pattern: /apple store|fnac|mediamarkt|pccomponentes|worten|samsung store/i, category: 'electronics' },
-  // Compras generales (Amazon, El Corte Inglés, paquetería)
-  { pattern: /amazon\b|el corte ingles|correos\b|mrw\b|seur\b|ups\b|dhl\b/i, category: 'shopping' },
-  // Salud
-  { pattern: /clinica|hospital|sanitas|adeslas|quironsalud|dentista|oculista|optica|medico/i, category: 'health' },
-  // Farmacia
-  { pattern: /farmacia|parafarmacia|farmacor/i, category: 'pharmacy' },
-  // Belleza y cuidado personal
-  { pattern: /peluquer|barberia|estetica|manicura|beauty/i, category: 'beauty' },
-  // Ocio
-  { pattern: /cine|teatro|concierto|entradas|ticketmaster|eventbrite|amazon prime video|disney\+|hbo/i, category: 'leisure' },
-  // Deporte
-  { pattern: /gimnasio|gym\b|decathlon|intersport|padel|tenis|natacion/i, category: 'sports' },
-  // Suscripciones
-  { pattern: /netflix|spotify|apple\.com\/bill|google one|microsoft 365|adobe|youtube premium|hbo max|paramount/i, category: 'subscriptions' },
+  { pattern: /apple store|fnac|mediamarkt|pccomponentes|worten|samsung store|vadeaudio/i, category: 'electronics' },
+  // Suscripciones (antes que el "amazon" genérico de Compras)
+  { pattern: /netflix|spotify|apple\.com\/bill|amzn\.com\/bill|google one|microsoft 365|adobe|youtube premium|hbo max|paramount|prime video|primevideo|amazon prime|filmin|dazn|disney\+/i, category: 'subscriptions' },
+  // Ocio (cine, espectáculos, loterías, parques temáticos)
+  { pattern: /\bcine\b|cinesa|multicines|teatro|concierto|entradas|ticketmaster|eventbrite|port.?aventura|tibidabo|loteri|tulotero|espectacul/i, category: 'leisure' },
+  // Deporte (esports = deportes en catalán)
+  { pattern: /gimnasio|gym\b|decathlon|intersport|padel|tenis|natacion|esports\b/i, category: 'sports' },
   // Viajes
-  { pattern: /booking\.com|airbnb|ryanair|vueling|iberia\b|iberia express|easyjet|aena|hotel|hostal|alojamiento/i, category: 'travel' },
-  // Educación
-  { pattern: /udemy|coursera|openwebinars|universidad|escuela|academia|fnac libros/i, category: 'education' },
-  // Recibo de seguro (antes que recibo genérico)
-  { pattern: /recibo\s+(?:seguro|axa|mapfre|allianz|mutua|linea directa|generali)/i, category: 'insurance' },
-  // Seguros (descripción o comercio)
-  { pattern: /seguros|mutua madrilena|linea directa|axa\b|allianz|generali|mapfre seguro/i, category: 'insurance' },
-  // Recibo genérico (domiciliaciones)
-  { pattern: /recibo\b/i, category: 'fees' },
-  // Impuestos y tasas
-  { pattern: /hacienda|agencia tributaria|aeat\b|impuesto|ivtm|ibi\b|tasa\b/i, category: 'taxes' },
+  { pattern: /booking\.com|airbnb|ryanair|vueling|iberia\b|iberia express|easyjet|aena|hotel|hostal|alojamiento|viajes halcon|halcon viajes/i, category: 'travel' },
+  // Educación (collegi/colegio, estudios reglados)
+  { pattern: /udemy|coursera|openwebinars|universidad|escuela|academia|fnac libros|colleg|colegi|colegio|estudios reglados|fundacio cultural|matricula/i, category: 'education' },
+  // Salud
+  { pattern: /clinica|hospital|quironsalud|dentista|oculista|optica|medico|fisio|reedufisio|podolog|psicolog/i, category: 'health' },
+  // Farmacia
+  { pattern: /farmacia|parafarmacia|farmacor|farmablava/i, category: 'pharmacy' },
+  // Belleza y cuidado personal (perruquers = peluquería en catalán)
+  { pattern: /peluquer|perruqu|barberia|estetica|manicura|beauty/i, category: 'beauty' },
+  // Pago / liquidación de tarjeta de crédito (no computable: las compras ya se computan en la cuenta de la tarjeta)
+  { pattern: /tarjeta credito\b|liquidacion tarjeta|pago tarjeta credito/i, category: 'card_payment' },
+  // Ahorro (planes de ahorro, aportaciones periódicas)
+  { pattern: /plan ahorro|plan de ahorro|aportacion periodica/i, category: 'savings' },
+  // Inversión
+  { pattern: /degiro|myinvestor|indexa capital|openbroker|interactive brokers|trading212|etf\b|fondo de inversion|gvc gaesco|gaesco/i, category: 'investment' },
   // Nómina e ingresos laborales
   { pattern: /nomina|salario|payroll|haberes|retribucion/i, category: 'income' },
-  // Reembolso / Devolución (antes que hacienda genérico)
-  { pattern: /devolucion|reembolso|reintegro/i, category: 'reimbursement' },
+  // Reembolso / Devolución (antes que impuestos: "devoluciones tributarias" es una devolución)
+  { pattern: /devolucion|reembolso|devoluciones tributarias/i, category: 'reimbursement' },
+  // Impuestos y tasas (ayuntamiento / organisme tributari)
+  { pattern: /hacienda|agencia tributaria|aeat\b|impuesto|ivtm|ibi\b|tasa\b|ajuntament|ayuntamiento|organisme tributari|\baj\.\s/i, category: 'taxes' },
   // Transferencia entre cuentas propias
   { pattern: /transferencia propia|traspaso propio|traspaso entre cuentas/i, category: 'transfer' },
-  // Retirada de efectivo
-  { pattern: /cajero|reintegro efectivo|retirada efectivo|withdrawal/i, category: 'cash' },
+  // Retirada de efectivo (captura "reintegro cajero" antes que el reembolso genérico)
+  { pattern: /cajero|reintegro efectivo|reintegro cajero|retirada efectivo|withdrawal/i, category: 'cash' },
+  // Compras generales (Amazon, El Corte Inglés, paquetería) — genérico, tras lo específico
+  { pattern: /amazon\b|el corte ingles|correos\b|mrw\b|seur\b|ups\b|dhl\b|aliexpress|temu|shein|pandora/i, category: 'shopping' },
+  // Solidaridad (ONG y donaciones; antes que "asociacion" genérico)
+  { pattern: /cruz roja|unicef|oxfam|intermon|\baecc\b|asociacion espanola contra|\bong\b|parroquia|donacion|esplai/i, category: 'charity' },
+  // Asociaciones (cuotas de socio)
+  { pattern: /asociacion\b|federacion/i, category: 'memberships' },
+  // ── FALLBACKS genéricos (deben ir al final) ──
+  // Recibo genérico (domiciliaciones sin emisor reconocido)
+  { pattern: /recibo\b/i, category: 'fees' },
   // Bizum (demasiado genérico para categorizar con precisión)
   { pattern: /bizum/i, category: 'other' },
-  // Inversión
-  { pattern: /degiro|myinvestor|indexa capital|openbroker|interactive brokers|trading212|etf\b|fondo de inversion/i, category: 'investment' },
 ]
 
 export interface DbCategorizationRule {

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -6,9 +6,9 @@ type RuleField = 'description' | 'merchant'
 // específicas van primero y los catch-all genéricos (`recibo`, `bizum`) van al FINAL.
 export const AUTO_RULES: { pattern: RegExp; category: CategoryId; field?: RuleField }[] = [
   // Supermercado (incluye cadenas locales catalanas, panaderías y carnicerías)
-  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor|caprabo|bonpreu|esclat|condis|sorli|ametller|la sirena|prat supermercat|superverd|supermercat|supermercado|granier|\bfornet\b|pastisseri|carniceri|cooperativa agricola/i, category: 'groceries' },
+  { pattern: /mercadona|carrefour|lidl|aldi|dia\b|eroski|alcampo|hipercor|consum|ahorramas|supercor|caprabo|bonpreu|esclat|condis|sorli|ametller|la sirena|prat supermercat|superverd|supermercat|supermercado|granier|\bfornet\b|panet|pastisseri|carniceri|cooperativa agricola/i, category: 'groceries' },
   // Restaurantes, bares y cafeterías
-  { pattern: /restaurante|mcdonalds|burger.?king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter|\bbar\b|\bcafe\b|barbacoa|braseri|\bgranja\b|tapeo/i, category: 'restaurant' },
+  { pattern: /restaurante|mcdonalds|burger.?king|kfc|telepizza|dominos|pizzer|sushi|kebab|cafeter|\bbar\b|\bcafe\b|barbacoa|braseri|\bgranja\b|tapeo|catering/i, category: 'restaurant' },
   // Comida a domicilio
   { pattern: /glovo|deliveroo|just.?eat|uber.?eats/i, category: 'restaurant' },
   // Gasolina (E.S. = estación de servicio)

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -2,10 +2,10 @@ import {
   ShoppingCart, UtensilsCrossed, Home, Gamepad2, ShoppingBag,
   TrendingUp, MoreHorizontal, CircleHelp, Fuel, ParkingCircle, Wrench,
   Building2, Users, Zap, Flame, Droplets, Wifi, Shirt, Laptop,
-  Stethoscope, Pill, Dumbbell, Repeat2, Plane, BookOpen, Shield,
+  Stethoscope, Pill, Dumbbell, Repeat2, Plane, BookOpen,
   Sparkles, Gift, Heart, Users2, Receipt, CreditCard, Banknote,
   Landmark, BarChart3, RotateCcw, CirclePlus, PiggyBank, ArrowLeftRight,
-  Wallet, Bus,
+  Wallet, Bus, SprayCan, ShieldPlus, Umbrella, Car, WalletCards,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { CategoryId, CategoryType } from '@/types'
@@ -77,7 +77,10 @@ export const CATEGORY_COLORS: Record<CategoryId, string> = {
   subscriptions:  '#f97316',
   travel:         '#0ea5e9',
   education:      '#a855f7',
-  insurance:      '#84cc16',
+  insurance_health: '#84cc16',
+  insurance_home: '#0d9488',
+  insurance_auto: '#65a30d',
+  domestic_help:  '#14b8a6',
   beauty:         '#f472b6',
   gifts:          '#fb7185',
   charity:        '#4ade80',
@@ -97,6 +100,7 @@ export const CATEGORY_COLORS: Record<CategoryId, string> = {
   savings:        '#0d9488',
   transfer:       '#78716c',
   loan_payment:   '#b45309',
+  card_payment:   '#a8a29e',
 }
 
 interface CategoryMeta {
@@ -131,7 +135,10 @@ export const CATEGORY_META: Record<CategoryId, CategoryMeta> = {
   subscriptions:  { label: 'Suscripciones',         color: '#f97316', type: 'expense',         Icon: Repeat2         },
   travel:         { label: 'Viajes',                color: '#0ea5e9', type: 'expense',         Icon: Plane           },
   education:      { label: 'Educación',             color: '#a855f7', type: 'expense',         Icon: BookOpen        },
-  insurance:      { label: 'Seguros',               color: '#84cc16', type: 'expense',         Icon: Shield          },
+  insurance_health: { label: 'Seguro salud',        color: '#84cc16', type: 'expense',         Icon: ShieldPlus      },
+  insurance_home: { label: 'Seguro hogar',          color: '#0d9488', type: 'expense',         Icon: Umbrella        },
+  insurance_auto: { label: 'Seguro auto',           color: '#65a30d', type: 'expense',         Icon: Car             },
+  domestic_help:  { label: 'Servicio doméstico',    color: '#14b8a6', type: 'expense',         Icon: SprayCan        },
   beauty:         { label: 'Cuidado personal',      color: '#f472b6', type: 'expense',         Icon: Sparkles        },
   gifts:          { label: 'Regalos',               color: '#fb7185', type: 'expense',         Icon: Gift            },
   charity:        { label: 'Solidaridad',           color: '#4ade80', type: 'expense',         Icon: Heart           },
@@ -151,6 +158,7 @@ export const CATEGORY_META: Record<CategoryId, CategoryMeta> = {
   savings:        { label: 'Ahorro',                color: '#0d9488', type: 'non_computable',  Icon: PiggyBank       },
   transfer:       { label: 'Transferencia interna', color: '#78716c', type: 'non_computable',  Icon: ArrowLeftRight  },
   loan_payment:   { label: 'Amortización',          color: '#b45309', type: 'non_computable',  Icon: Wallet          },
+  card_payment:   { label: 'Pago tarjeta crédito',  color: '#a8a29e', type: 'non_computable',  Icon: WalletCards     },
 }
 
 export const UNCATEGORIZED = {

--- a/supabase/migrations/20260609000000_categories_revision.sql
+++ b/supabase/migrations/20260609000000_categories_revision.sql
@@ -1,0 +1,51 @@
+-- Revisión del catálogo de categorías (Plan 1).
+--
+-- Altas (5):
+--   · domestic_help    (Servicio doméstico)   — expense
+--   · insurance_health (Seguro salud)         — expense   ┐ desglose del antiguo
+--   · insurance_home   (Seguro hogar)         — expense   │ 'insurance' en sus
+--   · insurance_auto   (Seguro auto)          — expense   ┘ tres ramos reales
+--   · card_payment     (Pago tarjeta crédito) — non_computable
+--       Liquidación de la VISA desde la cuenta corriente: no computable para
+--       evitar el doble cómputo (las compras ya se contabilizan en la cuenta
+--       de la tarjeta).
+--
+-- Baja (1):
+--   · insurance (Seguros) — sustituida por el desglose salud/hogar/auto.
+--
+-- Mantener en sincronía con: types/index.ts (CategoryId),
+-- lib/theme.ts (CATEGORY_META / CATEGORY_COLORS),
+-- app/api/transactions/[id]/route.ts (VALID_CATEGORIES) y
+-- lib/categories.ts (AUTO_RULES).
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- 1. Altas
+-- ============================================================
+-- sort_order de categories no se usa para ordenar en la app (la UI ordena por
+-- CATEGORY_META en lib/theme.ts), así que basta con valores distintos al final.
+INSERT INTO categories (id, name, color, type, sort_order) VALUES
+  ('domestic_help',    'Servicio doméstico',   '#14b8a6', 'expense',        42),
+  ('insurance_health', 'Seguro salud',         '#84cc16', 'expense',        43),
+  ('insurance_home',   'Seguro hogar',         '#0d9488', 'expense',        44),
+  ('insurance_auto',   'Seguro auto',          '#65a30d', 'expense',        45),
+  ('card_payment',     'Pago tarjeta crédito', '#a8a29e', 'non_computable', 46)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 2. Baja de 'insurance' (orden seguro)
+-- ============================================================
+-- Hoy 'insurance' no tiene transacciones, pero se reasigna por robustez antes
+-- de borrar (categorization_rules.category_id tiene FK a categories.id;
+-- transactions.category NO tiene FK, así que borrar sin reasignar dejaría filas
+-- huérfanas excluidas de Análisis por el INNER JOIN de la matview).
+UPDATE transactions      SET category        = 'insurance_home' WHERE category        = 'insurance';
+UPDATE transactions      SET category_manual = 'insurance_home' WHERE category_manual = 'insurance';
+DELETE FROM categorization_rules WHERE category_id = 'insurance';
+DELETE FROM categories           WHERE id          = 'insurance';
+
+-- ============================================================
+-- 3. Refrescar la vista materializada de analítica
+-- ============================================================
+REFRESH MATERIALIZED VIEW transactions_monthly_summary;

--- a/types/index.ts
+++ b/types/index.ts
@@ -27,7 +27,10 @@ export type CategoryId =
   | 'subscriptions'
   | 'travel'
   | 'education'
-  | 'insurance'
+  | 'insurance_health'
+  | 'insurance_home'
+  | 'insurance_auto'
+  | 'domestic_help'
   | 'beauty'
   | 'gifts'
   | 'charity'
@@ -47,6 +50,7 @@ export type CategoryId =
   | 'savings'
   | 'transfer'
   | 'loan_payment'
+  | 'card_payment'
 
 export interface Household {
   id: string


### PR DESCRIPTION
## Contexto
Plan 1 de dos: dejar el catálogo de categorías y sus reglas bien definidos **antes** de cargar el histórico (Plan 2), para no recategorizar después. Se contrastó el catálogo con el gasto real del usuario en Fintonic (ene-2025→) y con las descripciones reales de la BD/ficheros históricos.

## Cambios en el catálogo
**Altas (5):**
- `domestic_help` (Servicio doméstico) — *expense*
- `insurance_health` / `insurance_home` / `insurance_auto` — *expense* (desglose del antiguo `insurance`)
- `card_payment` (Pago tarjeta crédito) — **non_computable**: liquidación de la VISA desde la cuenta corriente; no computable para **evitar doble cómputo** (las compras ya se contabilizan en la cuenta de la tarjeta).

**Baja (1):** `insurance` (Seguros) — sustituida por el desglose salud/hogar/auto (tenía 0 transacciones).

## Reescritura de `AUTO_RULES`
- **Arreglo de orden**: los catch-all genéricos (`recibo`→fees, `bizum`→other) se mueven al final. Antes tapaban reglas específicas → `ADEUDO RECIBO AJ.…`→`taxes`, `…CDAD…`→`community_fees`.
- **Más bugs de orden corregidos**: `naturgy gas`→`gas` (antes `electricity`), `reintegro cajero`→`cash` (antes `reimbursement`), `Prime Video`→`subscriptions` (antes el `amazon` genérico de `shopping`).
- **Categorías que no tenían ninguna regla** ahora cubiertas: `loans`, `savings`, `charity`, `memberships`, `card_payment`.
- **Comercios reales del histórico**: cadenas locales catalanas (CAPRABO, AMETLLER, SUPERVERD, fornets/pastisseries), `E.S.`/CEDIPSA→gasolina, `PERRUQUERS`→belleza, `esports`→deporte, `COLLEGI`/`ESTUDIOS REGLADOS`→educación, `GVC GAESCO`→inversión, `PLAN AHORRO`→ahorro, etc.

## Coherencia (5 sitios de una categoría)
Migración SQL del seed + `CategoryId` (`types/index.ts`) + `CATEGORY_META`/`CATEGORY_COLORS` (`lib/theme.ts`) + `VALID_CATEGORIES` (`app/api/transactions/[id]/route.ts`) + `AUTO_RULES` (`lib/categories.ts`). El `Record<CategoryId,…>` garantiza por tipos que ninguno quede incompleto.

## Migración
`supabase/migrations/20260609000000_categories_revision.sql` — altas, baja segura de `insurance` (reasignar→borrar regla→borrar categoría) y `REFRESH MATERIALIZED VIEW`. **La aplica el usuario a mano en el SQL Editor de Supabase.**

## Validación
- `pnpm test` ✅ (282) · `pnpm lint` ✅ · `pnpm build` ✅
- Tests de categorización ampliados con las nuevas categorías y casos de prioridad de orden.

## Notas
- Iconos Lucide nuevos verificados disponibles: `SprayCan`, `ShieldPlus`, `Umbrella`, `Car`, `WalletCards`.
- Pendiente (opcional, tras aplicar la migración): backfill de re-categorización de las ~49 transacciones que hoy están sin categoría.

🤖 Generated with [Claude Code](https://claude.com/claude-code)