### PR TITLE
fix(categories): renombrar el id de categoría 'income' → 'payroll' (#151)

### DIFF
--- a/app/api/analytics/category/route.test.ts
+++ b/app/api/analytics/category/route.test.ts
@@ -210,7 +210,7 @@ describe('GET /api/analytics/category — drilldown por categoría', () => {
             income: 2000,
             expense: 0,
             savings: 2000,
-            by_category: [{ category: 'income', amount: 2000 }],
+            by_category: [{ category: 'payroll', amount: 2000 }],
           },
         ],
         error: null,
@@ -220,7 +220,7 @@ describe('GET /api/analytics/category — drilldown por categoría', () => {
       supabase as unknown as Awaited<ReturnType<typeof createClient>>
     )
 
-    const body = await (await GET(req({ granularity: 'month', id: 'income' }))).json()
+    const body = await (await GET(req({ granularity: 'month', id: 'payroll' }))).json()
     for (const p of body.periods) {
       expect(p.amount).toBe(2000)
     }

--- a/app/api/edenred/categories.test.ts
+++ b/app/api/edenred/categories.test.ts
@@ -7,8 +7,8 @@ import { describe, expect, it } from 'vitest'
 // `transactions_monthly_summary` hace INNER JOIN sobre `categories`: un `id`
 // desconocido excluiría la tx de las agregaciones SIN error. Ver issue #101.
 // - 'restaurant': consumo (fallback del webhook en route.ts)
-// - 'income':     recarga / top-up (RECARGA en scripts/scrapers/edenred/scrape.mjs)
-const EDENRED_CATEGORIES = ['restaurant', 'income'] as const
+// - 'payroll':    recarga / top-up (RECARGA en scripts/scrapers/edenred/scrape.mjs)
+const EDENRED_CATEGORIES = ['restaurant', 'payroll'] as const
 
 const SEED_PATH = fileURLToPath(
   new URL(

--- a/app/api/edenred/route.test.ts
+++ b/app/api/edenred/route.test.ts
@@ -350,7 +350,7 @@ describe('POST /api/edenred — mapeo de category', () => {
     expect(rows[0].category).toBe('restaurant')
   })
 
-  it('respeta la category provista por el scraper (p. ej. "income" en una recarga)', async () => {
+  it('respeta la category provista por el scraper (p. ej. "payroll" en una recarga)', async () => {
     const { db, upsertSpy } = buildMockDb({
       userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
@@ -367,7 +367,7 @@ describe('POST /api/edenred — mapeo de category', () => {
           amount: 50,
           description: 'Recarga mensual',
           transaction_date: '2026-05-01',
-          category: 'income',
+          category: 'payroll',
         },
         {
           external_id: 'gasto-1',
@@ -380,7 +380,7 @@ describe('POST /api/edenred — mapeo de category', () => {
 
     const [rows] = upsertSpy.mock.calls[0]
     expect(rows).toHaveLength(2)
-    expect(rows[0].category).toBe('income')
+    expect(rows[0].category).toBe('payroll')
     expect(rows[1].category).toBe('restaurant')
   })
 })

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -136,7 +136,7 @@ export async function POST(req: Request) {
     // supabase/migrations/20260509000000_categories_type.sql). La matview
     // `transactions_monthly_summary` hace INNER JOIN sobre `categories`, así que
     // un `id` desconocido excluiría la tx de las agregaciones SIN error. El
-    // scraper sólo emite 'restaurant' e 'income', y el fallback de aquí es
+    // scraper sólo emite 'restaurant' y 'payroll', y el fallback de aquí es
     // 'restaurant'; ambos están garantizados por ese seed. Ver issue #101.
     // `is_read` se omite a propósito (issue #149): los inserts nuevos toman el
     // DEFAULT false (nacen "no leídos"), y como el upsert usa

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -13,7 +13,7 @@ const VALID_CATEGORIES: CategoryId[] = [
   'beauty', 'gifts', 'charity', 'memberships', 'taxes', 'loans', 'cash',
   'fees', 'other',
   // Ingresos
-  'income', 'returns', 'reimbursement', 'other_income',
+  'payroll', 'returns', 'reimbursement', 'other_income',
   // No Computable
   'investment', 'savings', 'transfer', 'loan_payment', 'card_payment',
 ]

--- a/components/transactions/AddTxModal.tsx
+++ b/components/transactions/AddTxModal.tsx
@@ -87,7 +87,7 @@ export function AddTxModal({ open, onOpenChange, manualAccountId, onSave }: AddT
   const isValid = !isNaN(parsedAmount) && parsedAmount > 0
 
   const categoryEntries = (Object.entries(CATEGORY_META) as [CategoryId, typeof CATEGORY_META[CategoryId]][]).filter(([id]) =>
-    type === 'ingreso' ? id === 'income' || id === 'other' : id !== 'income'
+    type === 'ingreso' ? id === 'payroll' || id === 'other' : id !== 'payroll'
   )
 
   const currentMeta = CATEGORY_META[category] ?? CATEGORY_META.other
@@ -145,10 +145,10 @@ export function AddTxModal({ open, onOpenChange, manualAccountId, onSave }: AddT
                 key={tp}
                 onClick={() => {
                   setType(tp)
-                  if (tp === 'ingreso' && category !== 'income' && category !== 'other') {
+                  if (tp === 'ingreso' && category !== 'payroll' && category !== 'other') {
                     setCategory('other')
                   }
-                  if (tp === 'gasto' && category === 'income') {
+                  if (tp === 'gasto' && category === 'payroll') {
                     setCategory('other')
                   }
                 }}

--- a/lib/categories.test.ts
+++ b/lib/categories.test.ts
@@ -36,7 +36,7 @@ const positiveCases: ReadonlyArray<readonly [string, CategoryId]> = [
   ['Seguro auto Linea Directa', 'insurance_auto'],
   ['Recibo varios 23/05', 'fees'],
   ['Pago hacienda IRPF', 'taxes'],
-  ['Nomina mayo empresa', 'income'],
+  ['Nomina mayo empresa', 'payroll'],
   ['Devolucion compra online', 'reimbursement'],
   ['Transferencia propia entre cuentas', 'transfer'],
   ['Cajero ATM Banco', 'cash'],

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -70,7 +70,7 @@ export const AUTO_RULES: { pattern: RegExp; category: CategoryId; field?: RuleFi
   // Inversión
   { pattern: /degiro|myinvestor|indexa capital|openbroker|interactive brokers|trading212|etf\b|fondo de inversion|gvc gaesco|gaesco/i, category: 'investment' },
   // Nómina e ingresos laborales
-  { pattern: /nomina|salario|payroll|haberes|retribucion/i, category: 'income' },
+  { pattern: /nomina|salario|payroll|haberes|retribucion/i, category: 'payroll' },
   // Reembolso / Devolución (antes que impuestos: "devoluciones tributarias" es una devolución)
   { pattern: /devolucion|reembolso|devoluciones tributarias/i, category: 'reimbursement' },
   // Impuestos y tasas (ayuntamiento / organisme tributari)

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -91,7 +91,7 @@ export const CATEGORY_COLORS: Record<CategoryId, string> = {
   fees:           '#94a3b8',
   other:          '#64748b',
   // Ingresos
-  income:         '#3b82f6',
+  payroll:        '#3b82f6',
   returns:        '#0284c7',
   reimbursement:  '#16a34a',
   other_income:   '#6366f1',
@@ -149,7 +149,7 @@ export const CATEGORY_META: Record<CategoryId, CategoryMeta> = {
   fees:           { label: 'Comisiones',            color: '#94a3b8', type: 'expense',         Icon: Landmark        },
   other:          { label: 'Otros gastos',          color: '#64748b', type: 'expense',         Icon: MoreHorizontal  },
   // ── Ingresos ────────────────────────────────────────────────────────────────
-  income:         { label: 'Nómina',                color: '#3b82f6', type: 'income',          Icon: TrendingUp      },
+  payroll:        { label: 'Nómina',                color: '#3b82f6', type: 'income',          Icon: TrendingUp      },
   returns:        { label: 'Rendimientos',          color: '#0284c7', type: 'income',          Icon: BarChart3       },
   reimbursement:  { label: 'Reembolso',             color: '#16a34a', type: 'income',          Icon: RotateCcw       },
   other_income:   { label: 'Otros ingresos',        color: '#6366f1', type: 'income',          Icon: CirclePlus      },

--- a/scripts/scrapers/edenred/scrape.mjs
+++ b/scripts/scrapers/edenred/scrape.mjs
@@ -201,10 +201,10 @@ async function extractTransactions(page) {
     // nómina), todo lo demás es consumo en restaurante.
     // Las categorías deben coincidir con un `id` del seed de la tabla
     // `categories` (supabase/migrations/20260509000000_categories_type.sql):
-    // 'income' (Nómina) para la recarga y 'restaurant' (expense) para el consumo.
+    // 'payroll' (Nómina) para la recarga y 'restaurant' (expense) para el consumo.
     const isRecarga = description.toUpperCase() === 'RECARGA'
     const amount = isRecarga ? parseAmount(rawAmount) : -parseAmount(rawAmount)
-    const category = isRecarga ? 'income' : 'restaurant'
+    const category = isRecarga ? 'payroll' : 'restaurant'
 
     // external_id estable: fecha + hora (resolución de segundos). Si dos
     // movimientos colisionasen en el mismo segundo, el upsert los trataría

--- a/supabase/migrations/20260509000000_categories_type.sql
+++ b/supabase/migrations/20260509000000_categories_type.sql
@@ -48,7 +48,7 @@ INSERT INTO categories (id, name, color, type, sort_order) VALUES
   ('other',          'Otros gastos',           '#64748b', 'expense',        33),
 
 -- ─── INGRESOS ────────────────────────────────────────────────────────────────
-  ('income',         'Nómina',                 '#3b82f6', 'income',         34),
+  ('payroll',        'Nómina',                 '#3b82f6', 'income',         34),
   ('returns',        'Rendimientos',           '#0284c7', 'income',         35),
   ('reimbursement',  'Reembolso',              '#16a34a', 'income',         36),
   ('other_income',   'Otros ingresos',         '#6366f1', 'income',         37),

--- a/supabase/migrations/20260611000000_rename_income_category_to_payroll.sql
+++ b/supabase/migrations/20260611000000_rename_income_category_to_payroll.sql
@@ -1,0 +1,40 @@
+-- Renombrar el `id` de la categoría 'income' (name "Nómina") → 'payroll'.
+-- Ref: issue #151.
+--
+-- Motivo: el string 'income' se usaba con dos significados (el `type` que agrupa
+-- todos los ingresos, y el `id` de la categoría concreta "Nómina"), lo que
+-- resultaba ambiguo. Se renombra SOLO el `id`; el `type 'income'` permanece igual.
+--
+-- FK: categorization_rules.category_id referencia categories.id (sin ON UPDATE
+-- CASCADE); transactions.category / category_manual NO tienen FK. Por eso el
+-- orden es alta → repunte de referencias → baja, como en
+-- 20260609000000_categories_revision.sql.
+--
+-- Mantener en sincronía con el seed (20260509000000_categories_type.sql), que ya
+-- siembra 'payroll' para instalaciones nuevas.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- 1. Alta de la nueva fila 'payroll' (clon de 'income'/Nómina)
+-- ============================================================
+INSERT INTO categories (id, name, color, type, sort_order)
+VALUES ('payroll', 'Nómina', '#3b82f6', 'income', 34)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 2. Repuntar referencias al nuevo id
+-- ============================================================
+UPDATE transactions         SET category        = 'payroll' WHERE category        = 'income';
+UPDATE transactions         SET category_manual = 'payroll' WHERE category_manual = 'income';
+UPDATE categorization_rules SET category_id     = 'payroll' WHERE category_id     = 'income';
+
+-- ============================================================
+-- 3. Baja de la vieja fila (ya sin referencias)
+-- ============================================================
+DELETE FROM categories WHERE id = 'income';
+
+-- ============================================================
+-- 4. Refrescar la vista materializada de analítica
+-- ============================================================
+REFRESH MATERIALIZED VIEW transactions_monthly_summary;

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,7 +41,7 @@ export type CategoryId =
   | 'fees'
   | 'other'
   // Ingresos
-  | 'income'
+  | 'payroll'
   | 'returns'
   | 'reimbursement'
   | 'other_income'


### PR DESCRIPTION
Closes #151

## Contexto

El string `'income'` se usaba con **dos significados** distintos, lo que resultaba ambiguo:

- Como **`type`** de categoría (`categories.type = 'income'`): agrupa *todos* los ingresos. ✅ **No se toca.**
- Como **`id`** de la categoría concreta "Nómina" (`categories.id = 'income'`): choca conceptualmente con el `type`. ❌

Se renombra **solo el `id`** `'income'` → `'payroll'`, alineándolo con la convención de identificadores en inglés y eliminando la ambigüedad.

## Cambios

**Código**
- `types/index.ts` — union `CategoryId`
- `app/api/transactions/[id]/route.ts` — `VALID_CATEGORIES`
- `lib/categories.ts` — salida de la regla de nómina en `AUTO_RULES` (+ test)
- `lib/theme.ts` — claves `CATEGORY_COLORS` y `CATEGORY_META` (label "Nómina" y `type: 'income'` intactos)
- `components/transactions/AddTxModal.tsx` — filtros id vs type (3 sitios)
- `scripts/scrapers/edenred/scrape.mjs` — RECARGA emite `'payroll'`
- `app/api/edenred/route.ts` — comentario; tests de regresión `edenred/*` y `analytics/category`

**Base de datos**
- `supabase/migrations/20260509000000_categories_type.sql` — seed (instalaciones nuevas)
- `supabase/migrations/20260611000000_rename_income_category_to_payroll.sql` — **nueva** migración de datos para instalaciones existentes. Patrón alta → repunte de referencias → baja (respeta la FK `categorization_rules.category_id`, sin FK en `transactions.category`), siguiendo el precedente de `20260609000000_categories_revision.sql`.

> ⚠️ La migración de datos debe ejecutarse manualmente en el **SQL Editor de Supabase** tras el merge.

## Validación
- `pnpm test` ✅ 309 passed
- `pnpm lint` ✅
- `pnpm build` ✅
- `grep` de referencias restantes: todas son `type 'income'` o el campo agregado `income`, ninguna es el `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)