### PR TITLE
fix(security): revocar EXECUTE de refresh_monthly_summary a anon/authenticated (#179)

### DIFF
--- a/supabase/migrations/20260613000001_revoke_refresh_monthly_summary_execute.sql
+++ b/supabase/migrations/20260613000001_revoke_refresh_monthly_summary_execute.sql
@@ -1,0 +1,12 @@
+-- Issue #179 (seguridad): refresh_monthly_summary() (SECURITY DEFINER) era ejecutable
+-- por anon/authenticated por defecto. Como las funciones de `public` quedan ejecutables
+-- por esos roles en Supabase y no había REVOKE, cualquier usuario con sesión válida podía
+-- invocar el RPC (POST /rest/v1/rpc/refresh_monthly_summary) y forzar repetidamente un
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary, operación cara
+-- (DoS barato sobre la BBDD).
+--
+-- Mitigación: revocar EXECUTE a anon/authenticated. La función solo se invoca desde las
+-- syncs (sabadell-visa, enablebanking, cron) con el service role, que no se ve afectado
+-- por este REVOKE. A diferencia de #178 (get_period_data, llamada por /api/analytics con
+-- rol authenticated), aquí revocar no rompe ningún flujo de la app.
+REVOKE EXECUTE ON FUNCTION refresh_monthly_summary() FROM anon, authenticated;


### PR DESCRIPTION
Cierra #179.

## Problema
`refresh_monthly_summary()` está definida como `SECURITY DEFINER` y, como las funciones de `public` quedan ejecutables por `anon`/`authenticated` por defecto en Supabase (sin `REVOKE`), cualquier usuario autenticado podía invocar:

```
POST /rest/v1/rpc/refresh_monthly_summary
```

Cada llamada dispara un `REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary`, operación cara → llamadas repetidas = DoS barato sobre la BBDD. Severidad: baja.

## Solución
Nueva migración `supabase/migrations/20260613000001_revoke_refresh_monthly_summary_execute.sql`:

```sql
REVOKE EXECUTE ON FUNCTION refresh_monthly_summary() FROM anon, authenticated;
```

Los 3 únicos invocadores (`sabadell-visa`, `sync/enablebanking`, `sync/enablebanking/cron`) usan `createServiceClient()` (service role), no afectado por el REVOKE. `mark_internal_transfers` ya fue eliminada en `20260516000000`, así que esta es la única función afectada.

## Aplicación en Supabase
⚠️ Ejecutar el SQL de la migración en el **SQL Editor** del proyecto Supabase (las migraciones son la fuente de verdad pero se aplican manualmente).

## Validaciones
- `pnpm test` → 316 passed
- `pnpm lint` → limpio
- `pnpm build` → OK

No se toca código TS ni tests (el test de sabadell-visa mockea `rpc`).

## Criterios de aceptación
- [x] El REVOKE impide que un usuario `authenticated` invoque `refresh_monthly_summary` por RPC (verificar tras aplicar en Supabase).
- [x] Las syncs (cron, enablebanking, sabadell-visa) siguen refrescando la matview vía service role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)