### PR TITLE
fix(security): fijar SET search_path en refresh_monthly_summary (#180)

### DIFF
--- a/supabase/migrations/20260613000002_fix_refresh_monthly_summary_search_path.sql
+++ b/supabase/migrations/20260613000002_fix_refresh_monthly_summary_search_path.sql
@@ -1,0 +1,23 @@
+-- Issue #180 (seguridad, hardening): refresh_monthly_summary() (SECURITY DEFINER) no fijaba
+-- search_path, lo que la exponía a search_path injection (ver current_household_ids en
+-- 20260603000000_households.sql, que sí lo fija). Es la única DEFINER de public que faltaba:
+-- get_period_data ya lo añadió en #178 (20260613000000).
+--
+-- Solo se añade SET search_path = public; el cuerpo es idéntico a 20260507000000_sync_helpers.sql.
+-- CREATE OR REPLACE preserva los permisos, así que el REVOKE de #179 (20260613000001) sigue
+-- vigente; se re-incluye como defensa explícita.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+CREATE OR REPLACE FUNCTION refresh_monthly_summary()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION refresh_monthly_summary() FROM anon, authenticated;


### PR DESCRIPTION
Closes #180

## Contexto
Las funciones `SECURITY DEFINER` sin `SET search_path` quedan expuestas a *search_path injection*. Auditando todas las DEFINER del esquema `public`:

| Función | Estado |
|---|---|
| `get_period_data` | ✅ ya lo añadió #178 |
| `current_household_ids()` | ✅ ya lo tenía |
| `mark_internal_transfers` | N/A — eliminada en `20260516000000` |
| `update_updated_at_column` | fuera de alcance — es `SECURITY INVOKER` |
| **`refresh_monthly_summary()`** | ❌ era la única pendiente |

## Cambio
Nueva migración `20260613000002_fix_refresh_monthly_summary_search_path.sql` que hace `CREATE OR REPLACE` de `refresh_monthly_summary()` con cuerpo idéntico, añadiendo `SET search_path = public`. Se re-incluye el `REVOKE EXECUTE ... FROM anon, authenticated` de #179 como defensa explícita (CREATE OR REPLACE preserva permisos, pero deja la migración autocontenida).

No cambia firma ni lógica, así que las syncs que la invocan con service role no se ven afectadas.

## Verificación
- `pnpm test` (316 ok), `pnpm lint`, `pnpm build` ✅
- Pendiente: aplicar la migración en el **Supabase SQL Editor** (mismo flujo que #178/#179) y confirmar con:
  ```sql
  SELECT proname, proconfig FROM pg_proc
  WHERE proname IN ('refresh_monthly_summary','get_period_data','current_household_ids');
  ```
  `proconfig` debe contener `search_path=public` en las tres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)