### PR TITLE
fix(security): validar parámetro `next` en /auth/callback contra open redirect

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { sanitizeNext } from './sanitize-next'
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/'
+  const next = sanitizeNext(searchParams.get('next') ?? '/')
 
   if (code) {
     const supabase = await createClient()

--- a/app/auth/callback/sanitize-next.test.ts
+++ b/app/auth/callback/sanitize-next.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeNext } from './sanitize-next'
+
+describe('sanitizeNext', () => {
+  it('cae al fallback "/" con destinos externos', () => {
+    expect(sanitizeNext('@evil.com')).toBe('/')
+    expect(sanitizeNext('//evil.com')).toBe('/')
+    expect(sanitizeNext('/\\evil.com')).toBe('/')
+    expect(sanitizeNext('https://evil.com')).toBe('/')
+    expect(sanitizeNext('http://evil.com')).toBe('/')
+  })
+
+  it('conserva rutas internas relativas legítimas', () => {
+    expect(sanitizeNext('/')).toBe('/')
+    expect(sanitizeNext('/dashboard')).toBe('/dashboard')
+    expect(sanitizeNext('/transactions?month=2026-06')).toBe(
+      '/transactions?month=2026-06'
+    )
+  })
+})

--- a/app/auth/callback/sanitize-next.ts
+++ b/app/auth/callback/sanitize-next.ts
@@ -1,0 +1,11 @@
+/**
+ * Garantiza que el destino post-login sea una ruta interna relativa.
+ * Rechaza rutas externas: protocol-relative (`//host`), backslash trick
+ * (`/\host`) y cualquier valor que no empiece por `/`.
+ */
+export function sanitizeNext(raw: string): string {
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.startsWith('/\\')) {
+    return '/'
+  }
+  return raw
+}


### PR DESCRIPTION
Closes #181

## Problema

En `app/auth/callback/route.ts` el parámetro `next` del query string se concatenaba al `origin` sin validar (`${origin}${next}`). Valores como `@evil.com` (→ `https://app.com@evil.com`), `//evil.com` o `https://…` permitían un open redirect tras el intercambio OAuth.

## Solución

- Nuevo helper puro `sanitizeNext` en `app/auth/callback/sanitize-next.ts`: solo admite rutas internas relativas; cualquier otro destino cae al fallback `/`.
- Bloquea `//host`, el truco backslash `/\host` (que algunos navegadores normalizan a `//`), `@host` y URLs absolutas.
- El handler usa `sanitizeNext(searchParams.get('next') ?? '/')`.
- Test unitario co-localizado cubriendo los criterios de aceptación.

El helper vive en un módulo aparte porque Next.js no permite exports arbitrarios en ficheros `route.ts`.

## Criterios de aceptación

- [x] `next` con destino externo (`@host`, `//host`, `/\host`, `https://…`) cae al fallback `/`.
- [x] El redirect a rutas internas legítimas sigue funcionando.

## Validación

- `pnpm test` — 318 tests pasan (incluye los nuevos de `sanitizeNext`).
- `pnpm lint` — sin errores.
- `pnpm build` — compila correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)