### PR TITLE
fix(security): validar regex de reglas de categorización contra ReDoS (#182)

### DIFF
--- a/lib/categories/rules.test.ts
+++ b/lib/categories/rules.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { categorize } from './rules'
+import {
+  categorize,
+  categorizeWithRules,
+  validateRulePattern,
+  MAX_PATTERN_LENGTH,
+  type DbCategorizationRule,
+} from './rules'
 import type { CategoryId } from './catalog'
 
 // Casos positivos: una fila por cada categoría cubierta por AUTO_RULES.
@@ -207,5 +213,82 @@ describe('categorize', () => {
     it('devuelve null para descripción vacía', () => {
       expect(categorize('')).toBeNull()
     })
+  })
+})
+
+describe('validateRulePattern (issue #182)', () => {
+  it.each([
+    'glovo',
+    'mercadona|carrefour|lidl',
+    'amazon\\b',
+    'cafeter[ií]a',
+    'cuota \\d{1,4}',
+  ])('acepta patrones legítimos: %j', pattern => {
+    expect(validateRulePattern(pattern)).toEqual({ ok: true })
+  })
+
+  it('rechaza patrón vacío', () => {
+    expect(validateRulePattern('')).toEqual({ ok: false, reason: 'empty' })
+  })
+
+  it('rechaza patrón demasiado largo', () => {
+    const pattern = 'a'.repeat(MAX_PATTERN_LENGTH + 1)
+    expect(validateRulePattern(pattern)).toEqual({ ok: false, reason: 'too_long' })
+  })
+
+  it('acepta un patrón justo en el límite de longitud', () => {
+    const pattern = 'a'.repeat(MAX_PATTERN_LENGTH)
+    expect(validateRulePattern(pattern)).toEqual({ ok: true })
+  })
+
+  it('rechaza regex con sintaxis inválida', () => {
+    expect(validateRulePattern('(')).toEqual({ ok: false, reason: 'invalid_syntax' })
+    expect(validateRulePattern('[a-')).toEqual({ ok: false, reason: 'invalid_syntax' })
+  })
+
+  it.each([
+    '(a+)+$',
+    '(a*)*',
+    '(a+)*',
+    '((a)+)+',
+    '(\\d+){2,}',
+  ])('rechaza ReDoS por cuantificadores anidados: %j', pattern => {
+    expect(validateRulePattern(pattern)).toEqual({ ok: false, reason: 'unsafe_complexity' })
+  })
+})
+
+describe('categorizeWithRules (issue #182)', () => {
+  it('omite una regla con riesgo de ReDoS y resuelve rápido', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: '(a+)+$', field: 'description', category_id: 'shopping' },
+    ]
+    const malicious = 'a'.repeat(40) + '!'
+    const start = performance.now()
+    // La regla peligrosa se omite; cae al fallback estático (sin match aquí).
+    expect(categorizeWithRules(dbRules, malicious)).toBeNull()
+    expect(performance.now() - start).toBeLessThan(1000)
+  })
+
+  it('omite la regla inválida pero aplica el resto de reglas válidas', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: '(', field: 'description', category_id: 'shopping' },
+      { pattern: 'cafe-club', field: 'description', category_id: 'leisure' },
+    ]
+    expect(categorizeWithRules(dbRules, 'pago en cafe-club')).toBe('leisure')
+  })
+
+  it('una dbRule válida gana al fallback estático (regresión)', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: 'mercadona', field: 'description', category_id: 'restaurant' },
+    ]
+    // Sin reglas, "Mercadona" sería groceries; la regla del hogar lo reasigna.
+    expect(categorizeWithRules(dbRules, 'Compra Mercadona')).toBe('restaurant')
+  })
+
+  it('cae al fallback estático cuando ninguna dbRule casa', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: 'inexistente', field: 'description', category_id: 'shopping' },
+    ]
+    expect(categorizeWithRules(dbRules, 'Compra Mercadona')).toBe('groceries')
   })
 })

--- a/lib/categories/rules.ts
+++ b/lib/categories/rules.ts
@@ -100,6 +100,78 @@ export interface DbCategorizationRule {
   category_id: string
 }
 
+// Longitud máxima de un patrón de regla. Debe mantenerse sincronizada con el
+// CHECK de la tabla `categorization_rules` (migración pattern_length).
+export const MAX_PATTERN_LENGTH = 200
+// Las descripciones bancarias son cortas; acotamos la cadena objetivo como cota
+// defensiva extra para el peor caso de backtracking.
+const MAX_TARGET_LENGTH = 500
+
+export type PatternValidation = { ok: true } | { ok: false; reason: string }
+
+// ¿hay un cuantificador no acotado (`+`, `*`, `{n,}`) "vivo" en el texto?
+// Ignora los escapados (`\+`, `\*`) y los que están dentro de una clase `[...]`.
+function containsUnboundedQuantifier(s: string): boolean {
+  let inClass = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === '\\') { i++; continue }
+    if (inClass) { if (ch === ']') inClass = false; continue }
+    if (ch === '[') { inClass = true; continue }
+    if (ch === '+' || ch === '*') return true
+    if (ch === '{') {
+      const close = s.indexOf('}', i)
+      if (close !== -1 && /^\d+,$/.test(s.slice(i + 1, close))) return true
+    }
+  }
+  return false
+}
+
+// Detecta repetición anidada no acotada (star-height > 1), el patrón canónico del
+// backtracking exponencial: un grupo `(...)` seguido de un cuantificador no acotado
+// (`+`, `*`, `{n,}`) cuyo contenido contiene a su vez otro cuantificador no acotado.
+// P.ej. (a+)+, (a*)*, (a+)*, ((a)+)+ … Escanea con una pila respetando escapes y
+// clases de caracteres. Heurística conservadora: el cap de longitud es el backstop
+// duro si esto tiene un falso negativo; un falso positivo solo omite una regla.
+function hasNestedUnboundedQuantifier(pattern: string): boolean {
+  const stack: number[] = []
+  let inClass = false
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i]
+    if (ch === '\\') { i++; continue }
+    if (inClass) { if (ch === ']') inClass = false; continue }
+    if (ch === '[') { inClass = true; continue }
+    if (ch === '(') {
+      stack.push(i)
+    } else if (ch === ')') {
+      const open = stack.pop()
+      if (open === undefined) continue
+      const next = pattern[i + 1]
+      let unbounded = next === '+' || next === '*'
+      if (next === '{') {
+        const close = pattern.indexOf('}', i + 1)
+        if (close !== -1 && /^\d+,$/.test(pattern.slice(i + 2, close))) unbounded = true
+      }
+      if (unbounded && containsUnboundedQuantifier(pattern.slice(open + 1, i))) return true
+    }
+  }
+  return false
+}
+
+// Valida un patrón de regla antes de compilarlo/ejecutarlo. Fuente única de verdad,
+// reutilizable por la futura UI de gestión de reglas (§14.1/§14.2 del spec).
+export function validateRulePattern(pattern: string): PatternValidation {
+  if (!pattern) return { ok: false, reason: 'empty' }
+  if (pattern.length > MAX_PATTERN_LENGTH) return { ok: false, reason: 'too_long' }
+  try {
+    new RegExp(pattern, 'i')
+  } catch {
+    return { ok: false, reason: 'invalid_syntax' }
+  }
+  if (hasNestedUnboundedQuantifier(pattern)) return { ok: false, reason: 'unsafe_complexity' }
+  return { ok: true }
+}
+
 export function categorize(description: string, merchant?: string): CategoryId | null {
   for (const rule of AUTO_RULES) {
     const target = rule.field === 'merchant' ? (merchant ?? '') : description
@@ -114,7 +186,16 @@ export function categorizeWithRules(
   merchant?: string
 ): CategoryId | null {
   for (const rule of dbRules) {
-    const target = rule.field === 'merchant' ? (merchant ?? '') : description
+    // Tolerante a fallo: una regla inválida o con riesgo de ReDoS se OMITE en vez
+    // de colgar el sync (ver issue #182). La validez/complejidad se comprueba con el
+    // mismo validador que usará la UI de gestión de reglas.
+    const validation = validateRulePattern(rule.pattern)
+    if (!validation.ok) {
+      console.warn(`[categorizeWithRules] regla omitida (${validation.reason})`)
+      continue
+    }
+    const rawTarget = rule.field === 'merchant' ? (merchant ?? '') : description
+    const target = rawTarget.slice(0, MAX_TARGET_LENGTH)
     if (target && new RegExp(rule.pattern, 'i').test(target)) {
       return rule.category_id as CategoryId
     }

--- a/supabase/migrations/20260613000003_categorization_rules_pattern_length.sql
+++ b/supabase/migrations/20260613000003_categorization_rules_pattern_length.sql
@@ -1,0 +1,8 @@
+-- ReDoS hardening (issue #182): acota la longitud del patrón de regla en el único
+-- límite de escritura real. La validez/complejidad de la regex se valida en la app
+-- (lib/categories/rules.ts → validateRulePattern); no es práctico en SQL.
+-- Mantener el 200 sincronizado con MAX_PATTERN_LENGTH.
+
+ALTER TABLE categorization_rules
+  ADD CONSTRAINT categorization_rules_pattern_len
+  CHECK (char_length(pattern) BETWEEN 1 AND 200);


### PR DESCRIPTION
Cierra #182.

## Problema
`categorizeWithRules` ([lib/categories/rules.ts](https://github.com/MrClit/fin-app/blob/develop/lib/categories/rules.ts#L111-L123)) compilaba `new RegExp(rule.pattern, 'i')` con patrones provenientes de la tabla `categorization_rules` (editables por el hogar) y los ejecutaba durante el sync con el **service role**. Un patrón con *catastrophic backtracking* (p.ej. `(a+)+$`) podía colgar el proceso de sync (ReDoS). Severidad baja, pero el sync no debe poder quedar colgado.

Las tres rutas de sync (`enablebanking`, `enablebanking/cron`, `sabadell-visa`) pasan todas por esta única función, así que endurecerla las protege a todas. Todavía no existe UI/endpoint de creación-edición de reglas (diferido en el spec §14.1/§14.2).

## Cambios
- **Validador reutilizable `validateRulePattern`** (fuente única de verdad, lista para la futura UI):
  - Cap de longitud `MAX_PATTERN_LENGTH = 200`.
  - Compilación correcta (`try/catch` sobre `new RegExp`).
  - Análisis estático de complejidad: rechaza cuantificadores anidados no acotados (star-height > 1: `(a+)+`, `(a*)*`, `((a)+)+`, `(\d+){2,}`…) mediante un escáner que respeta escapes y clases de caracteres.
- **`categorizeWithRules` tolerante a fallo**: omite reglas inválidas o peligrosas (no cuelga el sync) y acota la cadena objetivo. Las reglas válidas siguen funcionando igual; se mantiene el fallback a las reglas estáticas.
- **Migración** `20260613000003_categorization_rules_pattern_length.sql`: `CHECK (char_length(pattern) BETWEEN 1 AND 200)` como defensa en profundidad en el único límite de escritura real.
- **Tests**: validador (acepta legítimos; rechaza vacío, demasiado largo, sintaxis inválida y ReDoS clásicos) + comportamiento tolerante a fallo de `categorizeWithRules` (la regla peligrosa se omite y resuelve en ms, el resto de reglas válidas siguen aplicándose).

## Criterios de aceptación
- [x] Un patrón inválido o excesivamente largo se rechaza (longitud en BD; validez+complejidad en ejecución vía `validateRulePattern`, reutilizable por la UI cuando se implemente).
- [x] La sync no puede quedar colgada por una regla de un hogar (reglas peligrosas se omiten).

## Verificación
- `pnpm test` → 336 ✓ (incluye caso ReDoS que resuelve en milisegundos)
- `pnpm lint` ✓ · `pnpm build` ✓

## Fuera de alcance
- UI/endpoint de gestión de reglas (§14.1/§14.2). Reutilizará `validateRulePattern` cuando se construya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)