### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Bump de versión `0.1.0` → `0.1.1` para el release a producción.

Inicia el versionado semántico (SemVer + tags git) del proyecto. Esta versión es un **patch** porque agrupa únicamente correcciones de seguridad:

- #178 — validar pertenencia al hogar en `get_period_data`
- #179 — revocar EXECUTE de `refresh_monthly_summary` a anon/authenticated
- #180 — fijar `SET search_path` en `refresh_monthly_summary`
- #191 — validar parámetro `next` en `/auth/callback` contra open redirect
- #182 — validar regex de reglas de categorización contra ReDoS

Tras mergear este PR a `develop`, se abrirá el PR `develop` → `main` y se etiquetará `v0.1.1` en `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)