### PR TITLE
Release v0.1.1

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { sanitizeNext } from './sanitize-next'
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/'
+  const next = sanitizeNext(searchParams.get('next') ?? '/')
 
   if (code) {
     const supabase = await createClient()

--- a/app/auth/callback/sanitize-next.test.ts
+++ b/app/auth/callback/sanitize-next.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeNext } from './sanitize-next'
+
+describe('sanitizeNext', () => {
+  it('cae al fallback "/" con destinos externos', () => {
+    expect(sanitizeNext('@evil.com')).toBe('/')
+    expect(sanitizeNext('//evil.com')).toBe('/')
+    expect(sanitizeNext('/\\evil.com')).toBe('/')
+    expect(sanitizeNext('https://evil.com')).toBe('/')
+    expect(sanitizeNext('http://evil.com')).toBe('/')
+  })
+
+  it('conserva rutas internas relativas legítimas', () => {
+    expect(sanitizeNext('/')).toBe('/')
+    expect(sanitizeNext('/dashboard')).toBe('/dashboard')
+    expect(sanitizeNext('/transactions?month=2026-06')).toBe(
+      '/transactions?month=2026-06'
+    )
+  })
+})

--- a/app/auth/callback/sanitize-next.ts
+++ b/app/auth/callback/sanitize-next.ts
@@ -1,0 +1,11 @@
+/**
+ * Garantiza que el destino post-login sea una ruta interna relativa.
+ * Rechaza rutas externas: protocol-relative (`//host`), backslash trick
+ * (`/\host`) y cualquier valor que no empiece por `/`.
+ */
+export function sanitizeNext(raw: string): string {
+  if (!raw.startsWith('/') || raw.startsWith('//') || raw.startsWith('/\\')) {
+    return '/'
+  }
+  return raw
+}

--- a/lib/categories/rules.test.ts
+++ b/lib/categories/rules.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { categorize } from './rules'
+import {
+  categorize,
+  categorizeWithRules,
+  validateRulePattern,
+  MAX_PATTERN_LENGTH,
+  type DbCategorizationRule,
+} from './rules'
 import type { CategoryId } from './catalog'
 
 // Casos positivos: una fila por cada categoría cubierta por AUTO_RULES.
@@ -207,5 +213,82 @@ describe('categorize', () => {
     it('devuelve null para descripción vacía', () => {
       expect(categorize('')).toBeNull()
     })
+  })
+})
+
+describe('validateRulePattern (issue #182)', () => {
+  it.each([
+    'glovo',
+    'mercadona|carrefour|lidl',
+    'amazon\\b',
+    'cafeter[ií]a',
+    'cuota \\d{1,4}',
+  ])('acepta patrones legítimos: %j', pattern => {
+    expect(validateRulePattern(pattern)).toEqual({ ok: true })
+  })
+
+  it('rechaza patrón vacío', () => {
+    expect(validateRulePattern('')).toEqual({ ok: false, reason: 'empty' })
+  })
+
+  it('rechaza patrón demasiado largo', () => {
+    const pattern = 'a'.repeat(MAX_PATTERN_LENGTH + 1)
+    expect(validateRulePattern(pattern)).toEqual({ ok: false, reason: 'too_long' })
+  })
+
+  it('acepta un patrón justo en el límite de longitud', () => {
+    const pattern = 'a'.repeat(MAX_PATTERN_LENGTH)
+    expect(validateRulePattern(pattern)).toEqual({ ok: true })
+  })
+
+  it('rechaza regex con sintaxis inválida', () => {
+    expect(validateRulePattern('(')).toEqual({ ok: false, reason: 'invalid_syntax' })
+    expect(validateRulePattern('[a-')).toEqual({ ok: false, reason: 'invalid_syntax' })
+  })
+
+  it.each([
+    '(a+)+$',
+    '(a*)*',
+    '(a+)*',
+    '((a)+)+',
+    '(\\d+){2,}',
+  ])('rechaza ReDoS por cuantificadores anidados: %j', pattern => {
+    expect(validateRulePattern(pattern)).toEqual({ ok: false, reason: 'unsafe_complexity' })
+  })
+})
+
+describe('categorizeWithRules (issue #182)', () => {
+  it('omite una regla con riesgo de ReDoS y resuelve rápido', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: '(a+)+$', field: 'description', category_id: 'shopping' },
+    ]
+    const malicious = 'a'.repeat(40) + '!'
+    const start = performance.now()
+    // La regla peligrosa se omite; cae al fallback estático (sin match aquí).
+    expect(categorizeWithRules(dbRules, malicious)).toBeNull()
+    expect(performance.now() - start).toBeLessThan(1000)
+  })
+
+  it('omite la regla inválida pero aplica el resto de reglas válidas', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: '(', field: 'description', category_id: 'shopping' },
+      { pattern: 'cafe-club', field: 'description', category_id: 'leisure' },
+    ]
+    expect(categorizeWithRules(dbRules, 'pago en cafe-club')).toBe('leisure')
+  })
+
+  it('una dbRule válida gana al fallback estático (regresión)', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: 'mercadona', field: 'description', category_id: 'restaurant' },
+    ]
+    // Sin reglas, "Mercadona" sería groceries; la regla del hogar lo reasigna.
+    expect(categorizeWithRules(dbRules, 'Compra Mercadona')).toBe('restaurant')
+  })
+
+  it('cae al fallback estático cuando ninguna dbRule casa', () => {
+    const dbRules: DbCategorizationRule[] = [
+      { pattern: 'inexistente', field: 'description', category_id: 'shopping' },
+    ]
+    expect(categorizeWithRules(dbRules, 'Compra Mercadona')).toBe('groceries')
   })
 })

--- a/lib/categories/rules.ts
+++ b/lib/categories/rules.ts
@@ -100,6 +100,78 @@ export interface DbCategorizationRule {
   category_id: string
 }
 
+// Longitud máxima de un patrón de regla. Debe mantenerse sincronizada con el
+// CHECK de la tabla `categorization_rules` (migración pattern_length).
+export const MAX_PATTERN_LENGTH = 200
+// Las descripciones bancarias son cortas; acotamos la cadena objetivo como cota
+// defensiva extra para el peor caso de backtracking.
+const MAX_TARGET_LENGTH = 500
+
+export type PatternValidation = { ok: true } | { ok: false; reason: string }
+
+// ¿hay un cuantificador no acotado (`+`, `*`, `{n,}`) "vivo" en el texto?
+// Ignora los escapados (`\+`, `\*`) y los que están dentro de una clase `[...]`.
+function containsUnboundedQuantifier(s: string): boolean {
+  let inClass = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === '\\') { i++; continue }
+    if (inClass) { if (ch === ']') inClass = false; continue }
+    if (ch === '[') { inClass = true; continue }
+    if (ch === '+' || ch === '*') return true
+    if (ch === '{') {
+      const close = s.indexOf('}', i)
+      if (close !== -1 && /^\d+,$/.test(s.slice(i + 1, close))) return true
+    }
+  }
+  return false
+}
+
+// Detecta repetición anidada no acotada (star-height > 1), el patrón canónico del
+// backtracking exponencial: un grupo `(...)` seguido de un cuantificador no acotado
+// (`+`, `*`, `{n,}`) cuyo contenido contiene a su vez otro cuantificador no acotado.
+// P.ej. (a+)+, (a*)*, (a+)*, ((a)+)+ … Escanea con una pila respetando escapes y
+// clases de caracteres. Heurística conservadora: el cap de longitud es el backstop
+// duro si esto tiene un falso negativo; un falso positivo solo omite una regla.
+function hasNestedUnboundedQuantifier(pattern: string): boolean {
+  const stack: number[] = []
+  let inClass = false
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i]
+    if (ch === '\\') { i++; continue }
+    if (inClass) { if (ch === ']') inClass = false; continue }
+    if (ch === '[') { inClass = true; continue }
+    if (ch === '(') {
+      stack.push(i)
+    } else if (ch === ')') {
+      const open = stack.pop()
+      if (open === undefined) continue
+      const next = pattern[i + 1]
+      let unbounded = next === '+' || next === '*'
+      if (next === '{') {
+        const close = pattern.indexOf('}', i + 1)
+        if (close !== -1 && /^\d+,$/.test(pattern.slice(i + 2, close))) unbounded = true
+      }
+      if (unbounded && containsUnboundedQuantifier(pattern.slice(open + 1, i))) return true
+    }
+  }
+  return false
+}
+
+// Valida un patrón de regla antes de compilarlo/ejecutarlo. Fuente única de verdad,
+// reutilizable por la futura UI de gestión de reglas (§14.1/§14.2 del spec).
+export function validateRulePattern(pattern: string): PatternValidation {
+  if (!pattern) return { ok: false, reason: 'empty' }
+  if (pattern.length > MAX_PATTERN_LENGTH) return { ok: false, reason: 'too_long' }
+  try {
+    new RegExp(pattern, 'i')
+  } catch {
+    return { ok: false, reason: 'invalid_syntax' }
+  }
+  if (hasNestedUnboundedQuantifier(pattern)) return { ok: false, reason: 'unsafe_complexity' }
+  return { ok: true }
+}
+
 export function categorize(description: string, merchant?: string): CategoryId | null {
   for (const rule of AUTO_RULES) {
     const target = rule.field === 'merchant' ? (merchant ?? '') : description
@@ -114,7 +186,16 @@ export function categorizeWithRules(
   merchant?: string
 ): CategoryId | null {
   for (const rule of dbRules) {
-    const target = rule.field === 'merchant' ? (merchant ?? '') : description
+    // Tolerante a fallo: una regla inválida o con riesgo de ReDoS se OMITE en vez
+    // de colgar el sync (ver issue #182). La validez/complejidad se comprueba con el
+    // mismo validador que usará la UI de gestión de reglas.
+    const validation = validateRulePattern(rule.pattern)
+    if (!validation.ok) {
+      console.warn(`[categorizeWithRules] regla omitida (${validation.reason})`)
+      continue
+    }
+    const rawTarget = rule.field === 'merchant' ? (merchant ?? '') : description
+    const target = rawTarget.slice(0, MAX_TARGET_LENGTH)
     if (target && new RegExp(rule.pattern, 'i').test(target)) {
       return rule.category_id as CategoryId
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/supabase/migrations/20260613000000_fix_get_period_data_household_guard.sql
+++ b/supabase/migrations/20260613000000_fix_get_period_data_household_guard.sql
@@ -1,0 +1,69 @@
+-- Issue #178 (seguridad): get_period_data (SECURITY DEFINER) no validaba pertenencia al hogar.
+--
+-- La función salta la RLS (SECURITY DEFINER) y filtra por el p_household_id recibido sin
+-- comprobar que auth.uid() pertenezca a ese hogar. Como las funciones de `public` son
+-- ejecutables por el rol `authenticated` por defecto, un usuario con sesión válida podía
+-- llamar al RPC directamente por PostgREST con el UUID de otro hogar y leer sus datos (IDOR).
+--
+-- Mitigación: validar la pertenencia dentro de la función reutilizando el helper seguro
+-- current_household_ids() (ver 20260603000000_households.sql), mismo punto de verdad que la RLS.
+-- No se puede usar REVOKE: las rutas /api/analytics invocan el RPC con el rol `authenticated`
+-- (anon key + JWT del usuario), no con service role.
+--
+-- Solo se añade la guarda y SET search_path = public; la lógica de agregación es idéntica
+-- a la versión vigente (20260605000000_rename_analytics_columns_to_english.sql).
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+CREATE OR REPLACE FUNCTION get_period_data(
+  p_household_id UUID,
+  p_start_date   DATE,
+  p_end_date     DATE
+) RETURNS TABLE (
+  income      DECIMAL,
+  expense     DECIMAL,
+  savings     DECIMAL,
+  by_category JSONB
+) LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  -- Guarda anti-IDOR: el usuario autenticado debe pertenecer al hogar solicitado.
+  -- Con service role auth.uid() es NULL -> conjunto vacío -> también se rechaza.
+  IF p_household_id NOT IN (SELECT current_household_ids()) THEN
+    RAISE EXCEPTION 'forbidden: household not accessible by current user'
+      USING ERRCODE = '42501';   -- insufficient_privilege
+  END IF;
+
+  RETURN QUERY
+  WITH txs AS (
+    SELECT t.amount,
+           COALESCE(t.category_manual, t.category) AS cat,
+           c.type                                  AS cat_type
+    FROM   transactions t
+    LEFT   JOIN categories c
+           ON c.id = COALESCE(t.category_manual, t.category)
+    WHERE  t.household_id = p_household_id
+      AND  t.date BETWEEN p_start_date AND p_end_date
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(amount) FILTER (WHERE cat_type = 'income'),       0) AS inc,
+      COALESCE(ABS(SUM(amount) FILTER (WHERE cat_type = 'expense')), 0) AS exp
+    FROM txs
+  ),
+  cats AS (
+    SELECT cat, SUM(amount) AS total
+    FROM   txs
+    WHERE  cat_type IN ('income', 'expense')
+    GROUP  BY cat
+  )
+  SELECT
+    totals.inc,
+    totals.exp,
+    totals.inc - totals.exp AS sav,
+    COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object('category', cat, 'amount', total)) FROM cats),
+      '[]'::jsonb
+    )
+  FROM totals;
+END;
+$$;

--- a/supabase/migrations/20260613000001_revoke_refresh_monthly_summary_execute.sql
+++ b/supabase/migrations/20260613000001_revoke_refresh_monthly_summary_execute.sql
@@ -1,0 +1,12 @@
+-- Issue #179 (seguridad): refresh_monthly_summary() (SECURITY DEFINER) era ejecutable
+-- por anon/authenticated por defecto. Como las funciones de `public` quedan ejecutables
+-- por esos roles en Supabase y no había REVOKE, cualquier usuario con sesión válida podía
+-- invocar el RPC (POST /rest/v1/rpc/refresh_monthly_summary) y forzar repetidamente un
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary, operación cara
+-- (DoS barato sobre la BBDD).
+--
+-- Mitigación: revocar EXECUTE a anon/authenticated. La función solo se invoca desde las
+-- syncs (sabadell-visa, enablebanking, cron) con el service role, que no se ve afectado
+-- por este REVOKE. A diferencia de #178 (get_period_data, llamada por /api/analytics con
+-- rol authenticated), aquí revocar no rompe ningún flujo de la app.
+REVOKE EXECUTE ON FUNCTION refresh_monthly_summary() FROM anon, authenticated;

--- a/supabase/migrations/20260613000002_fix_refresh_monthly_summary_search_path.sql
+++ b/supabase/migrations/20260613000002_fix_refresh_monthly_summary_search_path.sql
@@ -1,0 +1,23 @@
+-- Issue #180 (seguridad, hardening): refresh_monthly_summary() (SECURITY DEFINER) no fijaba
+-- search_path, lo que la exponía a search_path injection (ver current_household_ids en
+-- 20260603000000_households.sql, que sí lo fija). Es la única DEFINER de public que faltaba:
+-- get_period_data ya lo añadió en #178 (20260613000000).
+--
+-- Solo se añade SET search_path = public; el cuerpo es idéntico a 20260507000000_sync_helpers.sql.
+-- CREATE OR REPLACE preserva los permisos, así que el REVOKE de #179 (20260613000001) sigue
+-- vigente; se re-incluye como defensa explícita.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+CREATE OR REPLACE FUNCTION refresh_monthly_summary()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY transactions_monthly_summary;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION refresh_monthly_summary() FROM anon, authenticated;

--- a/supabase/migrations/20260613000003_categorization_rules_pattern_length.sql
+++ b/supabase/migrations/20260613000003_categorization_rules_pattern_length.sql
@@ -1,0 +1,8 @@
+-- ReDoS hardening (issue #182): acota la longitud del patrón de regla en el único
+-- límite de escritura real. La validez/complejidad de la regex se valida en la app
+-- (lib/categories/rules.ts → validateRulePattern); no es práctico en SQL.
+-- Mantener el 200 sincronizado con MAX_PATTERN_LENGTH.
+
+ALTER TABLE categorization_rules
+  ADD CONSTRAINT categorization_rules_pattern_len
+  CHECK (char_length(pattern) BETWEEN 1 AND 200);


### PR DESCRIPTION
## Release v0.1.1 → producción

Primer release con versionado semántico (SemVer + tags git). Versión **patch**: agrupa únicamente correcciones de seguridad.

### Incluye
- #178 — validar pertenencia al hogar en `get_period_data`
- #179 — revocar EXECUTE de `refresh_monthly_summary` a anon/authenticated
- #180 — fijar `SET search_path` en `refresh_monthly_summary`
- #191 — validar parámetro `next` en `/auth/callback` contra open redirect
- #182 — validar regex de reglas de categorización contra ReDoS
- bump de versión `0.1.0` → `0.1.1` (#193)

### Tras el merge
- Se etiqueta `v0.1.1` en `main`
- Vercel despliega automáticamente desde `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)