### PR TITLE
feat(observability): tabla error_log y captura centralizada de errores (#200)

### DIFF
--- a/app/api/analytics/category/route.ts
+++ b/app/api/analytics/category/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
 import { getWindowPeriods, toISODate } from '@/lib/analytics'
 import type { Granularity, CategoryId, CategoryAnalyticsResponse } from '@/types'
 import { CATEGORY_META } from '@/lib/theme'
@@ -58,6 +59,15 @@ export async function GET(request: NextRequest) {
     } satisfies CategoryAnalyticsResponse)
   } catch (e) {
     console.error('[GET /api/analytics/category]', e)
+    await logError({
+      source: 'server',
+      message: e instanceof Error ? e.message : String(e),
+      stack: e instanceof Error ? e.stack : null,
+      route: '/api/analytics/category',
+      context: { granularity, id },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 }

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
 import { getWindowPeriods, getYoYRange, toISODate } from '@/lib/analytics'
 import type { Granularity, PeriodData, AnalyticsResponse } from '@/types'
 
@@ -67,6 +68,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ granularity, periods } satisfies AnalyticsResponse)
   } catch (e) {
     console.error('[GET /api/analytics]', e)
+    await logError({
+      source: 'server',
+      message: e instanceof Error ? e.message : String(e),
+      stack: e instanceof Error ? e.stack : null,
+      route: '/api/analytics',
+      context: { granularity, offset },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 }

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getDashboardData } from '@/lib/dashboard'
+import { logError } from '@/lib/error-log'
 
 export async function GET() {
   const supabase = await createClient()
@@ -14,6 +15,13 @@ export async function GET() {
     return NextResponse.json(data)
   } catch (e) {
     console.error('[GET /api/dashboard]', e)
+    await logError({
+      source: 'server',
+      message: e instanceof Error ? e.message : String(e),
+      stack: e instanceof Error ? e.stack : null,
+      route: '/api/dashboard',
+      userId: user.id,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 }

--- a/app/api/error-log/route.ts
+++ b/app/api/error-log/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
+
+/**
+ * Endpoint de ingesta de errores de cliente (issue #200). Lo invocan los error
+ * boundaries del App Router (`app/error.tsx`, `app/global-error.tsx`).
+ *
+ * Es deliberadamente tolerante a la ausencia de sesión: un error puede ocurrir en
+ * una pantalla sin usuario autenticado y aun así queremos registrarlo. Si hay
+ * sesión, se adjuntan `user_id` y `household_id` como contexto.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+
+  const { message, stack, route, context } = body as Record<string, unknown>
+
+  if (typeof message !== 'string' || message.trim() === '') {
+    return NextResponse.json({ error: 'Missing message' }, { status: 400 })
+  }
+
+  // Resolver usuario/hogar de forma best-effort: nunca bloquea el registro.
+  let userId: string | null = null
+  let householdId: string | null = null
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) {
+      userId = user.id
+      householdId = await getHouseholdId(supabase, user.id)
+    }
+  } catch {
+    // sin sesión / cookies no disponibles: registramos igualmente
+  }
+
+  await logError({
+    source: 'client',
+    message,
+    stack: typeof stack === 'string' ? stack : null,
+    route: typeof route === 'string' ? route : null,
+    context: context && typeof context === 'object' ? (context as Record<string, unknown>) : null,
+    userId,
+    householdId,
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
 import type { CategoryId } from '@/types'
 import { VALID_CATEGORIES } from '@/lib/categories'
 
@@ -55,6 +56,14 @@ export async function PATCH(
 
   if (error) {
     console.error('[PATCH /api/transactions/[id]]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions/[id]',
+      context: { op: 'update', id, code: error.code },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 
@@ -98,6 +107,14 @@ export async function DELETE(
 
   if (error) {
     console.error('[DELETE /api/transactions/[id]]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions/[id]',
+      context: { op: 'delete', id, code: error.code },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
@@ -42,6 +43,14 @@ export async function POST(request: NextRequest) {
 
   if (error) {
     console.error('[POST /api/transactions]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions',
+      context: { op: 'insert', code: error.code },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 
@@ -109,6 +118,14 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     console.error('[GET /api/transactions]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions',
+      context: { op: 'list', code: error.code },
+      userId: user.id,
+      householdId,
+    })
     return NextResponse.json({ error: 'DB error' }, { status: 500 })
   }
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Error boundary del App Router (issue #200). Captura errores de renderizado en
+ * las rutas y, además del fallback visual, hace un POST best-effort a la ingesta
+ * de errores. El POST nunca bloquea ni rompe el fallback.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    fetch('/api/error-log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        route: window.location.pathname,
+        context: { digest: error.digest },
+      }),
+    }).catch(() => {
+      // best-effort: si la ingesta falla, no hay nada más que hacer
+    })
+  }, [error])
+
+  return (
+    <div className="grid min-h-dvh place-items-center px-6 text-center">
+      <div className="flex max-w-sm flex-col items-center gap-4">
+        <h1 className="text-lg font-semibold">Algo salió mal</h1>
+        <p className="text-sm text-muted-foreground">
+          Se ha producido un error inesperado. Puedes reintentar; si vuelve a
+          ocurrir, ya hemos registrado el fallo.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-2xl bg-foreground px-5 py-2.5 text-sm font-medium text-background"
+        >
+          Reintentar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Error boundary raíz (issue #200): captura errores en el propio root layout, que
+ * `error.tsx` no puede alcanzar. Debe renderizar su propio <html>/<body>. Hace el
+ * mismo POST best-effort a la ingesta de errores.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    fetch('/api/error-log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        route: window.location.pathname,
+        context: { digest: error.digest, scope: 'global' },
+      }),
+    }).catch(() => {
+      // best-effort
+    })
+  }, [error])
+
+  return (
+    <html lang="es">
+      <body className="min-h-full antialiased">
+        <div className="grid min-h-dvh place-items-center px-6 text-center">
+          <div className="flex max-w-sm flex-col items-center gap-4">
+            <h1 className="text-lg font-semibold">Algo salió mal</h1>
+            <p className="text-sm text-muted-foreground">
+              Se ha producido un error inesperado. Puedes reintentar; si vuelve a
+              ocurrir, ya hemos registrado el fallo.
+            </p>
+            <button
+              type="button"
+              onClick={reset}
+              className="rounded-2xl bg-foreground px-5 py-2.5 text-sm font-medium text-background"
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/lib/error-log.test.ts
+++ b/lib/error-log.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock del service client: capturamos los argumentos del insert para inspeccionarlos.
+const insert = vi.fn()
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => ({
+    from: () => ({ insert }),
+  }),
+}))
+
+import { logError } from './error-log'
+
+beforeEach(() => {
+  insert.mockReset()
+  insert.mockResolvedValue({ error: null })
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('logError', () => {
+  it('mapea los campos y convierte ausentes en null', async () => {
+    await logError({ source: 'server', message: 'boom' })
+
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(insert).toHaveBeenCalledWith({
+      source: 'server',
+      message: 'boom',
+      stack: null,
+      route: null,
+      context: null,
+      user_id: null,
+      household_id: null,
+    })
+  })
+
+  it('propaga todos los campos cuando están presentes', async () => {
+    await logError({
+      source: 'client',
+      message: 'boom',
+      stack: 'at foo',
+      route: '/api/x',
+      context: { op: 'insert' },
+      userId: 'u1',
+      householdId: 'h1',
+    })
+
+    expect(insert).toHaveBeenCalledWith({
+      source: 'client',
+      message: 'boom',
+      stack: 'at foo',
+      route: '/api/x',
+      context: { op: 'insert' },
+      user_id: 'u1',
+      household_id: 'h1',
+    })
+  })
+
+  it('trunca mensajes y stacks demasiado largos', async () => {
+    await logError({
+      source: 'server',
+      message: 'm'.repeat(5_000),
+      stack: 's'.repeat(20_000),
+    })
+
+    const arg = insert.mock.calls[0][0]
+    expect(arg.message.length).toBe(2_000)
+    expect(arg.stack.length).toBe(8_000)
+  })
+
+  it('nunca lanza aunque el insert rechace', async () => {
+    insert.mockRejectedValue(new Error('db down'))
+    await expect(
+      logError({ source: 'server', message: 'boom' })
+    ).resolves.toBeUndefined()
+  })
+
+  it('nunca lanza aunque el insert devuelva error', async () => {
+    insert.mockResolvedValue({ error: { message: 'rls' } })
+    await expect(
+      logError({ source: 'server', message: 'boom' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/lib/error-log.ts
+++ b/lib/error-log.ts
@@ -1,0 +1,51 @@
+import { createServiceClient } from '@/lib/supabase/service'
+
+/**
+ * Observabilidad de errores (issue #200).
+ *
+ * Registra un fallo en la tabla `error_log` de Supabase con contexto suficiente
+ * para revisarlo después por el SQL Editor. La inserción usa el service role, que
+ * se salta RLS, de modo que el error se registra siempre, incluso sin sesión ni
+ * hogar resoluble.
+ *
+ * `logError` es fire-and-forget y NUNCA lanza: un fallo al registrar jamás debe
+ * romper la petición que lo originó.
+ */
+
+export type LogErrorParams = {
+  source: 'client' | 'server'
+  message: string
+  stack?: string | null
+  route?: string | null
+  context?: Record<string, unknown> | null
+  userId?: string | null
+  householdId?: string | null
+}
+
+// Límites defensivos: evitar que un stack o un context enormes inflen la tabla.
+const MAX_STACK = 8_000
+const MAX_MESSAGE = 2_000
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value
+}
+
+export async function logError(params: LogErrorParams): Promise<void> {
+  try {
+    const db = createServiceClient()
+    const { error } = await db.from('error_log').insert({
+      source: params.source,
+      message: truncate(params.message, MAX_MESSAGE),
+      stack: params.stack ? truncate(params.stack, MAX_STACK) : null,
+      route: params.route ?? null,
+      context: params.context ?? null,
+      user_id: params.userId ?? null,
+      household_id: params.householdId ?? null,
+    })
+    if (error) {
+      console.error('[logError] no se pudo registrar el error', error)
+    }
+  } catch (e) {
+    console.error('[logError] no se pudo registrar el error', e)
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -13,6 +13,14 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next({ request })
   }
 
+  // Ingesta de errores (issue #200): debe ser alcanzable sin sesión para poder
+  // registrar fallos ocurridos en pantallas públicas (login, callback). El
+  // handler adjunta user/household sólo si hay cookies; la inserción usa service
+  // role. Sin esta excepción, el POST de los error boundaries se redirige a /login.
+  if (pathname === '/api/error-log') {
+    return NextResponse.next({ request })
+  }
+
   let supabaseResponse = NextResponse.next({ request })
 
   const supabase = createServerClient(

--- a/supabase/migrations/20260616000000_error_log.sql
+++ b/supabase/migrations/20260616000000_error_log.sql
@@ -1,0 +1,32 @@
+-- Issue #200: Observabilidad de errores. Tabla `error_log` para registrar fallos
+-- cliente/servidor con contexto suficiente para accionarlos por SQL Editor.
+--
+-- La ingesta se hace con el service role (ver lib/error-log.ts), que se salta RLS,
+-- de modo que un error se registra siempre, incluso sin sesión ni hogar resoluble.
+-- La RLS se activa igualmente por convención, con una policy de SOLO LECTURA por hogar.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+CREATE TABLE error_log (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  source       TEXT NOT NULL CHECK (source IN ('client', 'server')),
+  message      TEXT NOT NULL,
+  stack        TEXT,
+  route        TEXT,
+  context      JSONB,
+  -- user_id nullable + ON DELETE SET NULL: un error puede ocurrir sin sesión y no
+  -- queremos perder el registro si más adelante se borra el usuario.
+  user_id      UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  -- household_id nullable: puede no haber hogar resoluble en el momento del fallo.
+  household_id UUID REFERENCES households(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_error_log_created_at ON error_log(created_at DESC);
+
+ALTER TABLE error_log ENABLE ROW LEVEL SECURITY;
+
+-- Lectura por hogar (consistencia con el resto de tablas). La ingesta usa service
+-- role, que se salta RLS, así que no se necesita policy de INSERT para el cliente anon.
+CREATE POLICY "Household members read error log" ON error_log
+  FOR SELECT USING (household_id IN (SELECT current_household_ids()));


### PR DESCRIPTION
Closes #200

## Qué

Observabilidad de errores mínima y autocontenida (sin dependencias nuevas): los fallos cliente/servidor quedan registrados en una tabla `error_log` de Supabase con contexto suficiente para revisarlos por SQL Editor durante el período de uso real.

## Cambios

- **Migración** `supabase/migrations/20260616000000_error_log.sql`: tabla `error_log` (`id`, `created_at`, `source`, `message`, `stack`, `route`, `context` jsonb, `user_id`, `household_id`). RLS activada con policy de **solo lectura por hogar**; `user_id`/`household_id` nullable.
- **Helper** `lib/error-log.ts`: `logError()` fire-and-forget que **nunca lanza** e inserta vía **service role** (se salta RLS → registra siempre, aun sin sesión). Truncado defensivo de `message`/`stack`.
- **Endpoint** `app/api/error-log/route.ts` (POST): ingesta de errores de cliente, tolerante a sesión ausente (adjunta `user_id`/`household_id` si los hay).
- **Error boundaries** `app/error.tsx` y `app/global-error.tsx`: fallback visual en castellano con `reset()` + POST best-effort al endpoint.
- **Instrumentación** de route handlers de movimientos y agregaciones: `transactions` (POST/GET + `[id]` PATCH/DELETE), `analytics`, `analytics/category`, `dashboard`. Se mantiene el `console.error` existente y se añade `logError`.
- **Tests** `lib/error-log.test.ts` (mapeo de campos, truncado, no-throw ante fallo del insert).

## Decisiones de diseño

- **Service role para la ingesta** (como los webhooks): garantiza el registro incluso en contextos sin sesión/hogar.
- **Esquema = issue + `household_id` + `source`** para encajar con el modelo RLS por hogar y poder filtrar el origen.
- Pantalla de admin **fuera de alcance**: la revisión inicial es por SQL Editor.

## ⚠️ Acción manual requerida

No hay runner automático de migraciones: ejecutar `supabase/migrations/20260616000000_error_log.sql` en el **SQL Editor de Supabase** antes/junto al deploy.

## Verificación

- `pnpm test` (341 ✓, incluye 5 nuevos), `pnpm lint` (✓), `pnpm build` (✓, `/api/error-log` en el manifest).
- E2E sugerido: forzar un throw en una pantalla → ver `error.tsx` y una fila `source='client'`; romper una query de servidor → fila `source='server'` con `user_id`/`household_id`.
- Revisión: `SELECT created_at, source, route, message FROM error_log ORDER BY created_at DESC;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)