### PR TITLE
feat(scrapers): auto-relogin de Edenred cuando la sesión caduca sin 2FA (#203)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ El script:
 ### Verificar y operar
 
 ```bash
+pnpm cron:edenred:status                    # resumen: último éxito, último auto-relogin, 2FA pendiente, logs y estado del agente
 launchctl list | grep edenred-scraper      # confirma que está cargado
 launchctl start com.fin-app.edenred-scraper # dispararlo a mano (no-op si ya hubo éxito hoy)
 tail -f ~/Library/Logs/fin-app/edenred-scraper.out.log
 tail -f ~/Library/Logs/fin-app/edenred-scraper.err.log
 ```
+
+`pnpm cron:edenred:status` muestra **"Último auto-relogin: …"** cuando el scrape se re-logueó solo, y un aviso **"⚠ 2FA pendiente"** si el auto-relogin está suspendido a la espera de un `scrape:edenred:login` manual. En el `out.log`, una ejecución que se re-logueó termina con `OK (via auto-relogin)`.
 
 Para **forzar** un re-scrape aunque ya exista el marker del día (sin borrar ficheros ni desexportar `EDENRED_CRON`):
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ El scraper de Edenred (`scripts/scrapers/edenred/scrape.mjs`) se ejecuta **cada 
   |---|---|
   | `EDENRED_WEBHOOK_SECRET` | mismo valor que en Vercel (generado con `openssl rand -hex 32`) |
   | `APP_URL` | URL del deploy donde vive el webhook (`https://<...>.vercel.app`, sin barra final) |
-  | `EDENRED_USER` | email de edenred.es (solo para `scrape:edenred:login`) |
-  | `EDENRED_PASS` | contraseña de edenred.es (solo para `scrape:edenred:login`) |
+  | `EDENRED_USER` | email de edenred.es (para `scrape:edenred:login` y el auto-relogin de `scrape:edenred`) |
+  | `EDENRED_PASS` | contraseña de edenred.es (para `scrape:edenred:login` y el auto-relogin de `scrape:edenred`) |
 - Sesión válida en `scripts/scrapers/edenred/storage-state.json` — la generas con `pnpm scrape:edenred:login`.
 - `pnpm` instalado y en el `PATH`.
 
@@ -55,13 +55,17 @@ Tras una ejecución exitosa:
 
 ### Regenerar la sesión cuando caduca
 
-El scraper sale con **exit code 2** si Edenred pide login o 2FA. En ese caso:
+Cuando la sesión `storage-state.json` caduca, el scraper se recupera **solo** en el caso mayoritario: si Edenred solo pide usuario/contraseña (sin 2FA), `scrape:edenred` reenvía `EDENRED_USER`/`EDENRED_PASS` en la misma ejecución headless, guarda la sesión nueva (con backup del state anterior) y continúa el scrape sin abortar. No hay que intervenir.
+
+Solo se requiere intervención humana cuando Edenred pide **2FA** (código por email). En ese caso el scraper sale con **exit code 2** y hay que regenerar la sesión a mano:
 
 ```bash
 pnpm scrape:edenred:login   # abre Chromium, completas 2FA, ENTER al final
 ```
 
 `scripts/scrapers/edenred/storage-state.json` se actualiza y el siguiente run del cron volverá a funcionar. No hay que reinstalar el agente.
+
+> **Guard anti-spam de 2FA.** Si el auto-relogin desemboca en 2FA, el scraper crea el marker `~/Library/Logs/fin-app/edenred-2fa-pending` y deja de reintentar el auto-login en los siguientes slots del cron — así no reenvía credenciales una y otra vez disparando un email de código nuevo cada vez. Un `pnpm scrape:edenred:login` exitoso borra el marker y re-arma el auto-relogin.
 
 ### Desinstalar
 

--- a/scripts/scrapers/edenred/auth.mjs
+++ b/scripts/scrapers/edenred/auth.mjs
@@ -1,0 +1,105 @@
+// Lógica de autenticación compartida entre login.mjs (headed, manual) y
+// scrape.mjs (headless, auto-relogin). Mantener el relleno del formulario y el
+// guardado del storage-state en un único sitio evita que ambos flujos se
+// desincronicen (causa típica de exit code 2).
+//
+// A diferencia de config.mjs (puro, sin dependencias), este módulo tiene
+// efectos: toca el DOM vía Playwright y el sistema de ficheros.
+
+import { existsSync, copyFileSync, readFileSync, closeSync, openSync, unlinkSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  LOCAL_STORAGE_PATH,
+  LOCAL_STORAGE_BACKUP_PATH,
+  isStorageStateValid,
+} from './config.mjs'
+
+// Locators del formulario de login (capturados con `playwright codegen`
+// sobre empleados.edenred.es/login).
+export const loginLocators = (page) => ({
+  username: page.getByRole('textbox', { name: 'Usuario (campo requerido)' }),
+  password: page.getByRole('textbox', { name: 'Contraseña (campo requerido)' }),
+  submit: page.getByTestId('login'),
+})
+
+// Timeout corto: si el form no aparece pronto, asumimos que no hay que
+// auto-rellenar (ya logueado, redirección a home, o selectores cambiados).
+export const AUTOFILL_TIMEOUT_MS = 5000
+
+// Rellena y envía el formulario de login. Best-effort: devuelve false si el
+// form no aparece (ya logueado) o si el relleno falla, sin lanzar.
+export async function tryAutofill(page, user, pass) {
+  const { username, password, submit } = loginLocators(page)
+  try {
+    await username.waitFor({ timeout: AUTOFILL_TIMEOUT_MS })
+  } catch {
+    console.log('[edenred-auth] no se vio el form de login (¿ya logueado?).')
+    return false
+  }
+  try {
+    await username.fill(user)
+    await password.fill(pass)
+    await submit.click()
+    console.log('[edenred-auth] credenciales auto-rellenadas.')
+    return true
+  } catch (err) {
+    console.log(`[edenred-auth] auto-fill falló (${err.message}).`)
+    return false
+  }
+}
+
+function restoreBackup() {
+  if (existsSync(LOCAL_STORAGE_BACKUP_PATH)) {
+    copyFileSync(LOCAL_STORAGE_BACKUP_PATH, LOCAL_STORAGE_PATH)
+    console.error(`[edenred-auth] state restaurado desde ${LOCAL_STORAGE_BACKUP_PATH}`)
+  }
+}
+
+// Guarda el storage-state del contexto con salvaguardas: respalda el state
+// previo, escribe el nuevo, y valida que tenga cookies de Edenred; si no, lo
+// restaura desde el backup. Devuelve true si el state guardado es válido.
+export async function saveStorageStateWithBackup(context) {
+  if (existsSync(LOCAL_STORAGE_PATH)) {
+    copyFileSync(LOCAL_STORAGE_PATH, LOCAL_STORAGE_BACKUP_PATH)
+    console.log(`[edenred-auth] backup del state actual en ${LOCAL_STORAGE_BACKUP_PATH}`)
+  }
+
+  await context.storageState({ path: LOCAL_STORAGE_PATH, indexedDB: true })
+
+  const saved = JSON.parse(readFileSync(LOCAL_STORAGE_PATH, 'utf-8'))
+  if (!isStorageStateValid(saved)) {
+    console.error('[edenred-auth] state guardado sin cookies de Edenred — restaurando backup.')
+    restoreBackup()
+    return false
+  }
+
+  console.log(`[edenred-auth] [ok] guardado: ${LOCAL_STORAGE_PATH}`)
+  return true
+}
+
+// Marker persistente (no diario) que señala "2FA pendiente": lo crea el
+// auto-relogin de scrape.mjs cuando el envío de credenciales desemboca en 2FA,
+// y lo limpia un login manual exitoso (login.mjs). Mientras existe, scrape.mjs
+// no reintenta el auto-relogin (no reenvía credenciales) para no disparar un
+// email de código nuevo en cada slot del cron (~6/día).
+const CRON_LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
+const TWO_FA_PENDING_PATH = join(CRON_LOG_DIR, 'edenred-2fa-pending')
+
+export function twoFaPendingExists() {
+  return existsSync(TWO_FA_PENDING_PATH)
+}
+
+export function setTwoFaPending() {
+  try {
+    mkdirSync(CRON_LOG_DIR, { recursive: true })
+    closeSync(openSync(TWO_FA_PENDING_PATH, 'a'))
+  } catch {}
+}
+
+export function clearTwoFaPending() {
+  try {
+    unlinkSync(TWO_FA_PENDING_PATH)
+  } catch {}
+}

--- a/scripts/scrapers/edenred/auth.mjs
+++ b/scripts/scrapers/edenred/auth.mjs
@@ -6,7 +6,7 @@
 // A diferencia de config.mjs (puro, sin dependencias), este módulo tiene
 // efectos: toca el DOM vía Playwright y el sistema de ficheros.
 
-import { existsSync, copyFileSync, readFileSync, closeSync, openSync, unlinkSync, mkdirSync } from 'node:fs'
+import { existsSync, copyFileSync, readFileSync, writeFileSync, closeSync, openSync, unlinkSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -85,7 +85,10 @@ export async function saveStorageStateWithBackup(context) {
 // no reintenta el auto-relogin (no reenvía credenciales) para no disparar un
 // email de código nuevo en cada slot del cron (~6/día).
 const CRON_LOG_DIR = join(homedir(), 'Library/Logs/fin-app')
+// Nombres compartidos con status.mjs (mismos literales allí) para reportar el
+// estado del auto-relogin sin tener que rebuscar en el out.log.
 const TWO_FA_PENDING_PATH = join(CRON_LOG_DIR, 'edenred-2fa-pending')
+const LAST_RELOGIN_PATH = join(CRON_LOG_DIR, 'edenred-last-relogin')
 
 export function twoFaPendingExists() {
   return existsSync(TWO_FA_PENDING_PATH)
@@ -101,5 +104,15 @@ export function setTwoFaPending() {
 export function clearTwoFaPending() {
   try {
     unlinkSync(TWO_FA_PENDING_PATH)
+  } catch {}
+}
+
+// Registra el instante del último auto-relogin exitoso (timestamp ISO como
+// contenido) para que `pnpm cron:edenred:status` lo muestre. Persistente:
+// señala "última vez que el scrape se re-logueó solo".
+export function markLastRelogin() {
+  try {
+    mkdirSync(CRON_LOG_DIR, { recursive: true })
+    writeFileSync(LAST_RELOGIN_PATH, new Date().toISOString())
   } catch {}
 }

--- a/scripts/scrapers/edenred/login.mjs
+++ b/scripts/scrapers/edenred/login.mjs
@@ -22,28 +22,12 @@
 //     restaura desde el backup.
 
 import { chromium } from 'playwright'
-import { existsSync, copyFileSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 
-import {
-  LOCAL_STORAGE_PATH,
-  LOCAL_STORAGE_BACKUP_PATH,
-  EDENRED_LOGIN_URL,
-  isStorageStateValid,
-} from './config.mjs'
-
-// Locators del formulario de login (capturados con `playwright codegen`
-// sobre empleados.edenred.es/login).
-const locators = page => ({
-  username: page.getByRole('textbox', { name: 'Usuario (campo requerido)' }),
-  password: page.getByRole('textbox', { name: 'Contraseña (campo requerido)' }),
-  submit: page.getByTestId('login'),
-})
-
-// Timeout corto: si el form no aparece pronto, asumimos que no hay que
-// auto-rellenar (ya logueado, redirección a home, o selectores cambiados).
-const AUTOFILL_TIMEOUT_MS = 5000
+import { LOCAL_STORAGE_PATH, EDENRED_LOGIN_URL } from './config.mjs'
+import { tryAutofill, saveStorageStateWithBackup, clearTwoFaPending } from './auth.mjs'
 
 function requireEnv(name) {
   const v = process.env[name]
@@ -52,26 +36,6 @@ function requireEnv(name) {
     process.exit(1)
   }
   return v
-}
-
-async function tryAutofill(page, user, pass) {
-  const { username, password, submit } = locators(page)
-  try {
-    await username.waitFor({ timeout: AUTOFILL_TIMEOUT_MS })
-  } catch {
-    console.log('[edenred-login] no se vio el form de login (¿ya logueado?). Sigue a mano.')
-    return false
-  }
-  try {
-    await username.fill(user)
-    await password.fill(pass)
-    await submit.click()
-    console.log('[edenred-login] credenciales auto-rellenadas, completa 2FA si lo pide.')
-    return true
-  } catch (err) {
-    console.log(`[edenred-login] auto-fill falló (${err.message}). Termina el login a mano.`)
-    return false
-  }
 }
 
 // Si seguimos en /login o el campo de contraseña sigue visible, asumimos
@@ -86,25 +50,13 @@ async function isLoggedIn(page) {
   return !passwordVisible
 }
 
-function restoreBackup() {
-  if (existsSync(LOCAL_STORAGE_BACKUP_PATH)) {
-    copyFileSync(LOCAL_STORAGE_BACKUP_PATH, LOCAL_STORAGE_PATH)
-    console.error(`[edenred-login] state restaurado desde ${LOCAL_STORAGE_BACKUP_PATH}`)
-  }
-}
-
 async function main() {
   const user = requireEnv('EDENRED_USER')
   const pass = requireEnv('EDENRED_PASS')
 
   // Reutiliza el state previo (cookies persistentes pueden saltar el form
-  // y dejar sólo el 2FA por hacer). Y lo respalda antes de cualquier
-  // posible sobrescritura.
+  // y dejar sólo el 2FA por hacer).
   const hasPreviousState = existsSync(LOCAL_STORAGE_PATH)
-  if (hasPreviousState) {
-    copyFileSync(LOCAL_STORAGE_PATH, LOCAL_STORAGE_BACKUP_PATH)
-    console.log(`[edenred-login] backup del state actual en ${LOCAL_STORAGE_BACKUP_PATH}`)
-  }
 
   const browser = await chromium.launch({ headless: false })
   try {
@@ -117,6 +69,7 @@ async function main() {
     await page.goto(EDENRED_LOGIN_URL, { waitUntil: 'domcontentloaded' })
 
     await tryAutofill(page, user, pass)
+    console.log('[edenred-login] completa 2FA en el navegador si lo pide.')
 
     const rl = readline.createInterface({ input, output })
     await rl.question(
@@ -130,18 +83,15 @@ async function main() {
       process.exit(2)
     }
 
-    await context.storageState({ path: LOCAL_STORAGE_PATH, indexedDB: true })
-
-    // Sanity check: si el JSON guardado no tiene cookies de edenred,
-    // la sesión no sirve. Restauramos el backup y salimos con error.
-    const saved = JSON.parse(readFileSync(LOCAL_STORAGE_PATH, 'utf-8'))
-    if (!isStorageStateValid(saved)) {
-      console.error('[edenred-login] state guardado sin cookies de Edenred — restaurando backup.')
-      restoreBackup()
+    if (!(await saveStorageStateWithBackup(context))) {
+      // state sin cookies de Edenred: ya se restauró el backup, salimos.
       process.exit(2)
     }
 
-    console.log(`[edenred-login] [ok] guardado: ${LOCAL_STORAGE_PATH}`)
+    // Login manual exitoso: re-arma el auto-relogin de scrape.mjs limpiando
+    // el marker de "2FA pendiente" si lo había.
+    clearTwoFaPending()
+
     console.log('\nValida en caliente con:\n  pnpm scrape:edenred\n')
   } finally {
     await browser.close()

--- a/scripts/scrapers/edenred/scrape.mjs
+++ b/scripts/scrapers/edenred/scrape.mjs
@@ -27,6 +27,7 @@ import {
   saveStorageStateWithBackup,
   twoFaPendingExists,
   setTwoFaPending,
+  markLastRelogin,
 } from './auth.mjs'
 import { parseAmount, parseDate } from './parsers.mjs'
 
@@ -201,6 +202,7 @@ async function tryAutoRelogin(context, page) {
   const state = await isSessionInvalid(page)
   if (state === null) {
     await saveStorageStateWithBackup(context)
+    markLastRelogin()
     console.log('[edenred-scrape] auto-relogin OK, continúo el scrape.')
     return true
   }
@@ -307,6 +309,7 @@ async function main() {
     // Pequeña espera para que la SPA hidrate antes de inspeccionar el DOM.
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
 
+    let didRelogin = false
     const invalid = await isSessionInvalid(page)
     if (invalid === 'login') {
       // Caso mayoritario: sesión caducada sin 2FA → intentar auto-relogin y
@@ -315,6 +318,7 @@ async function main() {
         await dumpFailure(page)
         die(2, `Auto-relogin no completado. Regenera con: pnpm scrape:edenred:login`)
       }
+      didRelogin = true
       // Tras el relogin la SPA queda en su landing; recargamos la cuenta para
       // que la extracción corra contra la misma página que el flujo normal.
       await page.goto(EDENRED_ACCOUNT_URL, { waitUntil: 'domcontentloaded' })
@@ -330,7 +334,7 @@ async function main() {
     console.log(`[edenred-scrape] saldo=${balance} EUR, txs=${transactions.length}`)
 
     const result = await postToWebhook({ balance, transactions })
-    console.log(`[edenred-scrape] OK: ${JSON.stringify(result)}`)
+    console.log(`[edenred-scrape] OK${didRelogin ? ' (via auto-relogin)' : ''}: ${JSON.stringify(result)}`)
     if (CRON_MODE) writeCronMarker()
   } finally {
     await browser.close()

--- a/scripts/scrapers/edenred/scrape.mjs
+++ b/scripts/scrapers/edenred/scrape.mjs
@@ -21,7 +21,13 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
 
-import { LOCAL_STORAGE_PATH, EDENRED_ACCOUNT_URL } from './config.mjs'
+import { LOCAL_STORAGE_PATH, EDENRED_ACCOUNT_URL, EDENRED_LOGIN_URL } from './config.mjs'
+import {
+  tryAutofill,
+  saveStorageStateWithBackup,
+  twoFaPendingExists,
+  setTwoFaPending,
+} from './auth.mjs'
 import { parseAmount, parseDate } from './parsers.mjs'
 
 // Cuando se invoca desde launchd (EDENRED_CRON=1) se usa un marker diario
@@ -166,6 +172,47 @@ async function isSessionInvalid(page) {
   return null
 }
 
+// Auto-relogin desatendido para el caso mayoritario (sesión caducada sin 2FA).
+// Reenvía EDENRED_USER/EDENRED_PASS en el mismo navegador headless y re-evalúa
+// la sesión. Devuelve true si quedó dentro (state ya guardado) y el scrape puede
+// continuar; false si hay que abortar (el caller decide el exit).
+//
+// Guard anti-spam: si hay un marker de "2FA pendiente" no reintenta (no reenvía
+// credenciales → no dispara un email de código nuevo en cada slot del cron).
+async function tryAutoRelogin(context, page) {
+  if (twoFaPendingExists()) {
+    console.error('[edenred-scrape] 2FA pendiente: no se reintenta auto-login. Ejecuta: pnpm scrape:edenred:login')
+    return false
+  }
+
+  const user = process.env.EDENRED_USER
+  const pass = process.env.EDENRED_PASS
+  if (!user || !pass) {
+    console.error('[edenred-scrape] faltan EDENRED_USER/EDENRED_PASS — no se puede auto-relogin.')
+    return false
+  }
+
+  console.log('[edenred-scrape] sesión caducada (login): intentando auto-relogin…')
+  await page.goto(EDENRED_LOGIN_URL, { waitUntil: 'domcontentloaded' })
+
+  if (!(await tryAutofill(page, user, pass))) return false
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+
+  const state = await isSessionInvalid(page)
+  if (state === null) {
+    await saveStorageStateWithBackup(context)
+    console.log('[edenred-scrape] auto-relogin OK, continúo el scrape.')
+    return true
+  }
+  if (state === '2fa') {
+    setTwoFaPending()
+    console.error('[edenred-scrape] auto-relogin desembocó en 2FA — marcado pendiente.')
+    return false
+  }
+  console.error('[edenred-scrape] auto-relogin falló (sigue en login).')
+  return false
+}
+
 async function extractBalance(page) {
   const el = page.locator(SELECTORS.balance).first()
   if (!(await el.isVisible().catch(() => false))) {
@@ -261,9 +308,20 @@ async function main() {
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
 
     const invalid = await isSessionInvalid(page)
-    if (invalid) {
+    if (invalid === 'login') {
+      // Caso mayoritario: sesión caducada sin 2FA → intentar auto-relogin y
+      // continuar en la misma ejecución si funciona.
+      if (!(await tryAutoRelogin(context, page))) {
+        await dumpFailure(page)
+        die(2, `Auto-relogin no completado. Regenera con: pnpm scrape:edenred:login`)
+      }
+      // Tras el relogin la SPA queda en su landing; recargamos la cuenta para
+      // que la extracción corra contra la misma página que el flujo normal.
+      await page.goto(EDENRED_ACCOUNT_URL, { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
+    } else if (invalid === '2fa') {
       await dumpFailure(page)
-      die(2, `Sesión Edenred no válida (${invalid}). Regenera con: pnpm scrape:edenred:login`)
+      die(2, `Sesión Edenred no válida (2fa). Regenera con: pnpm scrape:edenred:login`)
     }
 
     const balance = await extractBalance(page)

--- a/scripts/scrapers/edenred/status.mjs
+++ b/scripts/scrapers/edenred/status.mjs
@@ -12,6 +12,9 @@ const OUT_LOG = join(LOG_DIR, 'edenred-scraper.out.log')
 const ERR_LOG = join(LOG_DIR, 'edenred-scraper.err.log')
 const MARKER_PREFIX = 'edenred-last-success.'
 const FAILURE_PREFIX = 'edenred-failure-'
+// Markers del auto-relogin (mismos literales que en auth.mjs).
+const RELOGIN_MARKER = 'edenred-last-relogin'
+const TWO_FA_PENDING_MARKER = 'edenred-2fa-pending'
 const AGENT_LABEL = 'com.fin-app.edenred-scraper'
 
 const fmtDate = (d) =>
@@ -38,6 +41,23 @@ function lastMarker() {
     date: name.slice(MARKER_PREFIX.length),
     mtime: statSync(path).mtime,
   }
+}
+
+// Último auto-relogin exitoso: el marker guarda un timestamp ISO como
+// contenido; si no parsea, caemos a la mtime del fichero.
+function lastRelogin() {
+  const path = join(LOG_DIR, RELOGIN_MARKER)
+  if (!existsSync(path)) return null
+  const raw = readFileSync(path, 'utf8').trim()
+  const parsed = new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? statSync(path).mtime : parsed
+}
+
+// Marker persistente de "2FA pendiente": mientras existe, el auto-relogin no
+// reintenta y hace falta `pnpm scrape:edenred:login`.
+function twoFaPending() {
+  const path = join(LOG_DIR, TWO_FA_PENDING_MARKER)
+  return existsSync(path) ? statSync(path).mtime : null
 }
 
 function lastFailureDump() {
@@ -97,6 +117,21 @@ if (!marker) {
 } else {
   console.log(
     `\nÚltimo éxito: ${marker.date} · ${fmtDate(marker.mtime)} (${ageSince(marker.mtime)})`,
+  )
+}
+
+const relogin = lastRelogin()
+if (relogin) {
+  console.log(
+    `\nÚltimo auto-relogin: ${fmtDate(relogin)} (${ageSince(relogin)})`,
+  )
+}
+
+const pending2fa = twoFaPending()
+if (pending2fa) {
+  console.log(
+    `\n⚠ 2FA pendiente desde ${fmtDate(pending2fa)} (${ageSince(pending2fa)})` +
+      ` — el auto-relogin está suspendido. Ejecuta: pnpm scrape:edenred:login`,
   )
 }
 


### PR DESCRIPTION
Closes #203

## Qué

Cuando la sesión Playwright de Edenred caduca, el scraper se re-loguea **solo** en el caso mayoritario (formulario usuario/contraseña, **sin 2FA**) y continúa el scrape en la misma ejecución headless. Solo cae a intervención humana (`exit 2`) cuando Edenred pide 2FA. Patrón "tolerante a fallo": automatizar el caso común, degradar con gracia el raro.

## Cambios

- **Nuevo `scripts/scrapers/edenred/auth.mjs`** — módulo compartido que extrae de `login.mjs` el relleno del formulario (`tryAutofill()` + `loginLocators`) y el guardado de `storage-state` con backup/validación (`saveStorageStateWithBackup`), más los helpers del marker 2FA. Evita que el flujo manual (`login.mjs`) y el automático (`scrape.mjs`) se desincronicen.
- **`scrape.mjs`** — bifurca la rama de sesión inválida:
  - `null` → continúa (como antes).
  - `'login'` → `tryAutoRelogin()`: reenvía `EDENRED_USER`/`EDENRED_PASS` headless, re-evalúa con `isSessionInvalid()`; si queda dentro guarda el state y reanuda el scrape; si aparece 2FA marca pendiente y sale 2; si sigue en login sale 2.
  - `'2fa'` → `exit 2` (intervención humana).
- **Guard anti-spam (crítico)** — marker persistente `~/Library/Logs/fin-app/edenred-2fa-pending`. Mientras existe, el auto-relogin no reintenta (no reenvía credenciales → no dispara un email de código nuevo en cada slot del cron ~6/día). Un `pnpm scrape:edenred:login` exitoso lo borra y re-arma el auto-relogin.
- **`login.mjs`** — refactor para consumir `auth.mjs` (sin cambios de comportamiento: headed + ENTER); limpia el marker 2FA tras un login exitoso.
- **README** — documenta el auto-relogin y el marker; aclara que `scrape:edenred` ahora usa `EDENRED_USER`/`EDENRED_PASS`.

## Decisión de diseño

Arrancamos en modo **headless** (reusar el navegador del propio scrape, 100% desatendido). Plan B documentado: pasar el relogin a headed un instante si la verificación demuestra que el envío de credenciales headless es frágil por anti-bot.

## Fuera de alcance

- Leer el código del email automáticamente (descartado a propósito).
- Notificar al usuario cuando hace falta 2FA → #115.
- Scraper de Sabadell (modelo de sesión distinto).

## Verificación

- ✅ `pnpm test` (341), `pnpm lint`, `pnpm build`.
- ⏳ Pendiente de validación en vivo (local, contra la cuenta real): invalidar la sesión y `pnpm scrape:edenred:force` → auto-relogin OK + scrape completo; simular 2FA → se crea el marker, segundo run no reenvía credenciales, y `scrape:edenred:login` lo limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)