### PR TITLE
feat(scrapers): push accionable cuando Edenred requiere 2FA (#204)

### DIFF
--- a/app/api/edenred/notify-2fa/route.test.ts
+++ b/app/api/edenred/notify-2fa/route.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createServiceClient } from '@/lib/supabase/service'
+import { sendPushToUser } from '@/lib/push'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+vi.mock('@/lib/push', () => ({
+  sendPushToUser: vi.fn(),
+}))
+
+const { POST } = await import('./route')
+
+const SECRET = 'test-secret'
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+function buildMockDb(userConfig: { data: { user_id: string } | null; error?: unknown }) {
+  const userConfigBuilder: Record<string, unknown> = {}
+  Object.assign(userConfigBuilder, {
+    select: vi.fn(() => userConfigBuilder),
+    limit: vi.fn(() => userConfigBuilder),
+    maybeSingle: vi.fn(() => Promise.resolve(userConfig)),
+  })
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === 'user_config') return userConfigBuilder
+      throw new Error(`Unmocked table: ${table}`)
+    }),
+  }
+  return db
+}
+
+function callRoute(opts: { auth?: string | null } = {}) {
+  const headers: Record<string, string> = {}
+  if (opts.auth !== null) {
+    headers.authorization = opts.auth ?? `Bearer ${SECRET}`
+  }
+  return POST(new Request('http://test/api/edenred/notify-2fa', { method: 'POST', headers }))
+}
+
+beforeEach(() => {
+  vi.stubEnv('EDENRED_WEBHOOK_SECRET', SECRET)
+  vi.mocked(sendPushToUser).mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /api/edenred/notify-2fa — auth', () => {
+  it('rechaza con 401 si falta el header Authorization', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: null })
+    expect(res.status).toBe(401)
+    expect(db.from).not.toHaveBeenCalled()
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+
+  it('rechaza con 401 si el Bearer es incorrecto', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: 'Bearer wrong' })
+    expect(res.status).toBe(401)
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/edenred/notify-2fa — configuración', () => {
+  it('devuelve 500 si falta EDENRED_WEBHOOK_SECRET', async () => {
+    vi.unstubAllEnvs()
+    delete process.env.EDENRED_WEBHOOK_SECRET
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Server misconfigured' })
+  })
+
+  it('devuelve 500 "No user configured" si user_config está vacío', async () => {
+    const db = buildMockDb({ data: null, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'No user configured' })
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/edenred/notify-2fa — envío', () => {
+  it('envía el push de 2FA al usuario y devuelve el conteo', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockResolvedValue(2)
+
+    const res = await callRoute()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ sent: 2 })
+
+    expect(sendPushToUser).toHaveBeenCalledTimes(1)
+    const [, userId, payload] = vi.mocked(sendPushToUser).mock.calls[0]
+    expect(userId).toBe(USER_ID)
+    expect(payload).toEqual({
+      title: 'Edenred requiere 2FA',
+      body: 'Ejecuta «pnpm scrape:edenred:login» para regenerar la sesión.',
+      url: '/cuentas',
+    })
+  })
+
+  it('devuelve 500 si sendPushToUser lanza (p. ej. VAPID sin configurar)', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockRejectedValue(new Error('VAPID env vars no configuradas'))
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Push failed' })
+  })
+})

--- a/app/api/edenred/notify-2fa/route.ts
+++ b/app/api/edenred/notify-2fa/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { safeBearerMatch } from '@/lib/http/bearer'
+import { sendPushToUser } from '@/lib/push'
+
+/**
+ * Webhook que dispara un push "Edenred requiere 2FA" (issue #204).
+ *
+ * El scraper corre en local (launchd en el Mac); cuando el auto-relogin de #203
+ * desemboca en 2FA, hace POST aquí para que el push se firme en el servidor (las
+ * claves VAPID nunca salen de Vercel). El propio scraper garantiza un único aviso
+ * por episodio atándolo al marker `edenred-2fa-pending`, así que este endpoint no
+ * deduplica: simplemente envía a las suscripciones del usuario.
+ *
+ * Auth por secreto compartido (`EDENRED_WEBHOOK_SECRET`, el mismo del webhook de
+ * datos /api/edenred). No lleva body.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.EDENRED_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[edenred/notify-2fa] EDENRED_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  const db = createServiceClient()
+
+  // App personal con un único hogar: el usuario destinatario es el único registro
+  // de user_config (mismo patrón que /api/edenred).
+  const { data: userRow, error: userErr } = await db
+    .from('user_config')
+    .select('user_id')
+    .limit(1)
+    .maybeSingle()
+  if (userErr || !userRow?.user_id) {
+    console.error('[edenred/notify-2fa] no user_config:', userErr)
+    return NextResponse.json({ error: 'No user configured' }, { status: 500 })
+  }
+
+  try {
+    const sent = await sendPushToUser(db, userRow.user_id as string, {
+      title: 'Edenred requiere 2FA',
+      body: 'Ejecuta «pnpm scrape:edenred:login» para regenerar la sesión.',
+      url: '/cuentas',
+    })
+    return NextResponse.json({ sent })
+  } catch (err) {
+    // sendPushToUser lanza si faltan las VAPID env vars. No debe tumbar el aviso
+    // de forma silenciosa: lo logueamos y devolvemos 500 (el scraper es
+    // best-effort y no romperá su exit code por esto).
+    console.error('[edenred/notify-2fa] push:', err)
+    return NextResponse.json({ error: 'Push failed' }, { status: 500 })
+  }
+}

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { timingSafeEqual } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
+import { safeBearerMatch } from '@/lib/http/bearer'
 
 type EdenredTx = {
   external_id: string
@@ -32,15 +32,6 @@ function isValidPayload(data: unknown): data is EdenredPayload {
     if (t.category !== undefined && typeof t.category !== 'string') return false
     return true
   })
-}
-
-function safeBearerMatch(header: string | null, secret: string): boolean {
-  if (!header) return false
-  const expected = `Bearer ${secret}`
-  const a = Buffer.from(header)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
 }
 
 export async function POST(req: Request) {

--- a/app/api/sabadell-visa/route.ts
+++ b/app/api/sabadell-visa/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
-import { timingSafeEqual } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
+import { safeBearerMatch } from '@/lib/http/bearer'
 
 type SabadellTx = {
   external_id: string
@@ -65,15 +65,6 @@ function isValidPayload(data: unknown): data is SabadellPayload {
     if (!Array.isArray(c.transactions)) return false
     return c.transactions.every(isValidTx)
   })
-}
-
-function safeBearerMatch(header: string | null, secret: string): boolean {
-  if (!header) return false
-  const expected = `Bearer ${secret}`
-  const a = Buffer.from(header)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
 }
 
 export async function POST(req: Request) {

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -1,19 +1,10 @@
 import { NextResponse } from 'next/server'
-import { timingSafeEqual } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 import { getConsentStatus } from '@/lib/accounts'
 import { sendPushToUser, selectAccountsToNotify, type NotifiableAccount } from '@/lib/push'
-
-function safeBearerMatch(header: string | null, secret: string): boolean {
-  if (!header) return false
-  const expected = `Bearer ${secret}`
-  const a = Buffer.from(header)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
-}
+import { safeBearerMatch } from '@/lib/http/bearer'
 
 export async function POST(req: Request) {
   const secret = process.env.ENABLEBANKING_WEBHOOK_SECRET

--- a/lib/http/bearer.ts
+++ b/lib/http/bearer.ts
@@ -1,0 +1,16 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Comprueba en tiempo constante que el header `Authorization` coincide con
+ * `Bearer <secret>`. Usado por los webhooks autenticados por secreto compartido
+ * (scrapers de Edenred / Sabadell, cron de Enable Banking). Devuelve false si el
+ * header falta o no coincide; nunca lanza.
+ */
+export function safeBearerMatch(header: string | null, secret: string): boolean {
+  if (!header) return false
+  const expected = `Bearer ${secret}`
+  const a = Buffer.from(header)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}

--- a/scripts/scrapers/edenred/scrape.mjs
+++ b/scripts/scrapers/edenred/scrape.mjs
@@ -73,6 +73,43 @@ function writeCronMarker() {
   }
 }
 
+// Push accionable "Edenred requiere 2FA" (issue #204). A diferencia de la
+// notificación macOS (local al Mac), este push llega al móvil aunque estés fuera.
+// El servidor firma el push con VAPID; aquí sólo hacemos POST al webhook (mismo
+// secreto que /api/edenred). Best-effort: nunca debe romper el exit del script.
+// La dedup ("un aviso por episodio") la hace enterTwoFaPending vía el marker.
+async function notify2faPending() {
+  try {
+    const appUrl = process.env.APP_URL?.replace(/\/$/, '')
+    const secret = process.env.EDENRED_WEBHOOK_SECRET
+    if (!appUrl || !secret) {
+      console.error('[edenred-scrape] falta APP_URL/EDENRED_WEBHOOK_SECRET — sin push de 2FA.')
+      return
+    }
+    const res = await fetch(`${appUrl}/api/edenred/notify-2fa`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${secret}` },
+    })
+    if (!res.ok) {
+      console.error(`[edenred-scrape] push de 2FA respondió ${res.status}`)
+    } else {
+      console.log('[edenred-scrape] push de 2FA enviado.')
+    }
+  } catch (err) {
+    console.error(`[edenred-scrape] push de 2FA falló (${err.message}).`)
+  }
+}
+
+// Entra al estado "2FA pendiente": marca el guard anti-spam (siempre, para no
+// reenviar credenciales en los próximos slots) y, sólo en la transición y bajo
+// cron, dispara el push una única vez por episodio. El marker lo limpia un login
+// manual exitoso (login.mjs), re-armando el aviso para el siguiente episodio.
+async function enterTwoFaPending() {
+  const firstTime = !twoFaPendingExists()
+  setTwoFaPending()
+  if (firstTime && CRON_MODE) await notify2faPending()
+}
+
 // Notificación nativa de macOS cuando la sesión Edenred caduca (exit 2). Sólo
 // se dispara desde el cron (CRON_MODE): en ejecuciones manuales el error ya se
 // ve por pantalla. Throttle de 1/día vía marker. Nunca debe romper el exit del
@@ -207,7 +244,7 @@ async function tryAutoRelogin(context, page) {
     return true
   }
   if (state === '2fa') {
-    setTwoFaPending()
+    await enterTwoFaPending()
     console.error('[edenred-scrape] auto-relogin desembocó en 2FA — marcado pendiente.')
     return false
   }
@@ -324,6 +361,10 @@ async function main() {
       await page.goto(EDENRED_ACCOUNT_URL, { waitUntil: 'domcontentloaded' })
       await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
     } else if (invalid === '2fa') {
+      // 2FA visible ya en la carga (p. ej. tras un episodio que sigue pendiente, o
+      // un 2FA forzado por Edenred). enterTwoFaPending marca el guard y avisa una
+      // sola vez: en slots posteriores el marker ya existe y no se re-notifica.
+      await enterTwoFaPending()
       await dumpFailure(page)
       die(2, `Sesión Edenred no válida (2fa). Regenera con: pnpm scrape:edenred:login`)
     }


### PR DESCRIPTION
Cierra #204.

## Contexto
Con el auto-relogin de #203, el scraper de Edenred se recupera solo cuando la sesión caduca **sin** 2FA. Cuando Edenred sí pide el código por email, el scraper para (`exit 2`) y necesita intervención humana (`pnpm scrape:edenred:login`) — hoy un **fallo silencioso** del que solo te enteras al ver datos viejos en `/cuentas`. Esta PR lo convierte en un aviso push accionable reutilizando la infra de web-push de #115.

## Cambios
- **Nuevo webhook `POST /api/edenred/notify-2fa`**: auth Bearer con `EDENRED_WEBHOOK_SECRET`, resuelve el usuario único (`user_config`) y firma el push en el servidor con `sendPushToUser` (las claves VAPID nunca salen de Vercel). Mensaje: *"Edenred requiere 2FA — ejecuta «pnpm scrape:edenred:login»"*, abre `/cuentas` al pulsar.
- **Disparo desde el scraper** (`scrape.mjs`): helper `enterTwoFaPending()` que marca el guard `edenred-2fa-pending` (siempre, anti-spam de credenciales) y dispara el push **una sola vez por episodio** — solo en la transición y bajo cron. Conectado en los dos puntos de entrada a 2FA: auto-relogin que desemboca en 2FA, y 2FA visible ya en la carga inicial (rama que antes no marcaba pendiente).
- **Refactor**: `safeBearerMatch` estaba duplicado en 3 rutas (edenred, sabadell-visa, enablebanking/cron) → extraído a `lib/http/bearer.ts`.

## Decisiones de diseño
- Mecanismo = endpoint en la app (no envío directo desde el scraper): mantiene los secrets VAPID en el servidor, encaja con el patrón webhook existente. **No requiere env vars nuevas** (`APP_URL` + `EDENRED_WEBHOOK_SECRET` ya en `.env.scrapers`).
- La notificación nativa de macOS existente (`notifySessionExpired`) se mantiene: otra superficie (el Mac), mensaje genérico; el push es cross-device y específico de 2FA. Coexisten.

## Verificación
- `pnpm test` (347 ✓, incluye tests nuevos del endpoint: auth 401, misconfig 500, no-user 500, envío OK con payload esperado, 500 si VAPID falla), `pnpm lint`, `pnpm build` (ruta `/api/edenred/notify-2fa` registrada).
- E2E manual pendiente de validar contra suscripción real: `curl -X POST "$APP_URL/api/edenred/notify-2fa" -H "authorization: Bearer $EDENRED_WEBHOOK_SECRET"` → llega push y responde `{ "sent": N }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)