### PR TITLE
fix(transactions): revalidar badge de no leídos al volver a primer plano (PWA)

### DIFF
--- a/app/api/transactions/unread-count/route.ts
+++ b/app/api/transactions/unread-count/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
+
+// Conteo de movimientos no leídos para refrescar el badge de la tabBar sin
+// recargar la página. El #149 calculaba el count solo en el server component del
+// layout; en una PWA (sobre todo iOS) reabrir desde segundo plano no lo
+// re-ejecuta, así que el badge se quedaba con un valor obsoleto. El
+// `UnreadProvider` consulta este endpoint al volver a primer plano
+// (visibilitychange). RLS limita la consulta al hogar del usuario; `head: true`
+// evita traer filas (solo el conteo, apoyado en el índice parcial de #149).
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { count, error } = await supabase
+    .from('transactions')
+    .select('*', { count: 'exact', head: true })
+    .eq('is_read', false)
+
+  if (error) {
+    console.error('[GET /api/transactions/unread-count]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions/unread-count',
+      context: { op: 'count', code: error.code },
+      userId: user.id,
+      householdId,
+    })
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ count: count ?? 0 })
+}

--- a/components/transactions/UnreadProvider.tsx
+++ b/components/transactions/UnreadProvider.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -53,6 +54,28 @@ export function UnreadProvider({
   const decrement = useCallback(() => setCountState(c => Math.max(0, c - 1)), [])
   const increment = useCallback(() => setCountState(c => c + 1), [])
   const setCount = useCallback((n: number) => setCountState(Math.max(0, n)), [])
+
+  // En una PWA (sobre todo iOS) reabrir la app desde segundo plano no re-ejecuta
+  // el server component del layout, así que el badge se quedaba clavado con el
+  // último valor (p.ej. seguía marcando no leídos ya leídos en otra sesión o en
+  // un sync en background). Al volver a primer plano revalidamos el contador
+  // contra el servidor —consulta barata, solo el conteo— y fijamos el valor
+  // autoritativo. Es independiente de los ajustes optimistas de marcar leído.
+  useEffect(() => {
+    function revalidate() {
+      if (document.visibilityState !== 'visible') return
+      fetch('/api/transactions/unread-count', { cache: 'no-store' })
+        .then(res => (res.ok ? res.json() : null))
+        .then(json => {
+          if (json && typeof json.count === 'number') setCount(json.count)
+        })
+        .catch(() => {
+          // Sin red / offline: conservar el valor actual, no romper el badge.
+        })
+    }
+    document.addEventListener('visibilitychange', revalidate)
+    return () => document.removeEventListener('visibilitychange', revalidate)
+  }, [setCount])
 
   const value = useMemo<UnreadValue>(
     () => ({ count, decrement, increment, setCount }),


### PR DESCRIPTION
## Problema

El badge de movimientos no leídos en la tabBar (#149) mostraba un valor obsoleto en la PWA de iOS: marcaba "2 no leídos" cuando en la BD no había ninguno (`select ... where is_read = false` → 0 filas).

**Causa:** el #149 calcula el contador **solo** en el server component del layout ([app/(app)/layout.tsx](app/(app)/layout.tsx)) y confía en `router.refresh()` tras un sync para recalcularlo. Pero al reabrir la PWA desde segundo plano, iOS **no re-ejecuta** el layout, así que el badge se queda con el último valor. No es una regresión del #149: el caso de "revalidar al volver a primer plano" quedó fuera de su alcance, y en una PWA no se puede recargar la página manualmente.

## Solución

- **Nuevo endpoint ligero** `GET /api/transactions/unread-count`: devuelve solo el conteo (`count: 'exact', head: true`, apoyado en el índice parcial `WHERE is_read = false` de #149). RLS limita al hogar.
- **`UnreadProvider`** revalida el contador contra el servidor en `visibilitychange` al volver a primer plano y fija el valor autoritativo con `setCount`. No interfiere con los ajustes optimistas de marcar leído/no leído (esos siguen igual).

También cubre como red de seguridad cualquier desincronización futura: leer un movimiento en otra sesión/dispositivo o un sync en background dejan de poder "clavar" el badge.

## Validación

- `pnpm test` → 347 passed
- `pnpm lint` → limpio
- `pnpm build` → OK (ruta `/api/transactions/unread-count` registrada)

Pendiente de verificar en el dispositivo: reabrir la PWA desde segundo plano debe poner el badge a 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)