### PR TITLE
fix(transactions): revalidar badge de no leídos en primer plano (poll + navegación)

### DIFF
--- a/components/transactions/UnreadProvider.tsx
+++ b/components/transactions/UnreadProvider.tsx
@@ -8,6 +8,12 @@ import {
   useMemo,
   useState,
 } from 'react'
+import { usePathname } from 'next/navigation'
+
+// Cada cuánto revalidar el contador contra el servidor mientras la app está
+// visible. Cubre el caso de que el nº de no leídos cambie desde otro dispositivo
+// con esta app abierta y en primer plano (no hay router.refresh ni navegación).
+const POLL_INTERVAL_MS = 60_000
 
 interface UnreadValue {
   /** Nº de movimientos no leídos (alimenta el badge de la tabBar). */
@@ -55,27 +61,44 @@ export function UnreadProvider({
   const increment = useCallback(() => setCountState(c => c + 1), [])
   const setCount = useCallback((n: number) => setCountState(Math.max(0, n)), [])
 
-  // En una PWA (sobre todo iOS) reabrir la app desde segundo plano no re-ejecuta
-  // el server component del layout, así que el badge se quedaba clavado con el
-  // último valor (p.ej. seguía marcando no leídos ya leídos en otra sesión o en
-  // un sync en background). Al volver a primer plano revalidamos el contador
-  // contra el servidor —consulta barata, solo el conteo— y fijamos el valor
-  // autoritativo. Es independiente de los ajustes optimistas de marcar leído.
-  useEffect(() => {
-    function revalidate() {
-      if (document.visibilityState !== 'visible') return
-      fetch('/api/transactions/unread-count', { cache: 'no-store' })
-        .then(res => (res.ok ? res.json() : null))
-        .then(json => {
-          if (json && typeof json.count === 'number') setCount(json.count)
-        })
-        .catch(() => {
-          // Sin red / offline: conservar el valor actual, no romper el badge.
-        })
+  // Revalida el contador contra el servidor y fija el valor autoritativo. Barata
+  // (solo el conteo) e independiente de los ajustes optimistas de marcar leído.
+  // Se autolimita a la app visible para no consultar en segundo plano.
+  const revalidate = useCallback(() => {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+      return
     }
-    document.addEventListener('visibilitychange', revalidate)
-    return () => document.removeEventListener('visibilitychange', revalidate)
+    fetch('/api/transactions/unread-count', { cache: 'no-store' })
+      .then(res => (res.ok ? res.json() : null))
+      .then(json => {
+        if (json && typeof json.count === 'number') setCount(json.count)
+      })
+      .catch(() => {
+        // Sin red / offline: conservar el valor actual, no romper el badge.
+      })
   }, [setCount])
+
+  // El badge vive en el layout y no se recomputa con la navegación soft de App
+  // Router (reutiliza el layout cacheado), así que sin estos disparadores se
+  // queda obsoleto cuando el nº de no leídos cambia por fuera (otra sesión u
+  // otro dispositivo). Revalidamos en tres momentos, todos con la app visible:
+  //  1. Al volver a primer plano (visibilitychange) — reabrir la PWA en iOS.
+  //  2. Periódicamente mientras está visible — la app abierta y un cambio
+  //     externo, sin navegar ni mandarla a segundo plano.
+  //  3. En cada navegación (cambio de pathname) — feedback inmediato al moverse.
+  useEffect(() => {
+    document.addEventListener('visibilitychange', revalidate)
+    const intervalId = setInterval(revalidate, POLL_INTERVAL_MS)
+    return () => {
+      document.removeEventListener('visibilitychange', revalidate)
+      clearInterval(intervalId)
+    }
+  }, [revalidate])
+
+  const pathname = usePathname()
+  useEffect(() => {
+    revalidate()
+  }, [pathname, revalidate])
 
   const value = useMemo<UnreadValue>(
     () => ({ count, decrement, increment, setCount }),


### PR DESCRIPTION
Cierra #216. Continuación de #215.

## Problema

Con la app abierta y en primer plano, si el nº de no leídos cambia por fuera (otro dispositivo/sesión), el badge sigue mostrando el valor anterior aunque se navegue por el menú. La navegación soft de App Router reutiliza el layout cacheado y no reconsulta el servidor, así que el `UnreadProvider` solo se actualizaba por ajustes optimistas locales o `visibilitychange` (#215).

## Solución

Se extrae `revalidate()` y se dispara en tres momentos, todos autolimitados a la app visible:
1. `visibilitychange` (ya existía) — reabrir la PWA en iOS.
2. **Intervalo de 60s** mientras está visible — cubre el cambio externo sin navegar ni mandar a segundo plano.
3. **Cambio de `pathname`** — feedback inmediato al navegar.

Consistencia eventual (≤60s, o instantánea al navegar), coste despreciable, sin infra extra. Se descartó Supabase Realtime por sobredimensionado para un caso raro en una app personal.

## Validación
- `pnpm test` → 347 passed
- `pnpm lint` → limpio
- `pnpm build` → OK

Pendiente de verificar en dispositivo: cambiar no leídos en otro dispositivo se refleja en el iPhone con la app abierta (≤60s o al navegar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)