### PR TITLE
feat(transactions): animación de salida/entrada al reorganizar «No leídos»

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,3 +158,16 @@
 .animate-fade-in {
   animation: fadeIn 0.2s ease forwards;
 }
+
+/* Entrada de una fila que se recoloca entre «No leídos» y su grupo de día
+   (issue #220): se monta colapsada y se expande con fade. La salida se hace por
+   transición inline en la propia fila; aquí solo la entrada, que necesita un
+   keyframe para garantizar el frame inicial al montar ya en estado final. */
+@keyframes rowIn {
+  from { grid-template-rows: 0fr; opacity: 0; }
+  to   { grid-template-rows: 1fr; opacity: 1; }
+}
+
+.animate-row-in {
+  animation: rowIn 0.2s ease-out forwards;
+}

--- a/components/transactions/TransactionsClient.tsx
+++ b/components/transactions/TransactionsClient.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
+import { useReducedMotion } from '@/hooks/useReducedMotion'
+import type { TxRowPhase } from './TxRow'
 import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
 import { CategoryPicker } from './CategoryPicker'
@@ -15,6 +17,10 @@ import { useTxPagination } from './useTxPagination'
 import { groupTxByDate } from '@/lib/transactions'
 import type { TransactionCursor } from '@/lib/pagination'
 import type { Account, TransactionWithAccount } from '@/types'
+
+// Debe coincidir con la duración de `.animate-row-in` y la transición de colapso
+// de `TxRow` (#220), en ms.
+const REORG_ANIM_MS = 200
 
 interface TransactionsClientProps {
   initialTransactions: TransactionWithAccount[]
@@ -44,6 +50,21 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
   const [swiped, setSwiped] = useState<{ id: string; side: SwipeSide } | null>(null)
   const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
   const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
+
+  // Animación de reorganización de «No leídos» (#220). Confirmación en dos fases:
+  // la fila colapsa en su sitio (`leavingIds`) antes de cambiar `is_read`, y al
+  // recolocarse entra expandiéndose (`enteringIds`). Con reduced-motion se omite.
+  const reducedMotion = useReducedMotion()
+  const [leavingIds, setLeavingIds] = useState<Set<string>>(() => new Set())
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set())
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  useEffect(() => () => { timeoutsRef.current.forEach(clearTimeout) }, [])
+
+  const phaseOf = useCallback(
+    (id: string): TxRowPhase =>
+      leavingIds.has(id) ? 'leaving' : enteringIds.has(id) ? 'entering' : 'idle',
+    [leavingIds, enteringIds]
+  )
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
 
@@ -75,8 +96,29 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
 
   function handleToggleRead(tx: TransactionWithAccount) {
     setSwiped(null)
-    if (tx.is_read) void markUnread(tx.id)
-    else void markRead(tx.id)
+    const apply = () => {
+      if (tx.is_read) void markUnread(tx.id)
+      else void markRead(tx.id)
+    }
+    // Con reduced-motion (o sin animación) se cambia el estado al instante.
+    if (reducedMotion) {
+      apply()
+      return
+    }
+    const id = tx.id
+    // Fase 1: colapsar la fila en su posición actual sin tocar `is_read`.
+    setLeavingIds(prev => new Set(prev).add(id))
+    const tLeave = setTimeout(() => {
+      // Fase 2: commit del cambio (la fila se recoloca) + entrada animada.
+      setLeavingIds(prev => { const next = new Set(prev); next.delete(id); return next })
+      apply()
+      setEnteringIds(prev => new Set(prev).add(id))
+      const tEnter = setTimeout(() => {
+        setEnteringIds(prev => { const next = new Set(prev); next.delete(id); return next })
+      }, REORG_ANIM_MS)
+      timeoutsRef.current.push(tEnter)
+    }, REORG_ANIM_MS)
+    timeoutsRef.current.push(tLeave)
   }
 
   async function handleDelete(txId: string) {
@@ -102,6 +144,7 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
         groups={groups}
         pinnedUnread={pinnedUnread}
         swiped={swiped}
+        phaseOf={phaseOf}
         onOpenSwipe={(id, side) => setSwiped({ id, side })}
         onCloseSwipe={() => setSwiped(null)}
         onRecategorize={handleRecategorize}

--- a/components/transactions/TransactionsList.tsx
+++ b/components/transactions/TransactionsList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { TxRow } from './TxRow'
+import { TxRow, type TxRowPhase } from './TxRow'
 import { TxDayGroupCard } from './TxDayGroupCard'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -13,6 +13,8 @@ interface TransactionsListProps {
   /** Movimientos no leídos fijados arriba (lista plana por fecha desc). */
   pinnedUnread: TransactionWithAccount[]
   swiped: { id: string; side: SwipeSide } | null
+  /** Fase de animación de reorganización por id de movimiento (#220). */
+  phaseOf: (id: string) => TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -28,6 +30,7 @@ export function TransactionsList({
   groups,
   pinnedUnread,
   swiped,
+  phaseOf,
   onOpenSwipe,
   onCloseSwipe,
   onRecategorize,
@@ -43,6 +46,7 @@ export function TransactionsList({
   const rowProps = (tx: TransactionWithAccount) => ({
     tx,
     openSide: swiped?.id === tx.id ? swiped.side : null,
+    phase: phaseOf(tx.id),
     onOpenSwipe,
     onCloseSwipe,
     onRecategorize,
@@ -99,6 +103,7 @@ export function TransactionsList({
             key={group.date}
             group={group}
             swiped={swiped}
+            phaseOf={phaseOf}
             onOpenSwipe={onOpenSwipe}
             onCloseSwipe={onCloseSwipe}
             onRecategorize={onRecategorize}

--- a/components/transactions/TxDayGroupCard.tsx
+++ b/components/transactions/TxDayGroupCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { TxRow } from './TxRow'
+import { TxRow, type TxRowPhase } from './TxRow'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { fmt } from '@/lib/formatting'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
@@ -9,6 +9,8 @@ import type { TransactionWithAccount } from '@/types'
 interface TxDayGroupCardProps {
   group: TxDayGroup
   swiped: { id: string; side: SwipeSide } | null
+  /** Fase de animación de reorganización por id (#220). Sin animación si se omite. */
+  phaseOf?: (id: string) => TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -25,6 +27,7 @@ interface TxDayGroupCardProps {
 export function TxDayGroupCard({
   group,
   swiped,
+  phaseOf = () => 'idle',
   onOpenSwipe,
   onCloseSwipe,
   onRecategorize,
@@ -51,6 +54,7 @@ export function TxDayGroupCard({
             key={tx.id}
             tx={tx}
             openSide={swiped?.id === tx.id ? swiped.side : null}
+            phase={phaseOf(tx.id)}
             onOpenSwipe={onOpenSwipe}
             onCloseSwipe={onCloseSwipe}
             onRecategorize={onRecategorize}

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -7,10 +7,18 @@ import { fmt } from '@/lib/formatting'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
+/**
+ * Fase de animación de reorganización entre «No leídos» y el grupo de día (#220):
+ * `leaving` colapsa la fila en su sitio antes de recolocarse; `entering` la expande
+ * al aparecer en su nueva posición; `idle` no anima.
+ */
+export type TxRowPhase = 'leaving' | 'entering' | 'idle'
+
 interface TxRowProps {
   tx: TransactionWithAccount
   /** Lado del panel de acción abierto para ESTA fila (`null` si está cerrada). */
   openSide: SwipeSide | null
+  phase?: TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -20,7 +28,7 @@ interface TxRowProps {
 
 const ACTION_WIDTH = 120
 
-export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize, onToggleRead, onTap }: TxRowProps) {
+export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe, onRecategorize, onToggleRead, onTap }: TxRowProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category) as CategoryId | null
   const meta = effectiveCategory ? (CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other) : UNCATEGORIZED
   const Icon = meta.Icon
@@ -35,9 +43,25 @@ export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize,
   const absAmount = fmt(Math.abs(tx.amount), 2)
   const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
 
+  const leaving = phase === 'leaving'
+
   return (
-    // overflow-hidden recorta los paneles de acción cuando están fuera de la fila
-    <div className="overflow-hidden">
+    // Wrapper de colapso (#220): grid-template-rows 1fr→0fr + opacity recoloca la
+    // fila sin saltos. `leaving` transiciona a colapsado; `entering` arranca
+    // colapsado y se expande vía keyframe `animate-row-in`.
+    <div
+      className={cn(
+        'grid transition-[grid-template-rows,opacity] duration-200 ease-out',
+        phase === 'entering' && 'animate-row-in'
+      )}
+      style={{
+        gridTemplateRows: leaving ? '0fr' : '1fr',
+        opacity: leaving ? 0 : 1,
+      }}
+    >
+      {/* overflow-hidden recorta los paneles de acción cuando están fuera de la fila
+          y el contenido de la fila mientras el grid colapsa */}
+      <div className="overflow-hidden">
       {/*
        * Slider flex único: [panel izq][contenido][panel der]
        * En reposo: translateX(-ACTION_WIDTH) → ambos paneles fuera, contenido visible
@@ -132,6 +156,7 @@ export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize,
             )}
           </button>
         </div>
+      </div>
       </div>
     </div>
   )

--- a/hooks/useReducedMotion.ts
+++ b/hooks/useReducedMotion.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function subscribe(onChange: () => void): () => void {
+  const mql = window.matchMedia(QUERY)
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}
+
+const getSnapshot = (): boolean => window.matchMedia(QUERY).matches
+
+// En SSR no hay `matchMedia`: asumimos sin reducción (snapshot estable).
+const getServerSnapshot = (): boolean => false
+
+/**
+ * Indica si el usuario ha pedido reducir el movimiento a nivel de sistema,
+ * suscribiéndose a cambios en la preferencia.
+ */
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}


### PR DESCRIPTION
## Contexto

Cierra #220. Tras la reorganización en vivo de #218/#219, al marcar leído/no leído desde el swipe la fila saltaba al instante entre la sección «No leídos» y su grupo de día, sin transición. Este PR suaviza ese movimiento con una animación sutil **fade + collapse**, puro pulido sin tocar la lógica de membresía.

## Enfoque

**Confirmación en dos fases** orquestada en `TransactionsClient`, aprovechando que la fila sigue montada en su posición original:

1. **Salida (`leaving`):** al togglear no se cambia aún `is_read`; la fila colapsa en su sitio (`grid-template-rows: 1fr→0fr` + opacity) → sin recálculo de membresía, sin salto.
2. **Commit + entrada (`entering`):** al terminar (~200 ms) se llama a la mutación real → la membresía viva recoloca la fila, que entra expandiéndose con el keyframe `rowIn`.

Decisiones (acordadas en planificación): **CSS propio** sin librería de animación (encaja con el ethos lean del proyecto) y alcance **solo el toggle del swipe** (el tap-abrir-detalle queda instantáneo, oculto tras el modal).

## Accesibilidad

Nuevo hook `useReducedMotion` (`useSyncExternalStore` sobre `matchMedia`). Con `prefers-reduced-motion: reduce` se cortocircuita y el cambio es instantáneo.

## Cambios

- `hooks/useReducedMotion.ts` *(nuevo)*
- `components/transactions/TransactionsClient.tsx` — orquestación dos fases (`leavingIds`/`enteringIds` + `phaseOf`)
- `components/transactions/TransactionsList.tsx` y `TxDayGroupCard.tsx` — propagan `phaseOf` (opcional en el grupo de día; la vista de detalle de categoría no anima)
- `components/transactions/TxRow.tsx` — prop `phase` + wrapper de colapso
- `app/globals.css` — `@keyframes rowIn` / `.animate-row-in`

## Validación

`pnpm test` (347 ✓), `pnpm lint` y `pnpm build` en verde. Pendiente prueba manual en `/transactions`: marcar leído/no leído (salida + entrada animadas, sin saltos), tap instantáneo, reduced-motion (instantáneo), y toggles concurrentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)