### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -98,5 +98,6 @@ git checkout develop
 
 | Versión | Fecha | Notas |
 | --- | --- | --- |
+| `v0.3.0` | 2026-06-18 | Sección «No leídos» de transacciones: reorganización en vivo (#219) con animación de entrada/salida (#221) y revalidación del badge al volver a primer plano (#214, #217). |
 | `v0.2.0` | 2026-06-17 | Observabilidad (error_log #200) y mejoras del scraper Edenred: auto-relogin (#208) y push accionable ante 2FA (#204). |
 | `v0.1.1` | 2026-06-13 | Primer release con versionado SemVer. 5 fixes de seguridad (#178, #179, #180, #182, #191). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Bump de versión a **v0.3.0**.

Salto **menor** (presencia de `feat:` desde `v0.2.0`).

## Incluido desde v0.2.0
- feat(transactions): animación de salida/entrada al reorganizar «No leídos» (#221)
- feat(transactions): reorganización en vivo de la sección «No leídos» (#219)
- fix(transactions): revalidar badge de no leídos en primer plano (#217)
- fix(transactions): revalidar badge de no leídos al volver a primer plano (#214)

🤖 Generated with [Claude Code](https://claude.com/claude-code)