### PR TITLE
Release v0.3.0

### DIFF
--- a/app/api/transactions/unread-count/route.ts
+++ b/app/api/transactions/unread-count/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
+import { logError } from '@/lib/error-log'
+
+// Conteo de movimientos no leídos para refrescar el badge de la tabBar sin
+// recargar la página. El #149 calculaba el count solo en el server component del
+// layout; en una PWA (sobre todo iOS) reabrir desde segundo plano no lo
+// re-ejecuta, así que el badge se quedaba con un valor obsoleto. El
+// `UnreadProvider` consulta este endpoint al volver a primer plano
+// (visibilitychange). RLS limita la consulta al hogar del usuario; `head: true`
+// evita traer filas (solo el conteo, apoyado en el índice parcial de #149).
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { count, error } = await supabase
+    .from('transactions')
+    .select('*', { count: 'exact', head: true })
+    .eq('is_read', false)
+
+  if (error) {
+    console.error('[GET /api/transactions/unread-count]', error)
+    await logError({
+      source: 'server',
+      message: error.message,
+      route: '/api/transactions/unread-count',
+      context: { op: 'count', code: error.code },
+      userId: user.id,
+      householdId,
+    })
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ count: count ?? 0 })
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -158,3 +158,16 @@
 .animate-fade-in {
   animation: fadeIn 0.2s ease forwards;
 }
+
+/* Entrada de una fila que se recoloca entre «No leídos» y su grupo de día
+   (issue #220): se monta colapsada y se expande con fade. La salida se hace por
+   transición inline en la propia fila; aquí solo la entrada, que necesita un
+   keyframe para garantizar el frame inicial al montar ya en estado final. */
+@keyframes rowIn {
+  from { grid-template-rows: 0fr; opacity: 0; }
+  to   { grid-template-rows: 1fr; opacity: 1; }
+}
+
+.animate-row-in {
+  animation: rowIn 0.2s ease-out forwards;
+}

--- a/components/transactions/TransactionsClient.tsx
+++ b/components/transactions/TransactionsClient.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
+import { useReducedMotion } from '@/hooks/useReducedMotion'
+import type { TxRowPhase } from './TxRow'
 import { TxModal } from './TxModal'
 import { AccountFilter } from './AccountFilter'
 import { CategoryPicker } from './CategoryPicker'
@@ -15,6 +17,10 @@ import { useTxPagination } from './useTxPagination'
 import { groupTxByDate } from '@/lib/transactions'
 import type { TransactionCursor } from '@/lib/pagination'
 import type { Account, TransactionWithAccount } from '@/types'
+
+// Debe coincidir con la duración de `.animate-row-in` y la transición de colapso
+// de `TxRow` (#220), en ms.
+const REORG_ANIM_MS = 200
 
 interface TransactionsClientProps {
   initialTransactions: TransactionWithAccount[]
@@ -44,6 +50,21 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
   const [swiped, setSwiped] = useState<{ id: string; side: SwipeSide } | null>(null)
   const [selectedTxId, setSelectedTxId] = useState<string | null>(null)
   const [catPickerTx, setCatPickerTx] = useState<TransactionWithAccount | null>(null)
+
+  // Animación de reorganización de «No leídos» (#220). Confirmación en dos fases:
+  // la fila colapsa en su sitio (`leavingIds`) antes de cambiar `is_read`, y al
+  // recolocarse entra expandiéndose (`enteringIds`). Con reduced-motion se omite.
+  const reducedMotion = useReducedMotion()
+  const [leavingIds, setLeavingIds] = useState<Set<string>>(() => new Set())
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set())
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  useEffect(() => () => { timeoutsRef.current.forEach(clearTimeout) }, [])
+
+  const phaseOf = useCallback(
+    (id: string): TxRowPhase =>
+      leavingIds.has(id) ? 'leaving' : enteringIds.has(id) ? 'entering' : 'idle',
+    [leavingIds, enteringIds]
+  )
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
 
@@ -75,8 +96,29 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
 
   function handleToggleRead(tx: TransactionWithAccount) {
     setSwiped(null)
-    if (tx.is_read) void markUnread(tx.id)
-    else void markRead(tx.id)
+    const apply = () => {
+      if (tx.is_read) void markUnread(tx.id)
+      else void markRead(tx.id)
+    }
+    // Con reduced-motion (o sin animación) se cambia el estado al instante.
+    if (reducedMotion) {
+      apply()
+      return
+    }
+    const id = tx.id
+    // Fase 1: colapsar la fila en su posición actual sin tocar `is_read`.
+    setLeavingIds(prev => new Set(prev).add(id))
+    const tLeave = setTimeout(() => {
+      // Fase 2: commit del cambio (la fila se recoloca) + entrada animada.
+      setLeavingIds(prev => { const next = new Set(prev); next.delete(id); return next })
+      apply()
+      setEnteringIds(prev => new Set(prev).add(id))
+      const tEnter = setTimeout(() => {
+        setEnteringIds(prev => { const next = new Set(prev); next.delete(id); return next })
+      }, REORG_ANIM_MS)
+      timeoutsRef.current.push(tEnter)
+    }, REORG_ANIM_MS)
+    timeoutsRef.current.push(tLeave)
   }
 
   async function handleDelete(txId: string) {
@@ -102,6 +144,7 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
         groups={groups}
         pinnedUnread={pinnedUnread}
         swiped={swiped}
+        phaseOf={phaseOf}
         onOpenSwipe={(id, side) => setSwiped({ id, side })}
         onCloseSwipe={() => setSwiped(null)}
         onRecategorize={handleRecategorize}

--- a/components/transactions/TransactionsClient.tsx
+++ b/components/transactions/TransactionsClient.tsx
@@ -29,26 +29,6 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
   const pagination = useTxPagination({ initialCursor, appendTxs })
   const filters = useTransactionsFilters(transactions, initialAccountIds)
 
-  // Membresía CONGELADA de la sección «No leídos»: un movimiento entra en la
-  // sección si era no leído la primera vez que apareció en la lista (snapshot
-  // inicial o página paginada), y permanece aunque luego se marque leído. Así el
-  // dot se apaga al instante pero la fila no salta. Al volver/recargar el
-  // componente se remonta y la membresía se recalcula desde datos frescos.
-  //
-  // Se modela con estado (no refs) y se actualiza durante el render —patrón
-  // recomendado por React— al detectar ids nuevos respecto a los ya vistos.
-  const [seenIds, setSeenIds] = useState<Set<string>>(
-    () => new Set(initialTransactions.map(t => t.id))
-  )
-  const [pinnedIds, setPinnedIds] = useState<Set<string>>(
-    () => new Set(initialTransactions.filter(t => !t.is_read).map(t => t.id))
-  )
-  const freshIds = transactions.filter(t => !seenIds.has(t.id))
-  if (freshIds.length > 0) {
-    setSeenIds(prev => new Set([...prev, ...freshIds.map(t => t.id)]))
-    setPinnedIds(prev => new Set([...prev, ...freshIds.filter(t => !t.is_read).map(t => t.id)]))
-  }
-
   // `?account=` solo actúa como deep-link de entrada: lo consumimos en el server
   // para inicializar el filtro y aquí limpiamos la URL para evitar que mienta
   // cuando el usuario cambia el filtro desde el selector. `replaceState` no
@@ -67,15 +47,18 @@ export function TransactionsClient({ initialTransactions, initialCursor, account
 
   const selectedTx = selectedTxId ? transactions.find(t => t.id === selectedTxId) ?? null : null
 
-  // Partición de la vista filtrada: arriba los «No leídos» (membresía congelada,
-  // lista plana por fecha desc) y debajo el resto agrupado por día como siempre.
+  // Partición de la vista filtrada: arriba los «No leídos» (lista plana por fecha
+  // desc) y debajo el resto agrupado por día. La membresía es VIVA: depende de
+  // `is_read` en cada render, así que marcar leído/no leído reorganiza la fila al
+  // instante (baja a su día o sube a la sección) y el contador del encabezado
+  // refleja siempre los no leídos reales de la vista cargada.
   const pinnedUnread = useMemo(
-    () => filters.filtered.filter(t => pinnedIds.has(t.id)),
-    [filters.filtered, pinnedIds]
+    () => filters.filtered.filter(t => !t.is_read),
+    [filters.filtered]
   )
   const groups = useMemo(
-    () => groupTxByDate(filters.filtered.filter(t => !pinnedIds.has(t.id))),
-    [filters.filtered, pinnedIds]
+    () => groupTxByDate(filters.filtered.filter(t => t.is_read)),
+    [filters.filtered]
   )
 
   function handleTxTap(tx: TransactionWithAccount) {

--- a/components/transactions/TransactionsList.tsx
+++ b/components/transactions/TransactionsList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { TxRow } from './TxRow'
+import { TxRow, type TxRowPhase } from './TxRow'
 import { TxDayGroupCard } from './TxDayGroupCard'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -13,6 +13,8 @@ interface TransactionsListProps {
   /** Movimientos no leídos fijados arriba (lista plana por fecha desc). */
   pinnedUnread: TransactionWithAccount[]
   swiped: { id: string; side: SwipeSide } | null
+  /** Fase de animación de reorganización por id de movimiento (#220). */
+  phaseOf: (id: string) => TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -28,6 +30,7 @@ export function TransactionsList({
   groups,
   pinnedUnread,
   swiped,
+  phaseOf,
   onOpenSwipe,
   onCloseSwipe,
   onRecategorize,
@@ -43,6 +46,7 @@ export function TransactionsList({
   const rowProps = (tx: TransactionWithAccount) => ({
     tx,
     openSide: swiped?.id === tx.id ? swiped.side : null,
+    phase: phaseOf(tx.id),
     onOpenSwipe,
     onCloseSwipe,
     onRecategorize,
@@ -99,6 +103,7 @@ export function TransactionsList({
             key={group.date}
             group={group}
             swiped={swiped}
+            phaseOf={phaseOf}
             onOpenSwipe={onOpenSwipe}
             onCloseSwipe={onCloseSwipe}
             onRecategorize={onRecategorize}

--- a/components/transactions/TxDayGroupCard.tsx
+++ b/components/transactions/TxDayGroupCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { TxRow } from './TxRow'
+import { TxRow, type TxRowPhase } from './TxRow'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { fmt } from '@/lib/formatting'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
@@ -9,6 +9,8 @@ import type { TransactionWithAccount } from '@/types'
 interface TxDayGroupCardProps {
   group: TxDayGroup
   swiped: { id: string; side: SwipeSide } | null
+  /** Fase de animación de reorganización por id (#220). Sin animación si se omite. */
+  phaseOf?: (id: string) => TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -25,6 +27,7 @@ interface TxDayGroupCardProps {
 export function TxDayGroupCard({
   group,
   swiped,
+  phaseOf = () => 'idle',
   onOpenSwipe,
   onCloseSwipe,
   onRecategorize,
@@ -51,6 +54,7 @@ export function TxDayGroupCard({
             key={tx.id}
             tx={tx}
             openSide={swiped?.id === tx.id ? swiped.side : null}
+            phase={phaseOf(tx.id)}
             onOpenSwipe={onOpenSwipe}
             onCloseSwipe={onCloseSwipe}
             onRecategorize={onRecategorize}

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -7,10 +7,18 @@ import { fmt } from '@/lib/formatting'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
+/**
+ * Fase de animación de reorganización entre «No leídos» y el grupo de día (#220):
+ * `leaving` colapsa la fila en su sitio antes de recolocarse; `entering` la expande
+ * al aparecer en su nueva posición; `idle` no anima.
+ */
+export type TxRowPhase = 'leaving' | 'entering' | 'idle'
+
 interface TxRowProps {
   tx: TransactionWithAccount
   /** Lado del panel de acción abierto para ESTA fila (`null` si está cerrada). */
   openSide: SwipeSide | null
+  phase?: TxRowPhase
   onOpenSwipe: (id: string, side: SwipeSide) => void
   onCloseSwipe: () => void
   onRecategorize: (tx: TransactionWithAccount) => void
@@ -20,7 +28,7 @@ interface TxRowProps {
 
 const ACTION_WIDTH = 120
 
-export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize, onToggleRead, onTap }: TxRowProps) {
+export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe, onRecategorize, onToggleRead, onTap }: TxRowProps) {
   const effectiveCategory = (tx.category_manual ?? tx.category) as CategoryId | null
   const meta = effectiveCategory ? (CATEGORY_META[effectiveCategory] ?? CATEGORY_META.other) : UNCATEGORIZED
   const Icon = meta.Icon
@@ -35,9 +43,25 @@ export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize,
   const absAmount = fmt(Math.abs(tx.amount), 2)
   const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
 
+  const leaving = phase === 'leaving'
+
   return (
-    // overflow-hidden recorta los paneles de acción cuando están fuera de la fila
-    <div className="overflow-hidden">
+    // Wrapper de colapso (#220): grid-template-rows 1fr→0fr + opacity recoloca la
+    // fila sin saltos. `leaving` transiciona a colapsado; `entering` arranca
+    // colapsado y se expande vía keyframe `animate-row-in`.
+    <div
+      className={cn(
+        'grid transition-[grid-template-rows,opacity] duration-200 ease-out',
+        phase === 'entering' && 'animate-row-in'
+      )}
+      style={{
+        gridTemplateRows: leaving ? '0fr' : '1fr',
+        opacity: leaving ? 0 : 1,
+      }}
+    >
+      {/* overflow-hidden recorta los paneles de acción cuando están fuera de la fila
+          y el contenido de la fila mientras el grid colapsa */}
+      <div className="overflow-hidden">
       {/*
        * Slider flex único: [panel izq][contenido][panel der]
        * En reposo: translateX(-ACTION_WIDTH) → ambos paneles fuera, contenido visible
@@ -132,6 +156,7 @@ export function TxRow({ tx, openSide, onOpenSwipe, onCloseSwipe, onRecategorize,
             )}
           </button>
         </div>
+      </div>
       </div>
     </div>
   )

--- a/components/transactions/UnreadProvider.tsx
+++ b/components/transactions/UnreadProvider.tsx
@@ -8,6 +8,12 @@ import {
   useMemo,
   useState,
 } from 'react'
+import { usePathname } from 'next/navigation'
+
+// Cada cuánto revalidar el contador contra el servidor mientras la app está
+// visible. Cubre el caso de que el nº de no leídos cambie desde otro dispositivo
+// con esta app abierta y en primer plano (no hay router.refresh ni navegación).
+const POLL_INTERVAL_MS = 60_000
 
 interface UnreadValue {
   /** Nº de movimientos no leídos (alimenta el badge de la tabBar). */
@@ -55,27 +61,44 @@ export function UnreadProvider({
   const increment = useCallback(() => setCountState(c => c + 1), [])
   const setCount = useCallback((n: number) => setCountState(Math.max(0, n)), [])
 
-  // En una PWA (sobre todo iOS) reabrir la app desde segundo plano no re-ejecuta
-  // el server component del layout, así que el badge se quedaba clavado con el
-  // último valor (p.ej. seguía marcando no leídos ya leídos en otra sesión o en
-  // un sync en background). Al volver a primer plano revalidamos el contador
-  // contra el servidor —consulta barata, solo el conteo— y fijamos el valor
-  // autoritativo. Es independiente de los ajustes optimistas de marcar leído.
-  useEffect(() => {
-    function revalidate() {
-      if (document.visibilityState !== 'visible') return
-      fetch('/api/transactions/unread-count', { cache: 'no-store' })
-        .then(res => (res.ok ? res.json() : null))
-        .then(json => {
-          if (json && typeof json.count === 'number') setCount(json.count)
-        })
-        .catch(() => {
-          // Sin red / offline: conservar el valor actual, no romper el badge.
-        })
+  // Revalida el contador contra el servidor y fija el valor autoritativo. Barata
+  // (solo el conteo) e independiente de los ajustes optimistas de marcar leído.
+  // Se autolimita a la app visible para no consultar en segundo plano.
+  const revalidate = useCallback(() => {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+      return
     }
-    document.addEventListener('visibilitychange', revalidate)
-    return () => document.removeEventListener('visibilitychange', revalidate)
+    fetch('/api/transactions/unread-count', { cache: 'no-store' })
+      .then(res => (res.ok ? res.json() : null))
+      .then(json => {
+        if (json && typeof json.count === 'number') setCount(json.count)
+      })
+      .catch(() => {
+        // Sin red / offline: conservar el valor actual, no romper el badge.
+      })
   }, [setCount])
+
+  // El badge vive en el layout y no se recomputa con la navegación soft de App
+  // Router (reutiliza el layout cacheado), así que sin estos disparadores se
+  // queda obsoleto cuando el nº de no leídos cambia por fuera (otra sesión u
+  // otro dispositivo). Revalidamos en tres momentos, todos con la app visible:
+  //  1. Al volver a primer plano (visibilitychange) — reabrir la PWA en iOS.
+  //  2. Periódicamente mientras está visible — la app abierta y un cambio
+  //     externo, sin navegar ni mandarla a segundo plano.
+  //  3. En cada navegación (cambio de pathname) — feedback inmediato al moverse.
+  useEffect(() => {
+    document.addEventListener('visibilitychange', revalidate)
+    const intervalId = setInterval(revalidate, POLL_INTERVAL_MS)
+    return () => {
+      document.removeEventListener('visibilitychange', revalidate)
+      clearInterval(intervalId)
+    }
+  }, [revalidate])
+
+  const pathname = usePathname()
+  useEffect(() => {
+    revalidate()
+  }, [pathname, revalidate])
 
   const value = useMemo<UnreadValue>(
     () => ({ count, decrement, increment, setCount }),

--- a/components/transactions/UnreadProvider.tsx
+++ b/components/transactions/UnreadProvider.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -53,6 +54,28 @@ export function UnreadProvider({
   const decrement = useCallback(() => setCountState(c => Math.max(0, c - 1)), [])
   const increment = useCallback(() => setCountState(c => c + 1), [])
   const setCount = useCallback((n: number) => setCountState(Math.max(0, n)), [])
+
+  // En una PWA (sobre todo iOS) reabrir la app desde segundo plano no re-ejecuta
+  // el server component del layout, así que el badge se quedaba clavado con el
+  // último valor (p.ej. seguía marcando no leídos ya leídos en otra sesión o en
+  // un sync en background). Al volver a primer plano revalidamos el contador
+  // contra el servidor —consulta barata, solo el conteo— y fijamos el valor
+  // autoritativo. Es independiente de los ajustes optimistas de marcar leído.
+  useEffect(() => {
+    function revalidate() {
+      if (document.visibilityState !== 'visible') return
+      fetch('/api/transactions/unread-count', { cache: 'no-store' })
+        .then(res => (res.ok ? res.json() : null))
+        .then(json => {
+          if (json && typeof json.count === 'number') setCount(json.count)
+        })
+        .catch(() => {
+          // Sin red / offline: conservar el valor actual, no romper el badge.
+        })
+    }
+    document.addEventListener('visibilitychange', revalidate)
+    return () => document.removeEventListener('visibilitychange', revalidate)
+  }, [setCount])
 
   const value = useMemo<UnreadValue>(
     () => ({ count, decrement, increment, setCount }),

--- a/docs/release.md
+++ b/docs/release.md
@@ -98,5 +98,6 @@ git checkout develop
 
 | Versión | Fecha | Notas |
 | --- | --- | --- |
+| `v0.3.0` | 2026-06-18 | Sección «No leídos» de transacciones: reorganización en vivo (#219) con animación de entrada/salida (#221) y revalidación del badge al volver a primer plano (#214, #217). |
 | `v0.2.0` | 2026-06-17 | Observabilidad (error_log #200) y mejoras del scraper Edenred: auto-relogin (#208) y push accionable ante 2FA (#204). |
 | `v0.1.1` | 2026-06-13 | Primer release con versionado SemVer. 5 fixes de seguridad (#178, #179, #180, #182, #191). |

--- a/hooks/useReducedMotion.ts
+++ b/hooks/useReducedMotion.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function subscribe(onChange: () => void): () => void {
+  const mql = window.matchMedia(QUERY)
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}
+
+const getSnapshot = (): boolean => window.matchMedia(QUERY).matches
+
+// En SSR no hay `matchMedia`: asumimos sin reducción (snapshot estable).
+const getServerSnapshot = (): boolean => false
+
+/**
+ * Indica si el usuario ha pedido reducir el movimiento a nivel de sistema,
+ * suscribiéndose a cambios en la preferencia.
+ */
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Release **v0.3.0** a producción.

## Incluido desde v0.2.0
- feat(transactions): reorganización en vivo de la sección «No leídos» (#219)
- feat(transactions): animación de salida/entrada al reorganizar «No leídos» (#221)
- fix(transactions): revalidar badge de no leídos al volver a primer plano (#214, #217)

🤖 Generated with [Claude Code](https://claude.com/claude-code)