### PR TITLE
feat(scrapers): push al iPhone cuando falla el scraper de Sabadell VISA (#213)

### DIFF
--- a/app/api/sabadell-visa/notify-error/route.test.ts
+++ b/app/api/sabadell-visa/notify-error/route.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createServiceClient } from '@/lib/supabase/service'
+import { sendPushToUser } from '@/lib/push'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+vi.mock('@/lib/push', () => ({
+  sendPushToUser: vi.fn(),
+}))
+
+const { POST } = await import('./route')
+
+const SECRET = 'test-secret'
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+function buildMockDb(userConfig: { data: { user_id: string } | null; error?: unknown }) {
+  const userConfigBuilder: Record<string, unknown> = {}
+  Object.assign(userConfigBuilder, {
+    select: vi.fn(() => userConfigBuilder),
+    limit: vi.fn(() => userConfigBuilder),
+    maybeSingle: vi.fn(() => Promise.resolve(userConfig)),
+  })
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === 'user_config') return userConfigBuilder
+      throw new Error(`Unmocked table: ${table}`)
+    }),
+  }
+  return db
+}
+
+function callRoute(opts: { auth?: string | null } = {}) {
+  const headers: Record<string, string> = {}
+  if (opts.auth !== null) {
+    headers.authorization = opts.auth ?? `Bearer ${SECRET}`
+  }
+  return POST(new Request('http://test/api/sabadell-visa/notify-error', { method: 'POST', headers }))
+}
+
+beforeEach(() => {
+  vi.stubEnv('SABADELL_VISA_WEBHOOK_SECRET', SECRET)
+  vi.mocked(sendPushToUser).mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /api/sabadell-visa/notify-error — auth', () => {
+  it('rechaza con 401 si falta el header Authorization', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: null })
+    expect(res.status).toBe(401)
+    expect(db.from).not.toHaveBeenCalled()
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+
+  it('rechaza con 401 si el Bearer es incorrecto', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: 'Bearer wrong' })
+    expect(res.status).toBe(401)
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/sabadell-visa/notify-error — configuración', () => {
+  it('devuelve 500 si falta SABADELL_VISA_WEBHOOK_SECRET', async () => {
+    vi.unstubAllEnvs()
+    delete process.env.SABADELL_VISA_WEBHOOK_SECRET
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Server misconfigured' })
+  })
+
+  it('devuelve 500 "No user configured" si user_config está vacío', async () => {
+    const db = buildMockDb({ data: null, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'No user configured' })
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/sabadell-visa/notify-error — envío', () => {
+  it('envía el push de sesión caducada al usuario y devuelve el conteo', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockResolvedValue(2)
+
+    const res = await callRoute()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ sent: 2 })
+
+    expect(sendPushToUser).toHaveBeenCalledTimes(1)
+    const [, userId, payload] = vi.mocked(sendPushToUser).mock.calls[0]
+    expect(userId).toBe(USER_ID)
+    expect(payload).toEqual({
+      title: 'Sabadell VISA: sesión caducada',
+      body: 'Ejecuta «pnpm scrape:sabadell-visa:login» para re-enrolar el dispositivo.',
+      url: '/cuentas',
+    })
+  })
+
+  it('devuelve 500 si sendPushToUser lanza (p. ej. VAPID sin configurar)', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockRejectedValue(new Error('VAPID env vars no configuradas'))
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Push failed' })
+  })
+})

--- a/app/api/sabadell-visa/notify-error/route.ts
+++ b/app/api/sabadell-visa/notify-error/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { safeBearerMatch } from '@/lib/http/bearer'
+import { sendPushToUser } from '@/lib/push'
+
+/**
+ * Webhook que dispara un push "Sabadell VISA: sesión caducada" (issue #213).
+ *
+ * El scraper corre en local (launchd en el Mac); cuando un fallo de sesión
+ * (exit 2: OTP / login fallido) requiere intervención, hace POST aquí para que el
+ * push se firme en el servidor (las claves VAPID nunca salen de Vercel). El propio
+ * scraper garantiza un único aviso por día atándolo al marker
+ * `sabadell-visa-notified.<fecha>`, así que este endpoint no deduplica: simplemente
+ * envía a las suscripciones del usuario.
+ *
+ * Auth por secreto compartido (`SABADELL_VISA_WEBHOOK_SECRET`, el mismo del webhook
+ * de datos /api/sabadell-visa). No lleva body. Réplica de /api/edenred/notify-2fa.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.SABADELL_VISA_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[sabadell-visa/notify-error] SABADELL_VISA_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  const db = createServiceClient()
+
+  // App personal con un único hogar: el usuario destinatario es el único registro
+  // de user_config (mismo patrón que /api/sabadell-visa).
+  const { data: userRow, error: userErr } = await db
+    .from('user_config')
+    .select('user_id')
+    .limit(1)
+    .maybeSingle()
+  if (userErr || !userRow?.user_id) {
+    console.error('[sabadell-visa/notify-error] no user_config:', userErr)
+    return NextResponse.json({ error: 'No user configured' }, { status: 500 })
+  }
+
+  try {
+    const sent = await sendPushToUser(db, userRow.user_id as string, {
+      title: 'Sabadell VISA: sesión caducada',
+      body: 'Ejecuta «pnpm scrape:sabadell-visa:login» para re-enrolar el dispositivo.',
+      url: '/cuentas',
+    })
+    return NextResponse.json({ sent })
+  } catch (err) {
+    // sendPushToUser lanza si faltan las VAPID env vars. No debe tumbar el aviso
+    // de forma silenciosa: lo logueamos y devolvemos 500 (el scraper es
+    // best-effort y no romperá su exit code por esto).
+    console.error('[sabadell-visa/notify-error] push:', err)
+    return NextResponse.json({ error: 'Push failed' }, { status: 500 })
+  }
+}

--- a/scripts/scrapers/sabadell-visa/scrape.mjs
+++ b/scripts/scrapers/sabadell-visa/scrape.mjs
@@ -57,12 +57,44 @@ function writeMarker() {
     }
   }
 }
-function notifySessionExpired() {
+// Best-effort: POST al webhook para que el servidor firme un push al iPhone (#213).
+// Las claves VAPID nunca salen de Vercel; aquí sólo hacemos POST con el secreto
+// compartido. Nunca debe romper el exit del script (calco de notify2faPending de
+// Edenred). La dedup ("un aviso por día") la garantiza el marker notifyPath().
+async function notifyError() {
+  try {
+    const appUrl = process.env.APP_URL?.replace(/\/$/, '')
+    const secret = process.env.SABADELL_VISA_WEBHOOK_SECRET
+    if (!appUrl || !secret) {
+      console.error('[sabadell-scrape] falta APP_URL/SABADELL_VISA_WEBHOOK_SECRET — sin push.')
+      return
+    }
+    const res = await fetch(`${appUrl}/api/sabadell-visa/notify-error`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${secret}` },
+    })
+    if (!res.ok) {
+      console.error(`[sabadell-scrape] push respondió ${res.status}`)
+    } else {
+      console.log('[sabadell-scrape] push de sesión caducada enviado.')
+    }
+  } catch (err) {
+    console.error(`[sabadell-scrape] push falló (${err.message}).`)
+  }
+}
+
+// Aviso de sesión caducada (exit 2): notificación nativa de macOS + push al iPhone.
+// Sólo se dispara bajo cron (CRON_MODE) desde login(); throttle 1/día vía el marker
+// notifyPath(), que cubre ambos canales. Todo en try/catch: nunca debe romper el exit.
+async function notifyExpired() {
   try {
     if (existsSync(notifyPath())) return
-    execFileSync('osascript', ['-e',
-      `display notification ${JSON.stringify('Ejecuta pnpm scrape:sabadell-visa:login para re-enrolar el dispositivo.')} with title ${JSON.stringify('Sabadell VISA: sesión caducada')}`,
-    ])
+    try {
+      execFileSync('osascript', ['-e',
+        `display notification ${JSON.stringify('Ejecuta pnpm scrape:sabadell-visa:login para re-enrolar el dispositivo.')} with title ${JSON.stringify('Sabadell VISA: sesión caducada')}`,
+      ])
+    } catch {}
+    await notifyError()
     mkdirSync(LOG_DIR, { recursive: true })
     closeSync(openSync(notifyPath(), 'a'))
   } catch {}
@@ -87,7 +119,6 @@ async function dump(page, tag) {
 }
 function die(code, msg) {
   console.error(`[sabadell-scrape] ${msg}`)
-  if (code === 2 && CRON_MODE) notifySessionExpired()
   process.exit(code)
 }
 function requireEnv(name) {
@@ -126,10 +157,12 @@ async function login(page) {
 
   if (await page.locator(LOGIN_SELECTORS.otp).first().isVisible().catch(() => false)) {
     await dump(page, 'login-otp')
+    if (CRON_MODE) await notifyExpired()
     die(2, 'Sabadell pide OTP: el dispositivo no está enrolado. Ejecuta pnpm scrape:sabadell:login')
   }
   if (await page.locator(LOGIN_SELECTORS.pass).first().isVisible().catch(() => false)) {
     await dump(page, 'login-failed')
+    if (CRON_MODE) await notifyExpired()
     die(2, 'Login no completado (¿credenciales incorrectas?)')
   }
   if (DEBUG) await dump(page, 'after-login')


### PR DESCRIPTION
## Contexto

Cuando el scraper de Sabadell VISA falla por sesión caducada (`exit 2`: OTP / login fallido), hasta ahora solo emitía una notificación nativa de macOS, que no llega al iPhone. Esta PR replica el patrón de Edenred (#204) para que ese fallo dispare también un **Web Push** firmado en el servidor con VAPID.

Cierra #213.

## Decisiones (acordadas en la issue)

- **Endpoint dedicado** (no generalizar el de Edenred).
- **Solo `exit 2`** dispara el push.
- **Mensaje único genérico** (sin body en el POST) — calco exacto de Edenred.

## Cambios

- **`app/api/sabadell-visa/notify-error/route.ts`** *(nuevo)*: auth por secreto compartido `SABADELL_VISA_WEBHOOK_SECRET` vía `safeBearerMatch`, resuelve el destinatario desde `user_config` (single-home) y delega en `sendPushToUser` (`lib/push.ts`). Las claves VAPID nunca salen del servidor.
- **`scripts/scrapers/sabadell-visa/scrape.mjs`**:
  - `notifyError()` best-effort (POST al endpoint), calco de `notify2faPending` de Edenred — nunca rompe el `exit code`.
  - `notifySessionExpired()` → `notifyExpired()` async: bajo el throttle 1/día existente (`sabadell-visa-notified.<fecha>`) hace **ambas** cosas, notificación macOS + push.
  - El disparo se mueve de `die()` a los dos sitios `exit 2` de `login()` (el push es async y debe awaitarse antes de `process.exit`). Solo bajo `CRON_MODE`.
- **`route.test.ts`** *(nuevo)*: calco del de `notify-2fa` (401 sin/erróneo Bearer, 500 sin secreto / sin `user_config` / VAPID, 200 `{ sent }`).

Sin cambios de BD ni env vars nuevas.

## Validación

- `pnpm test` ✅ (353 tests) · `pnpm lint` ✅ · `pnpm build` ✅ (endpoint registrado).
- Pendiente prueba manual: `POST` con el secreto y comprobar que llega el push al iPhone suscrito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)