### PR TITLE
chore(skills): cargar skills de .agents/skills vía symlinks en .claude/skills

### DIFF
--- a/.claude/skills/next-best-practices
+++ b/.claude/skills/next-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/next-best-practices

--- a/.claude/skills/shadcn
+++ b/.claude/skills/shadcn
@@ -1,0 +1,1 @@
+../../.agents/skills/shadcn

--- a/.claude/skills/supabase
+++ b/.claude/skills/supabase
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase

--- a/.claude/skills/supabase-postgres-best-practices
+++ b/.claude/skills/supabase-postgres-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase-postgres-best-practices

--- a/.claude/skills/tailwind-v4-shadcn
+++ b/.claude/skills/tailwind-v4-shadcn
@@ -1,0 +1,1 @@
+../../.agents/skills/tailwind-v4-shadcn

--- a/.claude/skills/typescript-advanced-types
+++ b/.claude/skills/typescript-advanced-types
@@ -1,0 +1,1 @@
+../../.agents/skills/typescript-advanced-types

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ public/sw.js.map
 
 # historical data
 historical_data
+# claude code — config local de la máquina (los symlinks de skills sí se versionan)
+.claude/settings.local.json


### PR DESCRIPTION
## Contexto

Las skills instaladas con `npx skills` (skills.sh) viven en `.agents/skills/`, ruta que **Claude Code no escanea**. En consecuencia, ninguna de las seis (`tailwind-v4-shadcn`, `next-best-practices`, `shadcn`, `supabase`, `supabase-postgres-best-practices`, `typescript-advanced-types`) se cargaba de forma nativa; solo la de Tailwind se consultaba puntualmente vía una memoria manual.

## Cambios

- Symlinks relativos desde `.claude/skills/*` → `../../.agents/skills/*` para que Claude Code las descubra y cargue por su `description`. Git los registra como modo `120000` (symlink), sin duplicar contenido.
- `.claude/settings.local.json` añadido a `.gitignore` (config local de máquina); los symlinks de skills **sí** se versionan.

## Notas

- Surten efecto al reiniciar Claude Code (las skills se escanean al arrancar).
- `.agents/skills/` ya estaba trackeado, así que los symlinks no quedan rotos en otras máquinas.
- 4 de las 6 tienen `user-invocable: false`: no serán invocables como `/comando`, pero sí se consideran automáticamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)