### PR TITLE
fix(security): elimina la MV transactions_monthly_summary (#231)

### DIFF
--- a/app/api/edenred/categories.test.ts
+++ b/app/api/edenred/categories.test.ts
@@ -3,8 +3,10 @@ import { CATEGORIES } from '@/lib/categories/catalog'
 
 // Categorías que usa la integración Edenred. Deben existir en el catálogo
 // (lib/categories/catalog.ts, fuente única de la tabla `categories`), porque
-// la matview `transactions_monthly_summary` hace INNER JOIN sobre `categories`:
-// un `id` desconocido excluiría la tx de las agregaciones SIN error. Ver #101.
+// `transactions.category` tiene FK a `categories.id` (#174): un `id` desconocido
+// haría fallar el insert de la tx. Además la analítica (`get_period_data`) hace
+// LEFT JOIN sobre `categories`, así que un id sin fila quedaría sin metadatos de
+// categoría en las agregaciones. Ver #101.
 // El scraper `scripts/scrapers/edenred/scrape.mjs` emite estos ids sin tipado,
 // por eso este test los protege explícitamente.
 // - 'restaurant': consumo (fallback del webhook en route.ts)

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -124,11 +124,12 @@ export async function POST(req: Request) {
   if (payload.transactions.length > 0) {
     // `category` debe coincidir con un `id` de la tabla `categories` (datos de
     // referencia compartidos, seed en
-    // supabase/migrations/20260509000000_categories_type.sql). La matview
-    // `transactions_monthly_summary` hace INNER JOIN sobre `categories`, así que
-    // un `id` desconocido excluiría la tx de las agregaciones SIN error. El
-    // scraper sólo emite 'restaurant' y 'payroll', y el fallback de aquí es
-    // 'restaurant'; ambos están garantizados por ese seed. Ver issue #101.
+    // supabase/migrations/20260509000000_categories_type.sql). `transactions.category`
+    // tiene FK a `categories.id` (#174), así que un `id` desconocido haría fallar el
+    // insert; además la analítica (`get_period_data`) hace LEFT JOIN sobre `categories`
+    // y dejaría la tx sin metadatos de categoría. El scraper sólo emite 'restaurant' y
+    // 'payroll', y el fallback de aquí es 'restaurant'; ambos están garantizados por
+    // ese seed. Ver issue #101.
     // `is_read` se omite a propósito (issue #149): los inserts nuevos toman el
     // DEFAULT false (nacen "no leídos"), y como el upsert usa
     // `ignoreDuplicates: false` (actualiza filas existentes), NO incluirlo evita

--- a/app/api/sabadell-visa/route.test.ts
+++ b/app/api/sabadell-visa/route.test.ts
@@ -28,7 +28,6 @@ function buildMockDb(opts: MockOpts = {}) {
   const insertSpy = vi.fn()
   const updateSpy = vi.fn()
   const upsertSpy = vi.fn()
-  const rpcSpy = vi.fn()
 
   const userConfigBuilder: Record<string, unknown> = {}
   Object.assign(userConfigBuilder, {
@@ -104,13 +103,10 @@ function buildMockDb(opts: MockOpts = {}) {
       if (table === 'transactions') return txBuilder
       throw new Error(`Unmocked table: ${table}`)
     }),
-    rpc: vi.fn((fn: string) => {
-      rpcSpy(fn)
-      return Promise.resolve({ error: null })
-    }),
+    rpc: vi.fn(() => Promise.resolve({ error: null })),
   }
 
-  return { db, insertSpy, updateSpy, upsertSpy, rpcSpy }
+  return { db, insertSpy, updateSpy, upsertSpy }
 }
 
 function callRoute(body: unknown, opts: { auth?: string | null; rawBody?: string } = {}) {
@@ -228,7 +224,7 @@ describe('POST /api/sabadell-visa — user_config', () => {
 
 describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
   it('inserta una cuenta de tarjeta por cada card y upsertea sus txns', async () => {
-    const { db, insertSpy, upsertSpy, rpcSpy } = buildMockDb({
+    const { db, insertSpy, upsertSpy } = buildMockDb({
       userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: null }, { data: null }],
       accountInserts: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
@@ -262,8 +258,6 @@ describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
     expect(rows[1].category).toBeNull()
     // is_read no se envía (preserva estado de lectura en re-syncs)
     expect(rows[0]).not.toHaveProperty('is_read')
-    // Refresca la matview
-    expect(rpcSpy).toHaveBeenCalledWith('refresh_monthly_summary')
   })
 })
 

--- a/app/api/sabadell-visa/route.ts
+++ b/app/api/sabadell-visa/route.ts
@@ -211,11 +211,6 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'DB error' }, { status: 500 })
     }
     upserted = txRows.length
-
-    // Refresca la matview de analítica (CONCURRENTLY) para que los gastos de
-    // tarjeta entren en las agregaciones sin esperar a la sync de Enable Banking.
-    const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-    if (refreshError) console.error('[sabadell-visa] refresh_monthly_summary:', refreshError)
   }
 
   return NextResponse.json({ cards: payload.cards.length, created_accounts: createdAccounts, upserted })

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -150,9 +150,6 @@ export async function POST(req: Request) {
       .eq('id', account.id)
   }
 
-  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-  if (refreshError) console.error('[sync/eb/cron] refresh_monthly_summary:', refreshError)
-
   // Aviso de caducidad PSD2 (≤7 días, issue #115). Se evalúa sobre todas las
   // cuentas (las críticas siguen siendo sincronizables) y se manda una sola vez
   // por ciclo de caducidad gracias a consent_reminder_sent_for.

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -148,8 +148,5 @@ export async function POST(request: Request) {
       .eq('id', account.id)
   }
 
-  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-  if (refreshError) console.error('[sync/eb] refresh_monthly_summary:', refreshError)
-
   return NextResponse.json({ synced: totalSynced, accounts: accounts.length })
 }

--- a/lib/categories/seed-sql.ts
+++ b/lib/categories/seed-sql.ts
@@ -43,7 +43,5 @@ ON CONFLICT (id) DO UPDATE
 
 DELETE FROM categories
 WHERE id NOT IN (${ids});
-
-REFRESH MATERIALIZED VIEW transactions_monthly_summary;
 `
 }

--- a/supabase/migrations/20260620000000_drop_transactions_monthly_summary.sql
+++ b/supabase/migrations/20260620000000_drop_transactions_monthly_summary.sql
@@ -1,0 +1,14 @@
+-- Issue #231 (seguridad + cómputo muerto): la MV transactions_monthly_summary no
+-- aplica RLS y vive en public (expuesta por PostgREST → fuga entre hogares). Además
+-- nadie la lee: la analítica usa get_period_data en vivo (app/api/analytics) y el
+-- Dashboard consulta transactions/accounts directamente. Solo se refrescaba en cada
+-- sync, pagando un REFRESH MATERIALIZED VIEW CONCURRENTLY completo sin lectores.
+--
+-- Se elimina la MV junto con su función de refresh. Los índices de la MV
+-- (idx_monthly_unique / idx_monthly_user_month y variantes household) caen
+-- automáticamente con el DROP MATERIALIZED VIEW.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+DROP MATERIALIZED VIEW IF EXISTS transactions_monthly_summary;
+DROP FUNCTION IF EXISTS refresh_monthly_summary();

--- a/supabase/seed/categories.sql
+++ b/supabase/seed/categories.sql
@@ -60,5 +60,3 @@ ON CONFLICT (id) DO UPDATE
 
 DELETE FROM categories
 WHERE id NOT IN ('groceries', 'restaurant', 'transport', 'fuel', 'parking', 'vehicle', 'mortgage', 'community_fees', 'electricity', 'gas', 'water', 'internet', 'home', 'clothing', 'shopping', 'electronics', 'health', 'pharmacy', 'leisure', 'sports', 'subscriptions', 'travel', 'education', 'insurance_health', 'insurance_home', 'insurance_auto', 'domestic_help', 'beauty', 'gifts', 'charity', 'memberships', 'taxes', 'loans', 'cash', 'fees', 'other', 'payroll', 'returns', 'reimbursement', 'other_income', 'investment', 'savings', 'transfer', 'loan_payment', 'card_payment');
-
-REFRESH MATERIALIZED VIEW transactions_monthly_summary;


### PR DESCRIPTION
Cierra #231.

## Problema

`transactions_monthly_summary` es una vista materializada en `public`. Las MV **no aplican RLS**, así que está expuesta por la Data API (PostgREST): si el rol `authenticated` tiene `SELECT`, cualquier usuario con sesión podría leer las finanzas agregadas de **todos los hogares** (fuga IDOR en cuanto aterrice multiusuario, #131/#132).

Además es **cómputo muerto**: nadie la lee (la analítica usa el RPC `get_period_data` en vivo sobre `transactions`; el Dashboard consulta `transactions`/`accounts` directamente). Solo se refrescaba en cada sync, pagando un `REFRESH MATERIALIZED VIEW CONCURRENTLY` completo sin lectores.

## Solución (Opción A del issue)

Eliminar la MV y todo su andamiaje:

- **Migración** `20260620000000_drop_transactions_monthly_summary.sql`: `DROP MATERIALIZED VIEW` + `DROP FUNCTION refresh_monthly_summary()` (los índices de la MV caen automáticamente).
- Retiradas las **3 llamadas** a `refresh_monthly_summary()` en los paths de sync (`sabadell-visa`, `sync/enablebanking`, `sync/enablebanking/cron`).
- Eliminado el `REFRESH` del template `lib/categories/seed-sql.ts` y regenerado `supabase/seed/categories.sql` (`pnpm seed:categories`).
- Actualizado el test de `sabadell-visa` (quita la aserción de refresh) y los comentarios de `edenred` (la razón vigente para validar `category` es la **FK `transactions.category → categories.id`** de #174, no el INNER JOIN de la MV).

## Validación

- ✅ `pnpm test` (353 tests), `pnpm lint`, `pnpm build`.
- ⏳ **Pendiente en el dashboard de Supabase:** ejecutar la migración en el SQL Editor, confirmar que el Security Advisor ya no reporta la exposición, y validar en runtime que `/api/analytics` y el Dashboard siguen devolviendo los mismos datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)