### PR TITLE
fix(security): habilita RLS en la tabla categories (#232)

### DIFF
--- a/supabase/migrations/20260620000001_categories_enable_rls.sql
+++ b/supabase/migrations/20260620000001_categories_enable_rls.sql
@@ -1,0 +1,21 @@
+-- Issue #232 (seguridad): la tabla categories se creó sin RLS (datos de referencia
+-- compartidos). Al estar en public queda expuesta por la Data API y el Security Advisor
+-- la marca como rls_disabled_in_public. Es destino de FK de transactions.category /
+-- category_manual: sin RLS, un authenticated con grant de escritura podría alterar el
+-- catálogo compartido de todos los hogares.
+--
+-- El cliente nunca escribe en categories: el catálogo se siembra server-side
+-- (pnpm seed:categories -> supabase/seed/categories.sql) con un rol que bypassa RLS.
+-- Habilitamos RLS con policy de solo lectura para authenticated; la siembra no se ve
+-- afectada. Revocamos además escrituras a anon/authenticated como defensa en profundidad.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+ALTER TABLE categories ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone authenticated can read categories" ON categories;
+CREATE POLICY "Anyone authenticated can read categories" ON categories
+  FOR SELECT TO authenticated USING (true);
+
+-- Defensa en profundidad: ningún rol de la Data API debe escribir el catálogo.
+REVOKE INSERT, UPDATE, DELETE ON categories FROM anon, authenticated;


### PR DESCRIPTION
## Qué

Habilita Row Level Security en la tabla `categories`, que se creó explícitamente **sin RLS** (`supabase/migrations/20260509000000_categories_type.sql:12`). Al vivir en el esquema `public` queda expuesta por la Data API y el Security Advisor la marca como `rls_disabled_in_public`.

Nueva migración `supabase/migrations/20260620000001_categories_enable_rls.sql`:

- `ALTER TABLE categories ENABLE ROW LEVEL SECURITY;`
- Policy de **solo lectura** para `authenticated` (`FOR SELECT USING (true)`).
- `REVOKE INSERT, UPDATE, DELETE` a `anon, authenticated` como defensa en profundidad.

## Por qué

`categories` es destino de FK de `transactions.category` / `category_manual`. Sin RLS, un usuario `authenticated` con grant de escritura vía Data API podría alterar el catálogo compartido de **todos los hogares**. El cliente nunca escribe en `categories`: el catálogo se siembra server-side (`pnpm seed:categories` → `supabase/seed/categories.sql`) con un rol que bypassa RLS, así que la siembra no se ve afectada y la lectura desde la app sigue intacta.

Misma línea de endurecimiento que #231 (drop de la MV) y #179 (revoke de `refresh_monthly_summary`).

## Verificación

- [x] `pnpm test` (353 ✓), `pnpm lint`, `pnpm build` — OK (sin cambios de código).
- [ ] Ejecutar la migración en el SQL Editor como un único bloque.
- [ ] Security Advisor (`/advisors/security`): confirmar que desaparece `rls_disabled_in_public` para `categories`.
- [ ] Confirmar que las pantallas que listan categorías siguen funcionando.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)