### PR TITLE
refactor(db): retira índices user_id obsoletos tras #131 (#239)

### DIFF
--- a/supabase/migrations/20260620000002_drop_obsolete_user_id_indexes.sql
+++ b/supabase/migrations/20260620000002_drop_obsolete_user_id_indexes.sql
@@ -1,0 +1,17 @@
+-- Issue #239: tras #131 la visibilidad y las queries pasaron de user_id a household_id.
+-- Estos índices del modelo anterior no los usa ninguna query: en transactions (tabla más
+-- escrita por el sync) son amplificación de escritura y almacenamiento muertos. Se retiran
+-- solo los índices; la columna user_id se conserva como creador/auditoría (ver #131).
+--
+-- Cubiertos hoy por idx_transactions_household_date / idx_accounts_household /
+-- idx_categorization_rules_household. NO se tocan idx_household_members_user ni
+-- idx_push_subscriptions_user_id (siguen sirviendo filtros vivos por user_id).
+--
+-- Precondición: confirmar idx_scan = 0 en pg_stat_user_indexes y revisar el Performance
+-- Advisor antes de ejecutar.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+DROP INDEX IF EXISTS idx_transactions_user_date;
+DROP INDEX IF EXISTS idx_accounts_user_id;
+DROP INDEX IF EXISTS idx_categorization_rules_user;


### PR DESCRIPTION
Cierra #239.

## Qué

Migración `20260620000002_drop_obsolete_user_id_indexes.sql` que retira tres índices del modelo `user_id` que quedaron muertos tras la migración a `household_id` (#131):

- `idx_transactions_user_date (user_id, date DESC)`
- `idx_accounts_user_id (user_id)`
- `idx_categorization_rules_user (user_id, priority DESC) WHERE is_active`

Solo se retiran los **índices**. La columna `user_id` se conserva como creador/auditoría.

## Por qué

Ninguna query filtra `transactions`, `accounts` ni `categorization_rules` por `user_id`: la app y la RLS van por `household_id`, cubiertas por `idx_transactions_household_date`, `idx_accounts_household` e `idx_categorization_rules_household`. En `transactions` (la tabla más escrita, cada inserción de sync) un índice no usado es amplificación de escritura y almacenamiento puro.

Se **conservan** `idx_household_members_user` e `idx_push_subscriptions_user_id`: siguen sirviendo filtros vivos por `user_id` (`getHouseholdId`, push subscriptions).

## Verificación

- `pnpm test` (353 ✓), `pnpm lint` y `pnpm build` en verde. Sin cambios de código de aplicación.
- ⚠️ **Precondición antes de ejecutar el bloque en producción**: confirmar `idx_scan = 0` en `pg_stat_user_indexes` para los tres índices y revisar el Performance Advisor (`/advisors/performance`). Ejecutar la migración en el SQL Editor como un único bloque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)