### PR TITLE
feat(ui): cifras tabulares para todos los importes monetarios (#243)

### DIFF
--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
 import { AccountIconBadge } from './AccountIconBadge'
 import { SyncButton } from './SyncButton'
@@ -108,7 +108,7 @@ export function AccountCard({ account }: { account: Account }) {
                   : undefined,
             }}
           >
-            {account.balance !== null ? `${fmt(account.balance, 2)} €` : '—'}
+            {account.balance !== null ? <Amount value={account.balance} decimals={2} /> : '—'}
           </div>
         </div>
         <Link

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { MoreHorizontal } from 'lucide-react'
 import type { CategoryBreakdown } from '@/types'
 import { CATEGORY_META } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import DonutChart, { type DonutItem } from './DonutChart'
 
 const MIN_PCT = 5
@@ -166,7 +166,7 @@ export default function CategoryBreakdownSection({ byCategory, periodStart }: Ca
                         {Math.round(item.pct)}%
                       </span>
                       <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--foreground)' }}>
-                        {fmt(item.amount)} €
+                        <Amount value={item.amount} />
                       </span>
                       {isNavigable && <span style={{ fontSize: 13, color: accentColor }}>›</span>}
                     </div>

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAnalytics } from '@/contexts/AnalyticsContext'
 import { CATEGORY_META } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { PERIOD_LABELS } from '@/lib/analytics'
 import type { CategoryId, CategoryPeriodData, TransactionWithAccount } from '@/types'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
@@ -213,7 +213,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
           <p className="mt-1 text-xs text-muted-foreground" style={{ paddingLeft: 44 }}>
             {transactions.length} movimiento{transactions.length !== 1 ? 's' : ''}{' '}
             ·{' '}
-            <span style={{ fontWeight: 700, color }}>{fmt(periodTotal, 2)} €</span>
+            <span style={{ fontWeight: 700, color }}><Amount value={periodTotal} decimals={2} /></span>
           </p>
         )}
       </div>
@@ -234,7 +234,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
             ) : (
               <>
                 <span style={{ fontSize: 32, fontWeight: 800, color, letterSpacing: -1 }}>
-                  {fmt(periodTotal, 2)} €
+                  <Amount value={periodTotal} decimals={2} />
                 </span>
                 {selectedPeriod && (
                   <span className="ml-2 text-xs text-muted-foreground">

--- a/components/analytics/DonutChart.tsx
+++ b/components/analytics/DonutChart.tsx
@@ -93,7 +93,7 @@ export default function DonutChart({ items, selectedIdx, accentColor, onSelect }
         </text>
 
         {/* Center value */}
-        <text x={CX} y={CY + 14} textAnchor="middle" fontSize={22} fontWeight={800} fill={centerColor}>
+        <text x={CX} y={CY + 14} textAnchor="middle" fontSize={22} fontWeight={800} fill={centerColor} style={{ fontVariantNumeric: 'tabular-nums slashed-zero' }}>
           {centerValue}
         </text>
       </svg>

--- a/components/analytics/KpiCard.tsx
+++ b/components/analytics/KpiCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 
 interface KpiCardProps {
   type: 'income' | 'expense'
@@ -42,7 +42,7 @@ export default function KpiCard({
         className="mb-2 font-extrabold leading-none"
         style={{ fontSize, color: mainColor }}
       >
-        {fmt(value)} €
+        <Amount value={value} />
       </div>
 
       {/* Badge vs período anterior — neutral */}

--- a/components/analytics/SavingsCard.tsx
+++ b/components/analytics/SavingsCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Granularity } from '@/types'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { PERIOD_LABELS } from '@/lib/analytics'
 
 interface SavingsCardProps {
@@ -24,7 +24,7 @@ export default function SavingsCard({ income, savings, granularity }: SavingsCar
         Ahorro · {PERIOD_LABELS[granularity]}
       </p>
       <p style={{ fontSize: 32, fontWeight: 800, color: 'white', marginBottom: 8 }}>
-        {fmt(savings)} €
+        <Amount value={savings} />
       </p>
       <div style={{ height: 6, background: 'rgba(255,255,255,0.2)', borderRadius: 3 }}>
         <div

--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { AccountIconBadge } from '@/components/accounts/AccountIconBadge'
 import type { Account, AccountType } from '@/types'
 
@@ -30,7 +30,7 @@ function AccountCell({ account }: { account: Account }) {
         className="text-[17px] font-bold leading-tight"
         style={{ color: isNegative ? '#ef4444' : undefined }}
       >
-        {fmt(balance, 2)} €
+        <Amount value={balance} decimals={2} />
       </div>
       {account.number && (
         <div className="text-[10px] text-muted-foreground mt-0.5">{account.number}</div>

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -1,4 +1,4 @@
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { Sparkline } from './Sparkline'
 
 interface DashboardBalanceCardProps {
@@ -38,7 +38,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
           Balance total
         </div>
         <div className="text-[36px] font-extrabold text-white tracking-tight leading-none mb-1">
-          {fmt(balance, 2)} €
+          <Amount value={balance} decimals={2} />
         </div>
 
         {/* Weekly delta pill */}
@@ -47,7 +47,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
             className="text-[12px] font-bold px-2 py-0.5 rounded-full"
             style={{ color: pillColor, background: pillBg }}
           >
-            {deltaArrow} {deltaSign}{fmt(weeklyDelta, 2)} €
+            {deltaArrow} {deltaSign}<Amount value={weeklyDelta} decimals={2} />
           </span>
           <span className="text-[11px]" style={{ color: 'rgba(255,255,255,0.7)' }}>esta semana</span>
         </div>

--- a/components/dashboard/NetWorthChart.tsx
+++ b/components/dashboard/NetWorthChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { AreaChart, Area, XAxis, ResponsiveContainer, Tooltip } from 'recharts'
 import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 
 interface Props {
   data: { label: string; value: number }[]
@@ -19,7 +20,7 @@ export function NetWorthChart({ data, annualDelta }: Props) {
               : 'text-red-500 bg-red-500/10'
           }`}>
             {annualDelta >= 0 ? '↑' : '↓'} {annualDelta >= 0 ? '+' : ''}
-            {fmt(annualDelta)} € vs hace 12 meses
+            <Amount value={annualDelta} /> vs hace 12 meses
           </span>
         ) : (
           <span className="text-[11px] text-muted-foreground px-2.5 py-0.5">
@@ -56,7 +57,7 @@ export function NetWorthChart({ data, annualDelta }: Props) {
           />
           <Tooltip
             formatter={(v) => [typeof v === 'number' ? `${fmt(v)} €` : '—', 'Patrimonio']}
-            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid rgba(0,0,0,0.08)' }}
+            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid rgba(0,0,0,0.08)', fontVariantNumeric: 'tabular-nums' }}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/components/transactions/TxDayGroupCard.tsx
+++ b/components/transactions/TxDayGroupCard.tsx
@@ -2,7 +2,7 @@
 
 import { TxRow, type TxRowPhase } from './TxRow'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
 import type { TransactionWithAccount } from '@/types'
 
@@ -34,7 +34,6 @@ export function TxDayGroupCard({
   onToggleRead,
   onTap,
 }: TxDayGroupCardProps) {
-  const netStr = (group.net >= 0 ? '+' : '') + fmt(group.net, 2) + ' €'
   const netColor = group.net >= 0 ? '#22c55e' : 'var(--foreground)'
 
   return (
@@ -44,7 +43,7 @@ export function TxDayGroupCard({
           {formatDayLabel(group.date)}
         </span>
         <span className="text-xs font-bold" style={{ color: netColor }}>
-          {netStr}
+          <Amount value={group.net} decimals={2} signed />
         </span>
       </div>
 

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Trash2, Calendar, CreditCard } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { CATEGORY_META, UNCATEGORIZED } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
@@ -73,8 +73,6 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
     })
   })()
 
-  const absAmount = fmt(Math.abs(renderTx.amount), 2)
-  const amountStr = (renderTx.amount > 0 ? '+' : '-') + absAmount + ' €'
   const isPositive = renderTx.amount > 0
 
   return (
@@ -102,7 +100,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
               isPositive ? 'text-[#22c55e]' : 'text-foreground'
             )}
           >
-            {amountStr}
+            <Amount value={renderTx.amount} decimals={2} signed />
           </div>
         </div>
 

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -3,7 +3,7 @@
 import { Edit3, Check, X } from 'lucide-react'
 import { useHorizontalSwipe, type SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { CATEGORY_META, UNCATEGORIZED } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
@@ -39,9 +39,6 @@ export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe,
     onOpen: side => onOpenSwipe(tx.id, side),
     onClose: onCloseSwipe,
   })
-
-  const absAmount = fmt(Math.abs(tx.amount), 2)
-  const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
 
   const leaving = phase === 'leaving'
 
@@ -130,7 +127,7 @@ export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe,
               tx.amount > 0 ? 'text-[#22c55e]' : 'text-destructive'
             )}
           >
-            {amountStr}
+            <Amount value={tx.amount} decimals={2} signed />
           </span>
         </div>
 

--- a/components/ui/amount.tsx
+++ b/components/ui/amount.tsx
@@ -1,0 +1,38 @@
+import { fmt } from '@/lib/formatting'
+import { cn } from '@/lib/utils'
+
+// Punto único de verdad de la clase de cifras tabulares. Reutilizable en sitios que no
+// pueden renderizar el componente <Amount> (strings, SVG, tooltips de chart).
+export const TABULAR_NUMS = 'tabular-nums [font-variant-numeric:tabular-nums_slashed-zero]'
+
+interface AmountProps {
+  value: number
+  /** Decimales a mostrar (por defecto 0, igual que fmt). */
+  decimals?: number
+  /** Añade el sufijo ' €' (por defecto true). */
+  currency?: boolean
+  /** Fuerza el '+' explícito en valores positivos (fmt ya pone '-' en negativos). */
+  signed?: boolean
+  className?: string
+}
+
+/**
+ * Renderiza un importe monetario con cifras tabulares (alineación en columnas y ancho
+ * estable al actualizarse). Hereda tamaño/peso/color del contenedor padre vía className.
+ */
+export function Amount({
+  value,
+  decimals = 0,
+  currency = true,
+  signed = false,
+  className,
+}: AmountProps) {
+  const plus = signed && value > 0 ? '+' : ''
+  return (
+    <span className={cn(TABULAR_NUMS, className)}>
+      {plus}
+      {fmt(value, decimals)}
+      {currency ? ' €' : ''}
+    </span>
+  )
+}


### PR DESCRIPTION
Cierra #243.

## Qué

DM Sans usa cifras **proporcionales** por defecto, lo que desalinea las columnas de importes y hace que las cifras "salten" de ancho al actualizarse. Se centraliza el arreglo con cifras tabulares.

## Cambios

- **Nuevo componente `Amount`** (`components/ui/amount.tsx`): envuelve `fmt()` y aplica `tabular-nums` + `slashed-zero`. Hereda tamaño/peso/color del contenedor padre vía `className`. Props: `value`, `decimals` (0), `currency` (true → sufijo ` €`), `signed` (fuerza `+` en positivos). Exporta la constante `TABULAR_NUMS` como punto único de verdad de la clase.
- **Sustituidas las renderizaciones JSX de `fmt()`** de importes por `<Amount>` en: `DashboardBalanceCard`, `DashboardAccountGrid`, `NetWorthChart` (delta), `AccountCard`, `KpiCard`, `SavingsCard`, `CategoryDetailClient`, `CategoryBreakdownSection`, `TxRow`, `TxModal`, `TxDayGroupCard`.
- **Sitios que no admiten el componente** (string/SVG/chart): `font-variant-numeric: tabular-nums` aplicado al `contentStyle` del tooltip de Recharts (`NetWorthChart`) y al `<text>` central del `DonutChart`.

## Notas

- **No depende de #242** (tokens de signo, aún abierto): `Amount` no aplica color de signo; cada consumidor conserva su color actual. El color se podrá añadir como mejora cuando #242 aterrice.
- `slashed-zero`: si DM Sans no expone la feature OpenType `zero`, es un no-op inofensivo; se deja por intención de diseño.

## Validación

- `pnpm test` ✅ (353 tests)
- `pnpm lint` ✅
- `pnpm build` ✅

## Criterios de aceptación

- [x] Todos los importes monetarios se renderizan con `tabular-nums`.
- [x] Las cifras alinean en columnas y no cambian de ancho al actualizarse.
- [x] `pnpm build` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)