### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Bump de versión a `v0.4.0` (salto menor por feats incluidos desde `v0.3.0`).

Validaciones locales: `pnpm test` (353 ✓), `pnpm lint` ✓, `pnpm build` ✓.

Incluye desde `v0.3.0`:
- feat(ui): cifras tabulares para todos los importes monetarios (#243)
- feat(scrapers): push al iPhone cuando falla el scraper de Sabadell VISA (#213)
- feat(auth): mostrar versión de la release y login solo con Google (#226)
- fix(security): RLS en categories (#232), eliminar MV transactions_monthly_summary (#231)
- refactor(db): retira índices user_id obsoletos tras #131 (#239)
- chore/docs varios (skills, settings, github-issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)