### PR TITLE
Release v0.4.0

### DIFF
--- a/.agents/skills/frontend-design/LICENSE.txt
+++ b/.agents/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: frontend-design
+description: Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.
+license: Complete terms in LICENSE.txt
+---
+
+# Frontend Design
+
+Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
+
+## Ground it in the subject
+
+If the brief does not pin down what the product or subject is, pin it yourself before designing: name one concrete subject, its audience, and the page's single job, and state your choice. If there's any information in your memory about the human's preferences, context about what they're building, or designs you've made before – use that as a hint. The subject's own world, its materials, instruments, artifacts, and vernacular, is where distinctive choices come from. Build with the brief's real content and subject matter throughout.
+
+## Design principles
+
+For web designs, the hero is a thesis. Open with the most characteristic thing in the subject's world, in whatever form makes sense for it: a headline, an image, an animation, a live demo, an interactive moment. Be deliberate with your choice: a big number with a small label, supporting stats, and a gradient accent is the template answer, only use if that's truly the best option.
+
+Typography carries the personality of the page. Pair the display and body faces deliberately, not the same families you would reach for on any other project, and set a clear type scale with intentional weights, widths, and spacing. Make the type treatment itself a memorable part of the design, not a neutral delivery vehicle for the content.
+
+Structure is information. Structural devices, numbering, eyebrows, dividers, labels, should encode something true about the content, not decorate it. Many generic designs use numbered markers (01 / 02 / 03), but that's only appropriate if the content actually is a sequence - like a real process or a typed timeline where order carries information the reader needs. Question if choices like numbered markers actually make sense before incorporating them.
+
+Leverage motion deliberately. Think about where and if animation can serve the subject: a page-load sequence, a scroll-triggered reveal, hover micro-interactions, ambient atmosphere. An orchestrated moment usually lands harder than scattered effects; choose what the direction calls for. However, sometimes less is more, and extra animation contributes to the feeling that the design is AI-generated.
+
+Match complexity to the vision. Maximalist directions need elaborate execution; minimal directions need precision in spacing, type, and detail. Elegance is executing the chosen vision well.
+
+Consider written content carefully. Often a design brief may not contain real content, and it's up to you to come up with copy. Copy can make a design feel as templated as the design itself. See the below section on writing for more guidance.
+
+## Process: brainstorm, explore, plan, critique, build, critique again
+
+For calibration: AI-generated design right now clusters around three looks: (1) a warm cream background (near #F4F1EA) with a high-contrast serif display and a terracotta accent; (2) a near-black background with a single bright acid-green or vermilion accent; (3) a broadsheet-style layout with hairline rules, zero border-radius, and dense newspaper-like columns. All three are legitimate for some briefs, but they are defaults rather than choices, and they appear regardless of subject. Where the brief pins down a visual direction, follow it exactly — the brief's own words always win, including when it asks for one of these looks. Where it leaves an axis free, don't spend that freedom on one of these defaults. Just like a human designer who's hired, there's often a careful balance between doing what you're good at and taking each project as a chance to experiment and learn.
+
+Work in two passes. First, brainstorm a short design plan based on the human's design brief: create a compact token system with color, type, layout, and signature. Color: describe the palette as 4–6 named hex values. Type: the typefaces for 2+ roles (a characterful display face that's used with restraint, a complementary body face, and a utility face for captions or data if needed). Layout: a layout concept, using one-sentence prose descriptions and ASCII wireframes to ideate and compare. Signature: the single unique element this page will be remembered by that embodies the brief in an appropriate way.
+
+Then review that plan against the brief before building: if any part of it reads like the generic default you would produce for any similar page (work through a similar prompt to see if you arrive somewhere similar) rather than a choice made for this specific brief — revise that part, say what you changed and why. Only after you've confirmed the relative uniqueness of your design plan should you start to write the code, following the revised plan exactly and deriving every color and type decision from it.
+
+When writing the code, be careful of structuring your CSS selector specificities. It's easy to generate CSS classes that cancel each other out (especially with a type-based selector like .section and a element-based selector like .cta). This can happen often with paddings/margins between sections.
+
+Try to do a lot of this planning and iteration in your thinking, and only show ideas to the user when you have higher confidence it'll delight them.
+
+## Restraint and self-critique
+
+Spend your boldness in one place. Let the signature element be the one memorable thing, keep everything around it quiet and disciplined, and cut any decoration that does not serve the brief. Not taking a risk can be a risk itself! Build to a quality floor without announcing it: responsive down to mobile, visible keyboard focus, reduced motion respected. Critique your own work as you build, taking screenshots if your environment supports it – a picture is worth 1000 tokens. Consider Chanel's advice: before leaving the house, take a look in the mirror and remove one accessory. Human creators have memory and always try to do something new, so if you have a space to quickly jot down notes about what you've tried, it can help you in future passes.
+
+## More on writing in design
+
+Words appear in a design for one reason: to make it easier to understand, and therefore easier to use. They are design material, not decoration. Bring the same intentionality to copy that you would bring to spacing and color. Before writing anything, ask what the design needs to say, and how it can best be said to help the person navigate the experience.
+
+Write from the end user's side of the screen. Name things by what people control and recognize, never by how the system is built. A person manages notifications, not webhook config. Describe what something does in plain terms rather than selling it. Being specific is always better than being clever.
+
+Use active voice as default. A control should say exactly what happens when it's used: "Save changes," not "Submit." An action keeps the same name through the whole flow, so the button that says "Publish" produces a toast that says "Published." The vocabulary of an interface is the signposting for someone navigating the product. Cohesion and consistency are how people learn their way around.
+
+Treat failure and emptiness as moments for direction, not mood. Explain what went wrong and how to fix it, in the interface's voice rather than a person's. Errors don't apologize, and they are never vague about what happened. An empty screen is an invitation to act.
+
+Keep the register conversational and tuned: plain verbs, sentence case, no filler, with tone matched to the brand and the audience. Let each element do exactly one job. A label labels, an example demonstrates, and nothing quietly does double duty.

--- a/.agents/skills/github-issues/SKILL.md
+++ b/.agents/skills/github-issues/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: github-issues
+description: 'Create, update, and manage GitHub issues using MCP tools. Use this skill when users want to create bug reports, feature requests, or task issues, update existing issues, add labels/assignees/milestones, set issue fields (dates, priority, custom fields), set issue types, manage issue workflows, link issues, add dependencies, or track blocked-by/blocking relationships. Triggers on requests like "create an issue", "file a bug", "request a feature", "update issue X", "set the priority", "set the start date", "link issues", "add dependency", "blocked by", "blocking", or any GitHub issue management task.'
+---
+
+# GitHub Issues
+
+Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
+
+## Available Tools
+
+### MCP Tools (read operations)
+
+| Tool | Purpose |
+|------|---------|
+| `mcp__github__issue_read` | Read issue details, sub-issues, comments, labels (methods: get, get_comments, get_sub_issues, get_labels) |
+| `mcp__github__list_issues` | List and filter repository issues by state, labels, date |
+| `mcp__github__search_issues` | Search issues across repos using GitHub search syntax |
+| `mcp__github__projects_list` | List projects, project fields, project items, status updates |
+| `mcp__github__projects_get` | Get details of a project, field, item, or status update |
+| `mcp__github__projects_write` | Add/update/delete project items, create status updates |
+
+### CLI / REST API (write operations)
+
+The MCP server does not currently support creating, updating, or commenting on issues. Use `gh api` for these operations.
+
+| Operation | Command |
+|-----------|---------|
+| Create issue | `gh api repos/{owner}/{repo}/issues -X POST -f title=... -f body=...` |
+| Update issue | `gh api repos/{owner}/{repo}/issues/{number} -X PATCH -f title=... -f state=...` |
+| Add comment | `gh api repos/{owner}/{repo}/issues/{number}/comments -X POST -f body=...` |
+| Close issue | `gh api repos/{owner}/{repo}/issues/{number} -X PATCH -f state=closed` |
+| Set issue type | Include `-f type=Bug` in the create call (REST API only, not supported by `gh issue create` CLI) |
+
+**Note:** `gh issue create` works for basic issue creation but does **not** support the `--type` flag. Use `gh api` when you need to set issue types.
+
+## Workflow
+
+1. **Determine action**: Create, update, or query?
+2. **Gather context**: Get repo info, existing labels, milestones if needed
+3. **Structure content**: Use appropriate template from [references/templates.md](references/templates.md)
+4. **Execute**: Use MCP tools for reads, `gh api` for writes
+5. **Confirm**: Report the issue URL to user
+
+## Creating Issues
+
+Use `gh api` to create issues. This supports all parameters including issue types.
+
+```bash
+gh api repos/{owner}/{repo}/issues \
+  -X POST \
+  -f title="Issue title" \
+  -f body="Issue body in markdown" \
+  -f type="Bug" \
+  --jq '{number, html_url}'
+```
+
+### Optional Parameters
+
+Add any of these flags to the `gh api` call:
+
+```
+-f type="Bug"                    # Issue type (Bug, Feature, Task, Epic, etc.)
+-f labels[]="bug"                # Labels (repeat for multiple)
+-f assignees[]="username"        # Assignees (repeat for multiple)
+-f milestone=1                   # Milestone number
+```
+
+**Issue types** are organization-level metadata. To discover available types, use:
+```bash
+gh api graphql -f query='{ organization(login: "ORG") { issueTypes(first: 10) { nodes { name } } } }' --jq '.data.organization.issueTypes.nodes[].name'
+```
+
+**Prefer issue types over labels for categorization.** When issue types are available (e.g., Bug, Feature, Task), use the `type` parameter instead of applying equivalent labels like `bug` or `enhancement`. Issue types are the canonical way to categorize issues on GitHub. Only fall back to labels when the org has no issue types configured.
+
+### Title Guidelines
+
+- Be specific and actionable
+- Keep under 72 characters
+- When issue types are set, don't add redundant prefixes like `[Bug]`
+- Examples:
+  - `Login fails with SSO enabled` (with type=Bug)
+  - `Add dark mode support` (with type=Feature)
+  - `Add unit tests for auth module` (with type=Task)
+
+### Body Structure
+
+Always use the templates in [references/templates.md](references/templates.md). Choose based on issue type:
+
+| User Request | Template |
+|--------------|----------|
+| Bug, error, broken, not working | Bug Report |
+| Feature, enhancement, add, new | Feature Request |
+| Task, chore, refactor, update | Task |
+
+## Updating Issues
+
+Use `gh api` with PATCH:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number} \
+  -X PATCH \
+  -f state=closed \
+  -f title="Updated title" \
+  --jq '{number, html_url}'
+```
+
+Only include fields you want to change. Available fields: `title`, `body`, `state` (open/closed), `labels`, `assignees`, `milestone`.
+
+## Examples
+
+### Example 1: Bug Report
+
+**User**: "Create a bug issue - the login page crashes when using SSO"
+
+**Action**: 
+```bash
+gh api repos/github/awesome-copilot/issues \
+  -X POST \
+  -f title="Login page crashes when using SSO" \
+  -f type="Bug" \
+  -f body="## Description
+The login page crashes when users attempt to authenticate using SSO.
+
+## Steps to Reproduce
+1. Navigate to login page
+2. Click 'Sign in with SSO'
+3. Page crashes
+
+## Expected Behavior
+SSO authentication should complete and redirect to dashboard.
+
+## Actual Behavior
+Page becomes unresponsive and displays error." \
+  --jq '{number, html_url}'
+```
+
+### Example 2: Feature Request
+
+**User**: "Create a feature request for dark mode with high priority"
+
+**Action**:
+```bash
+gh api repos/github/awesome-copilot/issues \
+  -X POST \
+  -f title="Add dark mode support" \
+  -f type="Feature" \
+  -f labels[]="high-priority" \
+  -f body="## Summary
+Add dark mode theme option for improved user experience and accessibility.
+
+## Motivation
+- Reduces eye strain in low-light environments
+- Increasingly expected by users
+
+## Proposed Solution
+Implement theme toggle with system preference detection.
+
+## Acceptance Criteria
+- [ ] Toggle switch in settings
+- [ ] Persists user preference
+- [ ] Respects system preference by default" \
+  --jq '{number, html_url}'
+```
+
+## Common Labels
+
+Use these standard labels when applicable:
+
+| Label | Use For |
+|-------|---------|
+| `bug` | Something isn't working |
+| `enhancement` | New feature or improvement |
+| `documentation` | Documentation updates |
+| `good first issue` | Good for newcomers |
+| `help wanted` | Extra attention needed |
+| `question` | Further information requested |
+| `wontfix` | Will not be addressed |
+| `duplicate` | Already exists |
+| `high-priority` | Urgent issues |
+
+## Tips
+
+- Always confirm the repository context before creating issues
+- Ask for missing critical information rather than guessing
+- Link related issues when known: `Related to #123`
+- For updates, fetch current issue first to preserve unchanged fields
+
+## Extended Capabilities
+
+The following features require REST or GraphQL APIs beyond the basic MCP tools. Each is documented in its own reference file so the agent only loads the knowledge it needs.
+
+| Capability | When to use | Reference |
+|------------|-------------|-----------|
+| Advanced search | Complex queries with boolean logic, date ranges, cross-repo search, issue field filters (`field.name:value`) | [references/search.md](references/search.md) |
+| Sub-issues & parent issues | Breaking work into hierarchical tasks | [references/sub-issues.md](references/sub-issues.md) |
+| Issue dependencies | Tracking blocked-by / blocking relationships | [references/dependencies.md](references/dependencies.md) |
+| Issue types (advanced) | GraphQL operations beyond MCP `list_issue_types` / `type` param | [references/issue-types.md](references/issue-types.md) |
+| Projects V2 | Project boards, progress reports, field management | [references/projects.md](references/projects.md) |
+| Issue fields | Custom metadata: dates, priority, text, numbers (private preview) | [references/issue-fields.md](references/issue-fields.md) |
+| Images in issues | Embedding images in issue bodies and comments via CLI | [references/images.md](references/images.md) |

--- a/.agents/skills/github-issues/references/dependencies.md
+++ b/.agents/skills/github-issues/references/dependencies.md
@@ -1,0 +1,71 @@
+# Issue Dependencies (Blocked By / Blocking)
+
+Dependencies let you mark that an issue is blocked by another issue. This creates a formal dependency relationship visible in the UI and trackable via API. No MCP tools exist for dependencies; use REST or GraphQL directly.
+
+## Using REST API
+
+**List issues blocking this issue:**
+```
+GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
+```
+
+**Add a blocking dependency:**
+```
+POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
+Body: { "issue_id": 12345 }
+```
+
+The `issue_id` is the numeric issue **ID** (not the issue number).
+
+**Remove a blocking dependency:**
+```
+DELETE /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by/{issue_id}
+```
+
+## Using GraphQL
+
+**Read dependencies:**
+```graphql
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      blockedBy(first: 10) { nodes { number title state } }
+      blocking(first: 10) { nodes { number title state } }
+      issueDependenciesSummary { blockedBy blocking totalBlockedBy totalBlocking }
+    }
+  }
+}
+```
+
+**Add a dependency:**
+```graphql
+mutation {
+  addBlockedBy(input: {
+    issueId: "BLOCKED_ISSUE_NODE_ID"
+    blockingIssueId: "BLOCKING_ISSUE_NODE_ID"
+  }) {
+    blockingIssue { number title }
+  }
+}
+```
+
+**Remove a dependency:**
+```graphql
+mutation {
+  removeBlockedBy(input: {
+    issueId: "BLOCKED_ISSUE_NODE_ID"
+    blockingIssueId: "BLOCKING_ISSUE_NODE_ID"
+  }) {
+    blockingIssue { number title }
+  }
+}
+```
+
+## Tracked issues (read-only)
+
+Task-list tracking relationships are available via GraphQL as read-only fields:
+
+- `trackedIssues(first: N)` - issues tracked in this issue's task list
+- `trackedInIssues(first: N)` - issues whose task lists reference this issue
+
+These are set automatically when issues are referenced in task lists (`- [ ] #123`). There are no mutations to manage them.

--- a/.agents/skills/github-issues/references/images.md
+++ b/.agents/skills/github-issues/references/images.md
@@ -1,0 +1,116 @@
+# Images in Issues and Comments
+
+How to embed images in GitHub issue bodies and comments programmatically via the CLI.
+
+## Methods (ranked by reliability)
+
+### 1. GitHub Contents API (recommended for private repos)
+
+Push image files to a branch in the same repo, then reference them with a URL that works for authenticated viewers.
+
+**Step 1: Create a branch**
+
+```bash
+# Get the SHA of the default branch
+SHA=$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq '.object.sha')
+
+# Create a new branch
+gh api repos/{owner}/{repo}/git/refs -X POST \
+  -f ref="refs/heads/{username}/images" \
+  -f sha="$SHA"
+```
+
+**Step 2: Upload images via Contents API**
+
+```bash
+# Base64-encode the image and upload
+BASE64=$(base64 -i /path/to/image.png)
+
+gh api repos/{owner}/{repo}/contents/docs/images/my-image.png \
+  -X PUT \
+  -f message="Add image" \
+  -f content="$BASE64" \
+  -f branch="{username}/images" \
+  --jq '.content.path'
+```
+
+Repeat for each image. The Contents API creates a commit per file.
+
+**Step 3: Reference in markdown**
+
+```markdown
+![Description](https://github.com/{owner}/{repo}/raw/{username}/images/docs/images/my-image.png)
+```
+
+> **Important:** Use `github.com/{owner}/{repo}/raw/{branch}/{path}` format, NOT `raw.githubusercontent.com`. The `raw.githubusercontent.com` URLs return 404 for private repos. The `github.com/.../raw/...` format works because the browser sends auth cookies when the viewer is logged in and has repo access.
+
+**Pros:** Works for any repo the viewer has access to, images live in version control, no expiration.
+**Cons:** Creates commits, viewers must be authenticated, images won't render in email notifications or for users without repo access.
+
+### 2. Gist hosting (public images only)
+
+Upload images as files in a gist. Only works for images you're comfortable making public.
+
+```bash
+# Create a gist with a placeholder file
+gh gist create --public -f description.md <<< "Image hosting gist"
+
+# Note: gh gist edit does NOT support binary files.
+# You must use the API to add binary content to gists.
+```
+
+> **Limitation:** Gists don't support binary file uploads via the CLI. You'd need to base64-encode and store as text, which won't render as images. Not recommended.
+
+### 3. Browser upload (most reliable rendering)
+
+The most reliable way to get permanent image URLs is through the GitHub web UI:
+
+1. Open the issue/comment in a browser
+2. Drag-drop or paste the image into the comment editor
+3. GitHub generates a permanent `https://github.com/user-attachments/assets/{UUID}` URL
+4. These URLs work for anyone, even without repo access, and render in email notifications
+
+> **Why the API can't do this:** GitHub's `upload/policies/assets` endpoint requires a browser session (CSRF token + cookies). It returns an HTML error page when called with API tokens. There is no public API for generating `user-attachments` URLs.
+
+## Taking screenshots programmatically
+
+Use `puppeteer-core` with local Chrome to screenshot HTML mockups:
+
+```javascript
+const puppeteer = require('puppeteer-core');
+
+const browser = await puppeteer.launch({
+  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  defaultViewport: { width: 900, height: 600, deviceScaleFactor: 2 }
+});
+
+const page = await browser.newPage();
+await page.setContent(htmlString);
+
+// Screenshot specific elements
+const elements = await page.$$('.section');
+for (let i = 0; i < elements.length; i++) {
+  await elements[i].screenshot({ path: `mockup-${i + 1}.png` });
+}
+
+await browser.close();
+```
+
+> **Note:** MCP Playwright may not connect to localhost due to network isolation. Use puppeteer-core with a local Chrome installation instead.
+
+## Quick reference
+
+| Method | Private repos | Permanent | No auth needed | API-only |
+|--------|:---:|:---:|:---:|:---:|
+| Contents API + `github.com/raw/` | ✅ | ✅ | ❌ | ✅ |
+| Browser drag-drop (`user-attachments`) | ✅ | ✅ | ✅ | ❌ |
+| `raw.githubusercontent.com` | ❌ (404) | ✅ | ❌ | ✅ |
+| Gist | Public only | ✅ | ✅ | ❌ (no binary) |
+
+## Common pitfalls
+
+- **`raw.githubusercontent.com` returns 404 for private repos** even with a valid token in the URL. GitHub's CDN does not pass auth headers through.
+- **API download URLs are temporary.** URLs returned by `gh api repos/.../contents/...` with `download_url` include a token that expires.
+- **`upload/policies/assets` requires a browser session.** Do not attempt to call this endpoint from the CLI.
+- **Base64 encoding for large files** can hit API payload limits. The Contents API has a ~100MB file size limit but practical limits are lower for base64-encoded payloads.
+- **Email notifications** will not render images that require authentication. If email readability matters, use the browser upload method.

--- a/.agents/skills/github-issues/references/issue-fields.md
+++ b/.agents/skills/github-issues/references/issue-fields.md
@@ -1,0 +1,229 @@
+# Issue Fields
+
+Issue fields are custom metadata (dates, text, numbers, single-select) defined at the organization level and set per-issue. They are separate from labels, milestones, and assignees. Common examples: Start Date, Target Date, Priority, Impact, Effort.
+
+**Prefer issue fields over project fields.** When you need to set metadata like dates, priority, or status on an issue, use issue fields (which live on the issue itself) rather than project fields (which live on a project item). Issue fields travel with the issue across projects and views, while project fields are scoped to a single project. Only use project fields when issue fields are not available or when the field is project-specific (e.g., sprint iterations).
+
+## REST API (recommended)
+
+The REST API is the simplest way to discover fields and set values.
+
+### Discovering available fields
+
+```bash
+gh api orgs/{org}/issue-fields --jq '.[] | {id, name, options: [.options[]? | {id, name}]}'
+```
+
+### Reading field values on an issue
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/issue-field-values
+```
+
+### Setting field values
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/issue-field-values \
+  -X POST \
+  --input - <<'EOF'
+{"issue_field_values": [{"field_id": 1, "value": "P1"}]}
+EOF
+```
+
+**Important:** The payload must be a JSON object with an `issue_field_values` array. Each entry has:
+- `field_id` (integer): the field's numeric ID from the org fields list
+- `value` (string): the **option name** for single-select fields (e.g., `"P1"`, `"High"`), or the literal value for text/number/date fields
+
+Common mistakes to avoid:
+- Passing the option ID instead of the option name as `value` (the API expects the display name)
+- Sending `field_id` and `value` as top-level keys without wrapping in `issue_field_values` array
+- Using `-f` flags instead of `--input` with JSON body
+
+### Example: Set priority to P1
+
+```bash
+# 1. Find the Priority field ID and option names
+gh api orgs/{org}/issue-fields --jq '.[] | select(.name == "Priority")'
+
+# 2. Set it (use the option NAME, not ID)
+gh api repos/{owner}/{repo}/issues/{number}/issue-field-values \
+  -X POST \
+  --input - <<'EOF'
+{"issue_field_values": [{"field_id": 1, "value": "P1"}]}
+EOF
+```
+
+### Example: Set multiple fields at once
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/issue-field-values \
+  -X POST \
+  --input - <<'EOF'
+{"issue_field_values": [
+  {"field_id": 1, "value": "P1"},
+  {"field_id": 5, "value": "2026-06-01"},
+  {"field_id": 7, "value": "High"}
+]}
+EOF
+```
+
+### Workflow for setting fields (REST)
+
+1. **Discover fields** - `gh api orgs/{org}/issue-fields` to get field IDs and option names
+2. **Set values** - POST to `repos/{owner}/{repo}/issues/{number}/issue-field-values` with JSON body
+3. **Batch when possible** - multiple fields can be set in a single request
+
+## GraphQL API (alternative)
+
+The GraphQL API requires the `GraphQL-Features: issue_fields` HTTP header. Without it, the fields are not visible in the schema.
+
+### Discovering available fields (GraphQL)
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+{
+  organization(login: "OWNER") {
+    issueFields(first: 30) {
+      nodes {
+        __typename
+        ... on IssueFieldDate { id name }
+        ... on IssueFieldText { id name }
+        ... on IssueFieldNumber { id name }
+        ... on IssueFieldSingleSelect { id name options { id name color } }
+      }
+    }
+  }
+}
+```
+
+Field types: `IssueFieldDate`, `IssueFieldText`, `IssueFieldNumber`, `IssueFieldSingleSelect`.
+
+### Reading field values (GraphQL)
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      issueFieldValues(first: 20) {
+        nodes {
+          __typename
+          ... on IssueFieldDateValue {
+            value
+            field { ... on IssueFieldDate { id name } }
+          }
+          ... on IssueFieldTextValue {
+            value
+            field { ... on IssueFieldText { id name } }
+          }
+          ... on IssueFieldNumberValue {
+            value
+            field { ... on IssueFieldNumber { id name } }
+          }
+          ... on IssueFieldSingleSelectValue {
+            name
+            color
+            field { ... on IssueFieldSingleSelect { id name } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Setting field values (GraphQL)
+
+Use `setIssueFieldValue` to set one or more fields at once. You need the issue's node ID and the field IDs from the discovery query above.
+
+```graphql
+# Header: GraphQL-Features: issue_fields
+mutation {
+  setIssueFieldValue(input: {
+    issueId: "ISSUE_NODE_ID"
+    issueFields: [
+      { fieldId: "IFD_xxx", dateValue: "2026-04-15" }
+      { fieldId: "IFT_xxx", textValue: "some text" }
+      { fieldId: "IFN_xxx", numberValue: 3.0 }
+      { fieldId: "IFSS_xxx", singleSelectOptionId: "OPTION_ID" }
+    ]
+  }) {
+    issue { id title }
+  }
+}
+```
+
+Each entry in `issueFields` takes a `fieldId` plus exactly one value parameter:
+
+| Field type | Value parameter | Format |
+|-----------|----------------|--------|
+| Date | `dateValue` | ISO 8601 date string, e.g. `"2026-04-15"` |
+| Text | `textValue` | String |
+| Number | `numberValue` | Float |
+| Single select | `singleSelectOptionId` | Node ID from the field's `options` list |
+
+To clear a field value, set `delete: true` instead of a value parameter.
+
+## Searching by field values
+
+### GraphQL bulk query (recommended)
+
+The most reliable way to find issues by field value is to fetch issues via GraphQL and filter by `issueFieldValues`. The search qualifier syntax (`field.name:value`) is not yet reliable across all environments.
+
+```bash
+# Find all open P1 issues in a repo
+gh api graphql -H "GraphQL-Features: issue_fields" -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issues(first: 100, states: OPEN) {
+      nodes {
+        number
+        title
+        updatedAt
+        assignees(first: 3) { nodes { login } }
+        issueFieldValues(first: 10) {
+          nodes {
+            __typename
+            ... on IssueFieldSingleSelectValue {
+              name
+              field { ... on IssueFieldSingleSelect { name } }
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '
+  [.data.repository.issues.nodes[] |
+    select(.issueFieldValues.nodes[] |
+      select(.field.name == "Priority" and .name == "P1")
+    ) |
+    {number, title, updatedAt, assignees: [.assignees.nodes[].login]}
+  ]'
+```
+
+**Schema notes for `IssueFieldSingleSelectValue`:**
+- The selected option's display text is in `.name` (not `.value`)
+- Also available: `.color`, `.description`, `.id`
+- The parent field reference is in `.field` (use inline fragment to get the field name)
+
+### Search qualifier syntax (experimental)
+
+Issue fields may also be searchable using dot notation in search queries. This requires `advanced_search=true` on REST or `ISSUE_ADVANCED` search type on GraphQL, but results are inconsistent and may return 0 results even when matching issues exist.
+
+```
+field.priority:P0                  # Single-select equals value
+field.target-date:>=2026-04-01     # Date comparison
+has:field.priority                 # Has any value set
+no:field.priority                  # Has no value set
+```
+
+Field names use the **slug** (lowercase, hyphens for spaces). For example, "Target Date" becomes `target-date`.
+
+```bash
+# REST API (may not return results in all environments)
+gh api "search/issues?q=repo:owner/repo+field.priority:P0+is:open&advanced_search=true" \
+  --jq '.items[] | "#\(.number): \(.title)"'
+```
+
+> **Warning:** The colon notation (`field:Priority:P1`) is silently ignored. If using search qualifiers, always use dot notation (`field.priority:P1`). However, the GraphQL bulk query approach above is more reliable. See [search.md](search.md) for the full search guide.

--- a/.agents/skills/github-issues/references/issue-types.md
+++ b/.agents/skills/github-issues/references/issue-types.md
@@ -1,0 +1,72 @@
+# Issue Types (Advanced GraphQL)
+
+Issue types (Bug, Feature, Task, Epic, etc.) are defined at the **organization** level and inherited by repositories. They categorize issues beyond labels.
+
+For basic usage, the MCP tools handle issue types natively. Call `mcp__github__list_issue_types` to discover types, and pass `type: "Bug"` to `mcp__github__create_issue` or `mcp__github__update_issue`. This reference covers advanced GraphQL operations.
+
+## GraphQL Feature Header
+
+All GraphQL issue type operations require the `GraphQL-Features: issue_types` HTTP header.
+
+## List types (org or repo level)
+
+```graphql
+# Header: GraphQL-Features: issue_types
+{
+  organization(login: "OWNER") {
+    issueTypes(first: 20) {
+      nodes { id name color description isEnabled }
+    }
+  }
+}
+```
+
+Types can also be listed per-repo via `repository.issueTypes` or looked up by name via `repository.issueType(name: "Bug")`.
+
+## Read an issue's type
+
+```graphql
+# Header: GraphQL-Features: issue_types
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      issueType { id name color }
+    }
+  }
+}
+```
+
+## Set type on an existing issue
+
+```graphql
+# Header: GraphQL-Features: issue_types
+mutation {
+  updateIssueIssueType(input: {
+    issueId: "ISSUE_NODE_ID"
+    issueTypeId: "IT_xxx"
+  }) {
+    issue { id issueType { name } }
+  }
+}
+```
+
+## Create issue with type
+
+```graphql
+# Header: GraphQL-Features: issue_types
+mutation {
+  createIssue(input: {
+    repositoryId: "REPO_NODE_ID"
+    title: "Fix login bug"
+    issueTypeId: "IT_xxx"
+  }) {
+    issue { id number issueType { name } }
+  }
+}
+```
+
+To clear the type, set `issueTypeId` to `null`.
+
+## Available colors
+
+`GRAY`, `BLUE`, `GREEN`, `YELLOW`, `ORANGE`, `RED`, `PINK`, `PURPLE`

--- a/.agents/skills/github-issues/references/projects.md
+++ b/.agents/skills/github-issues/references/projects.md
@@ -1,0 +1,273 @@
+# Projects V2
+
+GitHub Projects V2 is managed via GraphQL. The MCP server provides three tools that wrap the GraphQL API, so you typically don't need raw GraphQL.
+
+## Using MCP tools (preferred)
+
+**List projects:**
+Call `mcp__github__projects_list` with `method: "list_projects"`, `owner`, and `owner_type` ("user" or "organization").
+
+**List project fields:**
+Call `mcp__github__projects_list` with `method: "list_project_fields"` and `project_number`.
+
+**List project items:**
+Call `mcp__github__projects_list` with `method: "list_project_items"` and `project_number`.
+
+**Add an issue/PR to a project:**
+Call `mcp__github__projects_write` with `method: "add_project_item"`, `project_id` (node ID), and `content_id` (issue/PR node ID).
+
+**Update a project item field value:**
+Call `mcp__github__projects_write` with `method: "update_project_item"`, `project_id`, `item_id`, `field_id`, and `value` (object with one of: `text`, `number`, `date`, `singleSelectOptionId`, `iterationId`).
+
+**Delete a project item:**
+Call `mcp__github__projects_write` with `method: "delete_project_item"`, `project_id`, and `item_id`.
+
+## Workflow for project operations
+
+1. **Find the project** — see [Finding a project by name](#finding-a-project-by-name) below
+2. **Discover fields** - use `projects_list` with `list_project_fields` to get field IDs and option IDs
+3. **Find items** - use `projects_list` with `list_project_items` to get item IDs
+4. **Mutate** - use `projects_write` to add, update, or delete items
+
+## Finding a project by name
+
+> **⚠️ Known issue:** `projectsV2(query: "…")` does keyword search, not exact name match, and returns results sorted by recency. Common words like "issue" or "bug" return hundreds of false positives. The actual project may be buried dozens of pages deep.
+
+Use this priority order:
+
+### 1. Direct lookup (if you know the number)
+```bash
+gh api graphql -f query='{
+  organization(login: "ORG") {
+    projectV2(number: 42) { id title }
+  }
+}' --jq '.data.organization.projectV2'
+```
+
+### 2. Reverse lookup from a known issue (most reliable)
+If the user mentions an issue, epic, or milestone that's in the project, query that issue's `projectItems` to discover the project:
+
+```bash
+gh api graphql -f query='{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project { number title id }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes[] | {number: .project.number, title: .project.title, id: .project.id}'
+```
+
+This is the most reliable approach for large orgs where name search fails.
+
+### 3. GraphQL name search with client-side filtering (fallback)
+Query a large page and filter client-side for an exact title match:
+
+```bash
+gh api graphql -f query='{
+  organization(login: "ORG") {
+    projectsV2(first: 100, query: "search term") {
+      nodes { number title id }
+    }
+  }
+}' --jq '.data.organization.projectsV2.nodes[] | select(.title | test("(?i)^exact name$"))'
+```
+
+If this returns nothing, paginate with `after` cursor or broaden the regex. Results are sorted by recency so older projects require pagination.
+
+### 4. MCP tool (small orgs only)
+Call `mcp__github__projects_list` with `method: "list_projects"`. This works well for orgs with <50 projects but has no name filter, so you must scan all results.
+
+## Project discovery for progress reports
+
+When a user asks for a progress update on a project (e.g., "Give me a progress update for Project X"), follow this workflow:
+
+1. **Find the project** — use the [finding a project](#finding-a-project-by-name) strategies above. Ask the user for a known issue number if name search fails.
+
+2. **Discover fields** - call `projects_list` with `list_project_fields` to find the Status field (its options tell you the workflow stages) and any Iteration field (to scope to the current sprint).
+
+3. **Get all items** - call `projects_list` with `list_project_items`. For large projects (100+ items), paginate through all pages. Each item includes its field values (status, iteration, assignees).
+
+4. **Build the report** - group items by Status field value and count them. For iteration-based projects, filter to the current iteration first. Present a breakdown like:
+
+   ```
+   Project: Issue Fields (Iteration 42, Mar 2-8)
+   15 actionable items:
+     🎉 Done:        4 (27%)
+     In Review:      3
+     In Progress:    3
+     Ready:          2
+     Blocked:        2
+   ```
+
+5. **Add context** - if items have sub-issues, include `subIssuesSummary` counts. If items have dependencies, note blocked items and what blocks them.
+
+## OAuth Scope Requirements
+
+| Operation | Required scope |
+|-----------|---------------|
+| Read projects, fields, items | `read:project` |
+| Add/update/delete items, change field values | `project` |
+
+**Common pitfall:** The default `gh auth` token often only has `read:project`. Mutations will fail with `INSUFFICIENT_SCOPES`. To add the write scope:
+
+```bash
+gh auth refresh -h github.com -s project
+```
+
+This triggers a browser-based OAuth flow. You must complete it before mutations will work.
+
+## Finding an Issue's Project Item ID
+
+When you know the issue but need its project item ID (e.g., to update its Status), query from the issue side:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      projectItems(first: 5) {
+        nodes {
+          id
+          project { title number }
+          fieldValues(first: 10) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes'
+```
+
+This returns the item ID, project info, and current field values in one query.
+
+## Using GraphQL via gh api (recommended)
+
+Use `gh api graphql` to run GraphQL queries and mutations. This is more reliable than MCP tools for write operations.
+
+**Find a project and its Status field options:**
+```bash
+gh api graphql -f query='
+{
+  organization(login: "ORG") {
+    projectV2(number: 5) {
+      id
+      title
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}' --jq '.data.organization.projectV2'
+```
+
+**List all fields (including iterations):**
+```bash
+gh api graphql -f query='
+{
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2Field { id name }
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+          ... on ProjectV2IterationField { id name configuration { iterations { id startDate } } }
+        }
+      }
+    }
+  }
+}' --jq '.data.node.fields.nodes'
+```
+
+**Update a field value (e.g., set Status to "In Progress"):**
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+    fieldId: "FIELD_ID"
+    value: { singleSelectOptionId: "OPTION_ID" }
+  }) {
+    projectV2Item { id }
+  }
+}'
+```
+
+Value accepts one of: `text`, `number`, `date`, `singleSelectOptionId`, `iterationId`.
+
+**Add an item:**
+```bash
+gh api graphql -f query='
+mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PROJECT_ID"
+    contentId: "ISSUE_OR_PR_NODE_ID"
+  }) {
+    item { id }
+  }
+}'
+```
+
+**Delete an item:**
+```bash
+gh api graphql -f query='
+mutation {
+  deleteProjectV2Item(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+  }) {
+    deletedItemId
+  }
+}'
+```
+
+## End-to-End Example: Set Issue Status to "In Progress"
+
+```bash
+# 1. Get the issue's project item ID, project ID, and current status
+gh api graphql -f query='{
+  repository(owner: "github", name: "planning-tracking") {
+    issue(number: 2574) {
+      projectItems(first: 1) {
+        nodes { id project { id title } }
+      }
+    }
+  }
+}' --jq '.data.repository.issue.projectItems.nodes[0]'
+
+# 2. Get the Status field ID and "In Progress" option ID
+gh api graphql -f query='{
+  node(id: "PROJECT_ID") {
+    ... on ProjectV2 {
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+    }
+  }
+}' --jq '.data.node.field'
+
+# 3. Update the status
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PROJECT_ID"
+    itemId: "ITEM_ID"
+    fieldId: "FIELD_ID"
+    value: { singleSelectOptionId: "IN_PROGRESS_OPTION_ID" }
+  }) { projectV2Item { id } }
+}'
+```
+```

--- a/.agents/skills/github-issues/references/search.md
+++ b/.agents/skills/github-issues/references/search.md
@@ -1,0 +1,231 @@
+# Advanced Issue Search
+
+The `search_issues` MCP tool uses GitHub's issue search query format for cross-repo searches, supporting implicit-AND queries, date ranges, and metadata filters (but not explicit OR/NOT operators).
+
+## When to Use Search vs List vs Advanced Search
+
+There are three ways to find issues, each with different capabilities:
+
+| Capability | `list_issues` (MCP) | `search_issues` (MCP) | Advanced search (`gh api`) |
+|-----------|---------------------|----------------------|---------------------------|
+| **Scope** | Single repo only | Cross-repo, cross-org | Cross-repo, cross-org |
+| **Issue field filters** (`field.priority:P0`) | No | No | **Yes** (dot notation) |
+| **Issue type filter** (`type:Bug`) | No | Yes | Yes |
+| **Boolean logic** (AND/OR/NOT, nesting) | No | Yes (implicit AND only) | **Yes** (explicit AND/OR/NOT) |
+| **Label/state/date filters** | Yes | Yes | Yes |
+| **Assignee/author/mentions** | No | Yes | Yes |
+| **Negation** (`-label:x`, `no:label`) | No | Yes | Yes |
+| **Text search** (title/body/comments) | No | Yes | Yes |
+| **`since` filter** | Yes | No | No |
+| **Result limit** | No cap (paginate all) | 1,000 max | 1,000 max |
+| **How to call** | MCP tool directly | MCP tool directly | `gh api` with `advanced_search=true` |
+
+**Decision guide:**
+- **Single repo, simple filters (state, labels, recent updates):** use `list_issues`
+- **Cross-repo, text search, author/assignee, issue types:** use `search_issues`
+- **Issue field values (Priority, dates, custom fields) or complex boolean logic:** use `gh api` with `advanced_search=true`
+
+## Query Syntax
+
+The `query` parameter is a string of search terms and qualifiers. A space between terms is implicit AND.
+
+### Scoping
+
+```
+repo:owner/repo       # Single repo (auto-added if you pass owner+repo params)
+org:github            # All repos in an org
+user:octocat          # All repos owned by user
+in:title              # Search only in title
+in:body               # Search only in body
+in:comments           # Search only in comments
+```
+
+### State & Close Reason
+
+```
+is:open               # Open issues (auto-added: is:issue)
+is:closed             # Closed issues
+reason:completed      # Closed as completed
+reason:"not planned"  # Closed as not planned
+```
+
+### People
+
+```
+author:username       # Created by
+assignee:username     # Assigned to
+mentions:username     # Mentions user
+commenter:username    # Has comment from
+involves:username     # Author OR assignee OR mentioned OR commenter
+author:@me            # Current authenticated user
+team:org/team         # Team mentioned
+```
+
+### Labels, Milestones, Projects, Types
+
+```
+label:"bug"                 # Has label (quote multi-word labels)
+label:bug label:priority    # Has BOTH labels (AND)
+label:bug,enhancement       # Has EITHER label (OR)
+-label:wontfix              # Does NOT have label
+milestone:"v2.0"            # In milestone
+project:github/57           # In project board
+type:"Bug"                  # Issue type
+```
+
+### Missing Metadata
+
+```
+no:label              # No labels assigned
+no:milestone          # No milestone
+no:assignee           # Unassigned
+no:project            # Not in any project
+```
+
+### Dates
+
+All date qualifiers support `>`, `<`, `>=`, `<=`, and range (`..`) operators with ISO 8601 format:
+
+```
+created:>2026-01-01              # Created after Jan 1
+updated:>=2026-03-01             # Updated since Mar 1
+closed:2026-01-01..2026-02-01   # Closed in January
+created:<2026-01-01              # Created before Jan 1
+```
+
+### Linked Content
+
+```
+linked:pr             # Issue has a linked PR
+-linked:pr            # Issues not yet linked to any PR
+linked:issue          # PR is linked to an issue
+```
+
+### Numeric Filters
+
+```
+comments:>10          # More than 10 comments
+comments:0            # No comments
+interactions:>100     # Reactions + comments > 100
+reactions:>50         # More than 50 reactions
+```
+
+### Boolean Logic & Nesting
+
+Use `AND`, `OR`, and parentheses (up to 5 levels deep, max 5 operators):
+
+```
+label:bug AND assignee:octocat
+assignee:octocat OR assignee:hubot
+(type:"Bug" AND label:P1) OR (type:"Feature" AND label:P1)
+-author:app/dependabot          # Exclude bot issues
+```
+
+A space between terms without an explicit operator is treated as AND.
+
+## Common Query Patterns
+
+**Unassigned bugs:**
+```
+repo:owner/repo type:"Bug" no:assignee is:open
+```
+
+**Issues closed this week:**
+```
+repo:owner/repo is:closed closed:>=2026-03-01
+```
+
+**Stale open issues (no updates in 90 days):**
+```
+repo:owner/repo is:open updated:<2026-01-01
+```
+
+**Open issues without a linked PR (needs work):**
+```
+repo:owner/repo is:open -linked:pr
+```
+
+**Issues I'm involved in across an org:**
+```
+org:github involves:@me is:open
+```
+
+**High-activity issues:**
+```
+repo:owner/repo is:open comments:>20
+```
+
+**Issues by type and priority label:**
+```
+repo:owner/repo type:"Epic" label:P1 is:open
+```
+
+## Issue Field Search
+
+> **Reliability warning:** The `field.name:value` search qualifier syntax is experimental and may return 0 results even when matching issues exist. For reliable filtering by field values, use the GraphQL bulk query approach documented in [issue-fields.md](issue-fields.md#searching-by-field-values).
+
+Issue fields can theoretically be searched via the `field.name:value` qualifier using **advanced search mode**. This works in the web UI but results from the API are inconsistent.
+
+### REST API
+
+Add `advanced_search=true` as a query parameter:
+
+```bash
+gh api "search/issues?q=org:github+field.priority:P0+type:Epic+is:open&advanced_search=true" \
+  --jq '.items[] | "#\(.number): \(.title)"'
+```
+
+### GraphQL
+
+Use `type: ISSUE_ADVANCED` instead of `type: ISSUE`:
+
+```graphql
+{
+  search(query: "org:github field.priority:P0 type:Epic is:open", type: ISSUE_ADVANCED, first: 10) {
+    issueCount
+    nodes {
+      ... on Issue { number title }
+    }
+  }
+}
+```
+
+### Issue Field Qualifiers
+
+The syntax uses **dot notation** with the field's slug name (lowercase, hyphens for spaces):
+
+```
+field.priority:P0                  # Single-select field equals value
+field.priority:P1                  # Different option value
+field.target-date:>=2026-04-01     # Date comparison
+has:field.priority                 # Has any value set
+no:field.priority                  # Has no value set
+```
+
+**MCP limitation:** The `search_issues` MCP tool does not pass `advanced_search=true`. You must use `gh api` directly for issue field searches.
+
+### Common Field Search Patterns
+
+**P0 epics across an org:**
+```
+org:github field.priority:P0 type:Epic is:open
+```
+
+**Issues with a target date this quarter:**
+```
+org:github field.target-date:>=2026-04-01 field.target-date:<=2026-06-30 is:open
+```
+
+**Open bugs missing priority:**
+```
+org:github no:field.priority type:Bug is:open
+```
+
+## Limitations
+
+- Query text: max **256 characters** (excluding operators/qualifiers)
+- Boolean operators: max **5** AND/OR/NOT per query
+- Results: max **1,000** total (use `list_issues` if you need all issues)
+- Repo scan: searches up to **4,000** matching repositories
+- Rate limit: **30 requests/minute** for authenticated search
+- Issue field search requires `advanced_search=true` (REST) or `ISSUE_ADVANCED` (GraphQL); not available through MCP `search_issues`

--- a/.agents/skills/github-issues/references/sub-issues.md
+++ b/.agents/skills/github-issues/references/sub-issues.md
@@ -1,0 +1,137 @@
+# Sub-Issues and Parent Issues
+
+Sub-issues let you break down work into hierarchical tasks. Each parent issue can have up to 100 sub-issues, nested up to 8 levels deep. Sub-issues can span repositories within the same owner.
+
+## Recommended Workflow
+
+The simplest way to create a sub-issue is **two steps**: create the issue, then link it.
+
+```bash
+# Step 1: Create the issue and capture its numeric ID
+ISSUE_ID=$(gh api repos/{owner}/{repo}/issues \
+  -X POST \
+  -f title="Sub-task title" \
+  -f body="Description" \
+  --jq '.id')
+
+# Step 2: Link it as a sub-issue of the parent
+# IMPORTANT: sub_issue_id must be an integer. Use --input (not -f) to send JSON.
+echo "{\"sub_issue_id\": $ISSUE_ID}" | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues -X POST --input -
+```
+
+**Why `--input` instead of `-f`?** The `gh api -f` flag sends all values as strings, but the API requires `sub_issue_id` as an integer. Using `-f sub_issue_id=12345` will return a 422 error.
+
+Alternatively, use GraphQL `createIssue` with `parentIssueId` to do it in one step (see GraphQL section below).
+
+## Using MCP tools
+
+**List sub-issues:**
+Call `mcp__github__issue_read` with `method: "get_sub_issues"`, `owner`, `repo`, and `issue_number`.
+
+**Create an issue as a sub-issue:**
+There is no MCP tool for creating sub-issues directly. Use the workflow above or GraphQL.
+
+## Using REST API
+
+**List sub-issues:**
+```bash
+gh api repos/{owner}/{repo}/issues/{issue_number}/sub_issues
+```
+
+**Get parent issue:**
+```bash
+gh api repos/{owner}/{repo}/issues/{issue_number}/parent
+```
+
+**Add an existing issue as a sub-issue:**
+```bash
+# sub_issue_id is the numeric issue ID (not the issue number)
+# Get it from the .id field when creating or fetching an issue
+echo '{"sub_issue_id": 12345}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues -X POST --input -
+```
+
+To move a sub-issue that already has a parent, add `"replace_parent": true` to the JSON body.
+
+**Remove a sub-issue:**
+```bash
+echo '{"sub_issue_id": 12345}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issue -X DELETE --input -
+```
+
+**Reprioritize a sub-issue:**
+```bash
+echo '{"sub_issue_id": 6, "after_id": 5}' | gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues/priority -X PATCH --input -
+```
+
+Use `after_id` or `before_id` to position the sub-issue relative to another.
+
+## Using GraphQL
+
+**Read parent and sub-issues:**
+```graphql
+{
+  repository(owner: "OWNER", name: "REPO") {
+    issue(number: 123) {
+      parent { number title }
+      subIssues(first: 50) {
+        nodes { number title state }
+      }
+      subIssuesSummary { total completed percentCompleted }
+    }
+  }
+}
+```
+
+**Add a sub-issue:**
+```graphql
+mutation {
+  addSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+  }) {
+    issue { id }
+    subIssue { id number title }
+  }
+}
+```
+
+You can also use `subIssueUrl` instead of `subIssueId` (pass the issue's HTML URL). Add `replaceParent: true` to move a sub-issue from another parent.
+
+**Create an issue directly as a sub-issue:**
+```graphql
+mutation {
+  createIssue(input: {
+    repositoryId: "REPO_NODE_ID"
+    title: "Implement login validation"
+    parentIssueId: "PARENT_NODE_ID"
+  }) {
+    issue { id number }
+  }
+}
+```
+
+**Remove a sub-issue:**
+```graphql
+mutation {
+  removeSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+  }) {
+    issue { id }
+  }
+}
+```
+
+**Reprioritize a sub-issue:**
+```graphql
+mutation {
+  reprioritizeSubIssue(input: {
+    issueId: "PARENT_NODE_ID"
+    subIssueId: "CHILD_NODE_ID"
+    afterId: "OTHER_CHILD_NODE_ID"
+  }) {
+    issue { id }
+  }
+}
+```
+
+Use `afterId` or `beforeId` to position relative to another sub-issue.

--- a/.agents/skills/github-issues/references/templates.md
+++ b/.agents/skills/github-issues/references/templates.md
@@ -1,0 +1,90 @@
+# Issue Templates
+
+Copy and customize these templates for issue bodies.
+
+## Bug Report Template
+
+```markdown
+## Description
+[Clear description of the bug]
+
+## Steps to Reproduce
+1. [First step]
+2. [Second step]
+3. [And so on...]
+
+## Expected Behavior
+[What should happen]
+
+## Actual Behavior
+[What actually happens]
+
+## Environment
+- Browser: [e.g., Chrome 120]
+- OS: [e.g., macOS 14.0]
+- Version: [e.g., v1.2.3]
+
+## Screenshots/Logs
+[If applicable]
+
+## Additional Context
+[Any other relevant information]
+```
+
+## Feature Request Template
+
+```markdown
+## Summary
+[One-line description of the feature]
+
+## Motivation
+[Why is this feature needed? What problem does it solve?]
+
+## Proposed Solution
+[How should this feature work?]
+
+## Acceptance Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+## Alternatives Considered
+[Other approaches considered and why they weren't chosen]
+
+## Additional Context
+[Mockups, examples, or related issues]
+```
+
+## Task Template
+
+```markdown
+## Objective
+[What needs to be accomplished]
+
+## Details
+[Detailed description of the work]
+
+## Checklist
+- [ ] [Subtask 1]
+- [ ] [Subtask 2]
+- [ ] [Subtask 3]
+
+## Dependencies
+[Any blockers or related work]
+
+## Notes
+[Additional context or considerations]
+```
+
+## Minimal Template
+
+For simple issues:
+
+```markdown
+## Description
+[What and why]
+
+## Tasks
+- [ ] [Task 1]
+- [ ] [Task 2]
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__github__get_me"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__github__get_me"
-    ]
-  }
-}

--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+../../.agents/skills/frontend-design

--- a/.claude/skills/github-issues
+++ b/.claude/skills/github-issues
@@ -1,0 +1,1 @@
+../../.agents/skills/github-issues

--- a/.claude/skills/next-best-practices
+++ b/.claude/skills/next-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/next-best-practices

--- a/.claude/skills/shadcn
+++ b/.claude/skills/shadcn
@@ -1,0 +1,1 @@
+../../.agents/skills/shadcn

--- a/.claude/skills/supabase
+++ b/.claude/skills/supabase
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase

--- a/.claude/skills/supabase-postgres-best-practices
+++ b/.claude/skills/supabase-postgres-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/supabase-postgres-best-practices

--- a/.claude/skills/tailwind-v4-shadcn
+++ b/.claude/skills/tailwind-v4-shadcn
@@ -1,0 +1,1 @@
+../../.agents/skills/tailwind-v4-shadcn

--- a/.claude/skills/typescript-advanced-types
+++ b/.claude/skills/typescript-advanced-types
@@ -1,0 +1,1 @@
+../../.agents/skills/typescript-advanced-types

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ public/sw.js.map
 
 # historical data
 historical_data
+# claude code — config local de la máquina (los symlinks de skills sí se versionan)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,14 @@ export const fmt = (n: number, decimals = 0): string => {
 
 ## Flujos de GitHub
 
+**Skill obligatoria:** ante cualquier operación con GitHub issues invocar primero la skill `github-issues`. Si sus ejemplos genéricos chocan con esta sección, **manda esta sección de CLAUDE.md**.
+
+**Servidor MCP:** se usa el servidor remoto oficial `github/github-mcp-server` (`https://api.githubcopilot.com/mcp/`). Las escrituras de issues van por la tool consolidada `mcp__github__issue_write` (`method: "create"` o `"update"`). Projects V2 **no** está cubierto por el MCP (toolset no activada), así que el tablero sigue por `gh project`.
+
 **Regla general:** usar MCP siempre que sea posible; CLI `gh` solo para lo que el MCP no cubra.
 
 ### Crear issues y añadirlas al proyecto
-1. Crear la issue con MCP `mcp__github__create_issue` (owner: `MrClit`, repo: `fin-app`)
+1. Crear la issue con MCP `mcp__github__issue_write` (`method: "create"`, owner: `MrClit`, repo: `fin-app`)
 2. Vincularla al proyecto FinApp con `gh` (el MCP no soporta la API de Projects):
    ```bash
    gh project item-add 2 --owner MrClit --url "https://github.com/MrClit/fin-app/issues/$N"
@@ -84,7 +88,7 @@ gh project field-list 2 --owner MrClit --format json  # → field-id y option-id
 |---|---|
 | Antes de analizar/planificar una issue | Verificar que la rama activa es `develop` (si no, avisar y parar) |
 | Antes de analizar/planificar una issue | Mover a **Ready** (si no lo está ya) |
-| Al aceptar el plan e iniciar implementación | Si el plan difiere significativamente de la descripción original de la issue, actualizarla con `mcp__github__update_issue` antes de empezar |
+| Al aceptar el plan e iniciar implementación | Si el plan difiere significativamente de la descripción original de la issue, actualizarla con `mcp__github__issue_write` (`method: "update"`) antes de empezar |
 | Al aceptar el plan e iniciar implementación | Mover a **In progress** |
 | Al aceptar el plan e iniciar implementación | Crear rama `feature/<issue-slug>` o `fix/<issue-slug>` desde `develop` y trabajar en ella |
 | Antes de abrir PR | Ejecutar **siempre** `pnpm test`, `pnpm lint` y `pnpm build`. Si alguno falla, arreglarlo antes de pushear. No usar `--no-verify` ni saltarse hooks. |

--- a/app/api/edenred/categories.test.ts
+++ b/app/api/edenred/categories.test.ts
@@ -3,8 +3,10 @@ import { CATEGORIES } from '@/lib/categories/catalog'
 
 // Categorías que usa la integración Edenred. Deben existir en el catálogo
 // (lib/categories/catalog.ts, fuente única de la tabla `categories`), porque
-// la matview `transactions_monthly_summary` hace INNER JOIN sobre `categories`:
-// un `id` desconocido excluiría la tx de las agregaciones SIN error. Ver #101.
+// `transactions.category` tiene FK a `categories.id` (#174): un `id` desconocido
+// haría fallar el insert de la tx. Además la analítica (`get_period_data`) hace
+// LEFT JOIN sobre `categories`, así que un id sin fila quedaría sin metadatos de
+// categoría en las agregaciones. Ver #101.
 // El scraper `scripts/scrapers/edenred/scrape.mjs` emite estos ids sin tipado,
 // por eso este test los protege explícitamente.
 // - 'restaurant': consumo (fallback del webhook en route.ts)

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -124,11 +124,12 @@ export async function POST(req: Request) {
   if (payload.transactions.length > 0) {
     // `category` debe coincidir con un `id` de la tabla `categories` (datos de
     // referencia compartidos, seed en
-    // supabase/migrations/20260509000000_categories_type.sql). La matview
-    // `transactions_monthly_summary` hace INNER JOIN sobre `categories`, así que
-    // un `id` desconocido excluiría la tx de las agregaciones SIN error. El
-    // scraper sólo emite 'restaurant' y 'payroll', y el fallback de aquí es
-    // 'restaurant'; ambos están garantizados por ese seed. Ver issue #101.
+    // supabase/migrations/20260509000000_categories_type.sql). `transactions.category`
+    // tiene FK a `categories.id` (#174), así que un `id` desconocido haría fallar el
+    // insert; además la analítica (`get_period_data`) hace LEFT JOIN sobre `categories`
+    // y dejaría la tx sin metadatos de categoría. El scraper sólo emite 'restaurant' y
+    // 'payroll', y el fallback de aquí es 'restaurant'; ambos están garantizados por
+    // ese seed. Ver issue #101.
     // `is_read` se omite a propósito (issue #149): los inserts nuevos toman el
     // DEFAULT false (nacen "no leídos"), y como el upsert usa
     // `ignoreDuplicates: false` (actualiza filas existentes), NO incluirlo evita

--- a/app/api/sabadell-visa/notify-error/route.test.ts
+++ b/app/api/sabadell-visa/notify-error/route.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createServiceClient } from '@/lib/supabase/service'
+import { sendPushToUser } from '@/lib/push'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+vi.mock('@/lib/push', () => ({
+  sendPushToUser: vi.fn(),
+}))
+
+const { POST } = await import('./route')
+
+const SECRET = 'test-secret'
+const USER_ID = '00000000-0000-0000-0000-000000000001'
+
+function buildMockDb(userConfig: { data: { user_id: string } | null; error?: unknown }) {
+  const userConfigBuilder: Record<string, unknown> = {}
+  Object.assign(userConfigBuilder, {
+    select: vi.fn(() => userConfigBuilder),
+    limit: vi.fn(() => userConfigBuilder),
+    maybeSingle: vi.fn(() => Promise.resolve(userConfig)),
+  })
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === 'user_config') return userConfigBuilder
+      throw new Error(`Unmocked table: ${table}`)
+    }),
+  }
+  return db
+}
+
+function callRoute(opts: { auth?: string | null } = {}) {
+  const headers: Record<string, string> = {}
+  if (opts.auth !== null) {
+    headers.authorization = opts.auth ?? `Bearer ${SECRET}`
+  }
+  return POST(new Request('http://test/api/sabadell-visa/notify-error', { method: 'POST', headers }))
+}
+
+beforeEach(() => {
+  vi.stubEnv('SABADELL_VISA_WEBHOOK_SECRET', SECRET)
+  vi.mocked(sendPushToUser).mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('POST /api/sabadell-visa/notify-error — auth', () => {
+  it('rechaza con 401 si falta el header Authorization', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: null })
+    expect(res.status).toBe(401)
+    expect(db.from).not.toHaveBeenCalled()
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+
+  it('rechaza con 401 si el Bearer es incorrecto', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID } })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute({ auth: 'Bearer wrong' })
+    expect(res.status).toBe(401)
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/sabadell-visa/notify-error — configuración', () => {
+  it('devuelve 500 si falta SABADELL_VISA_WEBHOOK_SECRET', async () => {
+    vi.unstubAllEnvs()
+    delete process.env.SABADELL_VISA_WEBHOOK_SECRET
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Server misconfigured' })
+  })
+
+  it('devuelve 500 "No user configured" si user_config está vacío', async () => {
+    const db = buildMockDb({ data: null, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'No user configured' })
+    expect(sendPushToUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/sabadell-visa/notify-error — envío', () => {
+  it('envía el push de sesión caducada al usuario y devuelve el conteo', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockResolvedValue(2)
+
+    const res = await callRoute()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ sent: 2 })
+
+    expect(sendPushToUser).toHaveBeenCalledTimes(1)
+    const [, userId, payload] = vi.mocked(sendPushToUser).mock.calls[0]
+    expect(userId).toBe(USER_ID)
+    expect(payload).toEqual({
+      title: 'Sabadell VISA: sesión caducada',
+      body: 'Ejecuta «pnpm scrape:sabadell-visa:login» para re-enrolar el dispositivo.',
+      url: '/cuentas',
+    })
+  })
+
+  it('devuelve 500 si sendPushToUser lanza (p. ej. VAPID sin configurar)', async () => {
+    const db = buildMockDb({ data: { user_id: USER_ID }, error: null })
+    vi.mocked(createServiceClient).mockReturnValue(
+      db as unknown as ReturnType<typeof createServiceClient>
+    )
+    vi.mocked(sendPushToUser).mockRejectedValue(new Error('VAPID env vars no configuradas'))
+
+    const res = await callRoute()
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Push failed' })
+  })
+})

--- a/app/api/sabadell-visa/notify-error/route.ts
+++ b/app/api/sabadell-visa/notify-error/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { safeBearerMatch } from '@/lib/http/bearer'
+import { sendPushToUser } from '@/lib/push'
+
+/**
+ * Webhook que dispara un push "Sabadell VISA: sesión caducada" (issue #213).
+ *
+ * El scraper corre en local (launchd en el Mac); cuando un fallo de sesión
+ * (exit 2: OTP / login fallido) requiere intervención, hace POST aquí para que el
+ * push se firme en el servidor (las claves VAPID nunca salen de Vercel). El propio
+ * scraper garantiza un único aviso por día atándolo al marker
+ * `sabadell-visa-notified.<fecha>`, así que este endpoint no deduplica: simplemente
+ * envía a las suscripciones del usuario.
+ *
+ * Auth por secreto compartido (`SABADELL_VISA_WEBHOOK_SECRET`, el mismo del webhook
+ * de datos /api/sabadell-visa). No lleva body. Réplica de /api/edenred/notify-2fa.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.SABADELL_VISA_WEBHOOK_SECRET
+  if (!secret) {
+    console.error('[sabadell-visa/notify-error] SABADELL_VISA_WEBHOOK_SECRET no configurado')
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+
+  if (!safeBearerMatch(req.headers.get('authorization'), secret)) {
+    return new NextResponse(null, { status: 401 })
+  }
+
+  const db = createServiceClient()
+
+  // App personal con un único hogar: el usuario destinatario es el único registro
+  // de user_config (mismo patrón que /api/sabadell-visa).
+  const { data: userRow, error: userErr } = await db
+    .from('user_config')
+    .select('user_id')
+    .limit(1)
+    .maybeSingle()
+  if (userErr || !userRow?.user_id) {
+    console.error('[sabadell-visa/notify-error] no user_config:', userErr)
+    return NextResponse.json({ error: 'No user configured' }, { status: 500 })
+  }
+
+  try {
+    const sent = await sendPushToUser(db, userRow.user_id as string, {
+      title: 'Sabadell VISA: sesión caducada',
+      body: 'Ejecuta «pnpm scrape:sabadell-visa:login» para re-enrolar el dispositivo.',
+      url: '/cuentas',
+    })
+    return NextResponse.json({ sent })
+  } catch (err) {
+    // sendPushToUser lanza si faltan las VAPID env vars. No debe tumbar el aviso
+    // de forma silenciosa: lo logueamos y devolvemos 500 (el scraper es
+    // best-effort y no romperá su exit code por esto).
+    console.error('[sabadell-visa/notify-error] push:', err)
+    return NextResponse.json({ error: 'Push failed' }, { status: 500 })
+  }
+}

--- a/app/api/sabadell-visa/route.test.ts
+++ b/app/api/sabadell-visa/route.test.ts
@@ -28,7 +28,6 @@ function buildMockDb(opts: MockOpts = {}) {
   const insertSpy = vi.fn()
   const updateSpy = vi.fn()
   const upsertSpy = vi.fn()
-  const rpcSpy = vi.fn()
 
   const userConfigBuilder: Record<string, unknown> = {}
   Object.assign(userConfigBuilder, {
@@ -104,13 +103,10 @@ function buildMockDb(opts: MockOpts = {}) {
       if (table === 'transactions') return txBuilder
       throw new Error(`Unmocked table: ${table}`)
     }),
-    rpc: vi.fn((fn: string) => {
-      rpcSpy(fn)
-      return Promise.resolve({ error: null })
-    }),
+    rpc: vi.fn(() => Promise.resolve({ error: null })),
   }
 
-  return { db, insertSpy, updateSpy, upsertSpy, rpcSpy }
+  return { db, insertSpy, updateSpy, upsertSpy }
 }
 
 function callRoute(body: unknown, opts: { auth?: string | null; rawBody?: string } = {}) {
@@ -228,7 +224,7 @@ describe('POST /api/sabadell-visa — user_config', () => {
 
 describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
   it('inserta una cuenta de tarjeta por cada card y upsertea sus txns', async () => {
-    const { db, insertSpy, upsertSpy, rpcSpy } = buildMockDb({
+    const { db, insertSpy, upsertSpy } = buildMockDb({
       userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: null }, { data: null }],
       accountInserts: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
@@ -262,8 +258,6 @@ describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
     expect(rows[1].category).toBeNull()
     // is_read no se envía (preserva estado de lectura en re-syncs)
     expect(rows[0]).not.toHaveProperty('is_read')
-    // Refresca la matview
-    expect(rpcSpy).toHaveBeenCalledWith('refresh_monthly_summary')
   })
 })
 

--- a/app/api/sabadell-visa/route.ts
+++ b/app/api/sabadell-visa/route.ts
@@ -211,11 +211,6 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'DB error' }, { status: 500 })
     }
     upserted = txRows.length
-
-    // Refresca la matview de analítica (CONCURRENTLY) para que los gastos de
-    // tarjeta entren en las agregaciones sin esperar a la sync de Enable Banking.
-    const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-    if (refreshError) console.error('[sabadell-visa] refresh_monthly_summary:', refreshError)
   }
 
   return NextResponse.json({ cards: payload.cards.length, created_accounts: createdAccounts, upserted })

--- a/app/api/sync/enablebanking/cron/route.ts
+++ b/app/api/sync/enablebanking/cron/route.ts
@@ -150,9 +150,6 @@ export async function POST(req: Request) {
       .eq('id', account.id)
   }
 
-  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-  if (refreshError) console.error('[sync/eb/cron] refresh_monthly_summary:', refreshError)
-
   // Aviso de caducidad PSD2 (≤7 días, issue #115). Se evalúa sobre todas las
   // cuentas (las críticas siguen siendo sincronizables) y se manda una sola vez
   // por ciclo de caducidad gracias a consent_reminder_sent_for.

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -148,8 +148,5 @@ export async function POST(request: Request) {
       .eq('id', account.id)
   }
 
-  const { error: refreshError } = await db.rpc('refresh_monthly_summary')
-  if (refreshError) console.error('[sync/eb] refresh_monthly_summary:', refreshError)
-
   return NextResponse.json({ synced: totalSynced, accounts: accounts.length })
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 
 function GoogleIcon() {
@@ -28,9 +27,6 @@ function GoogleIcon() {
 }
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [loading, setLoading] = useState(false)
   const [googleLoading, setGoogleLoading] = useState(false)
   // Si el callback OAuth falla (p. ej. el usuario cancela en Google), vuelve
   // aquí con ?error=auth. Lo leemos en el render inicial y limpiamos la URL.
@@ -41,31 +37,12 @@ export default function LoginPage() {
       ? 'No se pudo iniciar sesión con Google. Inténtalo de nuevo.'
       : null
   })
-  const router = useRouter()
 
   useEffect(() => {
     if (new URLSearchParams(window.location.search).has('error')) {
       window.history.replaceState(null, '', window.location.pathname)
     }
   }, [])
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    setError(null)
-
-    const supabase = createClient()
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
-
-    setLoading(false)
-
-    if (error) {
-      setError('Email o contraseña incorrectos.')
-    } else {
-      router.push('/')
-      router.refresh()
-    }
-  }
 
   async function handleGoogle() {
     setGoogleLoading(true)
@@ -85,8 +62,6 @@ export default function LoginPage() {
     }
   }
 
-  const busy = loading || googleLoading
-
   return (
     <main className="min-h-screen flex items-center justify-center bg-neutral-950 px-4">
       <div className="w-full max-w-sm">
@@ -99,63 +74,21 @@ export default function LoginPage() {
           <button
             type="button"
             onClick={handleGoogle}
-            disabled={busy}
+            disabled={googleLoading}
             className="w-full flex items-center justify-center gap-2.5 rounded-lg bg-white hover:bg-neutral-100 disabled:bg-neutral-300 disabled:text-neutral-500 px-4 py-2.5 text-sm font-medium text-neutral-900 transition-colors"
           >
             <GoogleIcon />
             {googleLoading ? 'Conectando…' : 'Continuar con Google'}
           </button>
 
-          <div className="my-5 flex items-center gap-3">
-            <div className="h-px flex-1 bg-neutral-800" />
-            <span className="text-xs text-neutral-500">o</span>
-            <div className="h-px flex-1 bg-neutral-800" />
-          </div>
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="email" className="block text-sm text-neutral-400 mb-1.5">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="tu@email.com"
-                required
-                className="w-full rounded-lg bg-neutral-800 border border-neutral-700 px-3 py-2.5 text-sm text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="password" className="block text-sm text-neutral-400 mb-1.5">
-                Contraseña
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="••••••••"
-                required
-                className="w-full rounded-lg bg-neutral-800 border border-neutral-700 px-3 py-2.5 text-sm text-white placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
-              />
-            </div>
-
-            {error && (
-              <p className="text-sm text-red-400">{error}</p>
-            )}
-
-            <button
-              type="submit"
-              disabled={busy || !email || !password}
-              className="w-full rounded-lg bg-blue-600 hover:bg-blue-500 disabled:bg-neutral-700 disabled:text-neutral-500 px-4 py-2.5 text-sm font-medium text-white transition-colors"
-            >
-              {loading ? 'Entrando…' : 'Entrar'}
-            </button>
-          </form>
+          {error && (
+            <p className="mt-4 text-sm text-red-400">{error}</p>
+          )}
         </div>
+
+        <p className="mt-6 text-center text-xs text-neutral-500">
+          v{process.env.NEXT_PUBLIC_APP_VERSION}
+        </p>
       </div>
     </main>
   )

--- a/components/accounts/AccountCard.tsx
+++ b/components/accounts/AccountCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Check, AlertTriangle, XCircle } from 'lucide-react'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { getConsentStatus, type ConsentInfo } from '@/lib/accounts'
 import { AccountIconBadge } from './AccountIconBadge'
 import { SyncButton } from './SyncButton'
@@ -108,7 +108,7 @@ export function AccountCard({ account }: { account: Account }) {
                   : undefined,
             }}
           >
-            {account.balance !== null ? `${fmt(account.balance, 2)} €` : '—'}
+            {account.balance !== null ? <Amount value={account.balance} decimals={2} /> : '—'}
           </div>
         </div>
         <Link

--- a/components/analytics/CategoryBreakdownSection.tsx
+++ b/components/analytics/CategoryBreakdownSection.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { MoreHorizontal } from 'lucide-react'
 import type { CategoryBreakdown } from '@/types'
 import { CATEGORY_META } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import DonutChart, { type DonutItem } from './DonutChart'
 
 const MIN_PCT = 5
@@ -166,7 +166,7 @@ export default function CategoryBreakdownSection({ byCategory, periodStart }: Ca
                         {Math.round(item.pct)}%
                       </span>
                       <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--foreground)' }}>
-                        {fmt(item.amount)} €
+                        <Amount value={item.amount} />
                       </span>
                       {isNavigable && <span style={{ fontSize: 13, color: accentColor }}>›</span>}
                     </div>

--- a/components/analytics/CategoryDetailClient.tsx
+++ b/components/analytics/CategoryDetailClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAnalytics } from '@/contexts/AnalyticsContext'
 import { CATEGORY_META } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { PERIOD_LABELS } from '@/lib/analytics'
 import type { CategoryId, CategoryPeriodData, TransactionWithAccount } from '@/types'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
@@ -213,7 +213,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
           <p className="mt-1 text-xs text-muted-foreground" style={{ paddingLeft: 44 }}>
             {transactions.length} movimiento{transactions.length !== 1 ? 's' : ''}{' '}
             ·{' '}
-            <span style={{ fontWeight: 700, color }}>{fmt(periodTotal, 2)} €</span>
+            <span style={{ fontWeight: 700, color }}><Amount value={periodTotal} decimals={2} /></span>
           </p>
         )}
       </div>
@@ -234,7 +234,7 @@ export default function CategoryDetailClient({ categoryId }: Props) {
             ) : (
               <>
                 <span style={{ fontSize: 32, fontWeight: 800, color, letterSpacing: -1 }}>
-                  {fmt(periodTotal, 2)} €
+                  <Amount value={periodTotal} decimals={2} />
                 </span>
                 {selectedPeriod && (
                   <span className="ml-2 text-xs text-muted-foreground">

--- a/components/analytics/DonutChart.tsx
+++ b/components/analytics/DonutChart.tsx
@@ -93,7 +93,7 @@ export default function DonutChart({ items, selectedIdx, accentColor, onSelect }
         </text>
 
         {/* Center value */}
-        <text x={CX} y={CY + 14} textAnchor="middle" fontSize={22} fontWeight={800} fill={centerColor}>
+        <text x={CX} y={CY + 14} textAnchor="middle" fontSize={22} fontWeight={800} fill={centerColor} style={{ fontVariantNumeric: 'tabular-nums slashed-zero' }}>
           {centerValue}
         </text>
       </svg>

--- a/components/analytics/KpiCard.tsx
+++ b/components/analytics/KpiCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 
 interface KpiCardProps {
   type: 'income' | 'expense'
@@ -42,7 +42,7 @@ export default function KpiCard({
         className="mb-2 font-extrabold leading-none"
         style={{ fontSize, color: mainColor }}
       >
-        {fmt(value)} €
+        <Amount value={value} />
       </div>
 
       {/* Badge vs período anterior — neutral */}

--- a/components/analytics/SavingsCard.tsx
+++ b/components/analytics/SavingsCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Granularity } from '@/types'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { PERIOD_LABELS } from '@/lib/analytics'
 
 interface SavingsCardProps {
@@ -24,7 +24,7 @@ export default function SavingsCard({ income, savings, granularity }: SavingsCar
         Ahorro · {PERIOD_LABELS[granularity]}
       </p>
       <p style={{ fontSize: 32, fontWeight: 800, color: 'white', marginBottom: 8 }}>
-        {fmt(savings)} €
+        <Amount value={savings} />
       </p>
       <div style={{ height: 6, background: 'rgba(255,255,255,0.2)', borderRadius: 3 }}>
         <div

--- a/components/dashboard/DashboardAccountGrid.tsx
+++ b/components/dashboard/DashboardAccountGrid.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { AccountIconBadge } from '@/components/accounts/AccountIconBadge'
 import type { Account, AccountType } from '@/types'
 
@@ -30,7 +30,7 @@ function AccountCell({ account }: { account: Account }) {
         className="text-[17px] font-bold leading-tight"
         style={{ color: isNegative ? '#ef4444' : undefined }}
       >
-        {fmt(balance, 2)} €
+        <Amount value={balance} decimals={2} />
       </div>
       {account.number && (
         <div className="text-[10px] text-muted-foreground mt-0.5">{account.number}</div>

--- a/components/dashboard/DashboardBalanceCard.tsx
+++ b/components/dashboard/DashboardBalanceCard.tsx
@@ -1,4 +1,4 @@
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { Sparkline } from './Sparkline'
 
 interface DashboardBalanceCardProps {
@@ -38,7 +38,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
           Balance total
         </div>
         <div className="text-[36px] font-extrabold text-white tracking-tight leading-none mb-1">
-          {fmt(balance, 2)} €
+          <Amount value={balance} decimals={2} />
         </div>
 
         {/* Weekly delta pill */}
@@ -47,7 +47,7 @@ export function DashboardBalanceCard({ balance, weeklyDelta, dailyBalances }: Da
             className="text-[12px] font-bold px-2 py-0.5 rounded-full"
             style={{ color: pillColor, background: pillBg }}
           >
-            {deltaArrow} {deltaSign}{fmt(weeklyDelta, 2)} €
+            {deltaArrow} {deltaSign}<Amount value={weeklyDelta} decimals={2} />
           </span>
           <span className="text-[11px]" style={{ color: 'rgba(255,255,255,0.7)' }}>esta semana</span>
         </div>

--- a/components/dashboard/NetWorthChart.tsx
+++ b/components/dashboard/NetWorthChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { AreaChart, Area, XAxis, ResponsiveContainer, Tooltip } from 'recharts'
 import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 
 interface Props {
   data: { label: string; value: number }[]
@@ -19,7 +20,7 @@ export function NetWorthChart({ data, annualDelta }: Props) {
               : 'text-red-500 bg-red-500/10'
           }`}>
             {annualDelta >= 0 ? '↑' : '↓'} {annualDelta >= 0 ? '+' : ''}
-            {fmt(annualDelta)} € vs hace 12 meses
+            <Amount value={annualDelta} /> vs hace 12 meses
           </span>
         ) : (
           <span className="text-[11px] text-muted-foreground px-2.5 py-0.5">
@@ -56,7 +57,7 @@ export function NetWorthChart({ data, annualDelta }: Props) {
           />
           <Tooltip
             formatter={(v) => [typeof v === 'number' ? `${fmt(v)} €` : '—', 'Patrimonio']}
-            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid rgba(0,0,0,0.08)' }}
+            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid rgba(0,0,0,0.08)', fontVariantNumeric: 'tabular-nums' }}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/components/dashboard/UserMenuTrigger.tsx
+++ b/components/dashboard/UserMenuTrigger.tsx
@@ -87,6 +87,10 @@ export function UserMenuTrigger({ email, avatarUrl, fullName }: Props) {
             </button>
           </form>
         </div>
+
+        <p className="px-3 pt-1 text-center text-xs text-muted-foreground">
+          v{process.env.NEXT_PUBLIC_APP_VERSION}
+        </p>
       </SheetContent>
     </Sheet>
   )

--- a/components/transactions/TxDayGroupCard.tsx
+++ b/components/transactions/TxDayGroupCard.tsx
@@ -2,7 +2,7 @@
 
 import { TxRow, type TxRowPhase } from './TxRow'
 import type { SwipeSide } from '@/hooks/useHorizontalSwipe'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { formatDayLabel, type TxDayGroup } from '@/lib/transactions'
 import type { TransactionWithAccount } from '@/types'
 
@@ -34,7 +34,6 @@ export function TxDayGroupCard({
   onToggleRead,
   onTap,
 }: TxDayGroupCardProps) {
-  const netStr = (group.net >= 0 ? '+' : '') + fmt(group.net, 2) + ' €'
   const netColor = group.net >= 0 ? '#22c55e' : 'var(--foreground)'
 
   return (
@@ -44,7 +43,7 @@ export function TxDayGroupCard({
           {formatDayLabel(group.date)}
         </span>
         <span className="text-xs font-bold" style={{ color: netColor }}>
-          {netStr}
+          <Amount value={group.net} decimals={2} signed />
         </span>
       </div>
 

--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Trash2, Calendar, CreditCard } from 'lucide-react'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { CATEGORY_META, UNCATEGORIZED } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
@@ -73,8 +73,6 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
     })
   })()
 
-  const absAmount = fmt(Math.abs(renderTx.amount), 2)
-  const amountStr = (renderTx.amount > 0 ? '+' : '-') + absAmount + ' €'
   const isPositive = renderTx.amount > 0
 
   return (
@@ -102,7 +100,7 @@ export function TxModal({ tx, open, onOpenChange, onRecategorize, onDelete }: Tx
               isPositive ? 'text-[#22c55e]' : 'text-foreground'
             )}
           >
-            {amountStr}
+            <Amount value={renderTx.amount} decimals={2} signed />
           </div>
         </div>
 

--- a/components/transactions/TxRow.tsx
+++ b/components/transactions/TxRow.tsx
@@ -3,7 +3,7 @@
 import { Edit3, Check, X } from 'lucide-react'
 import { useHorizontalSwipe, type SwipeSide } from '@/hooks/useHorizontalSwipe'
 import { CATEGORY_META, UNCATEGORIZED } from '@/lib/theme'
-import { fmt } from '@/lib/formatting'
+import { Amount } from '@/components/ui/amount'
 import { cn } from '@/lib/utils'
 import type { CategoryId, TransactionWithAccount } from '@/types'
 
@@ -39,9 +39,6 @@ export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe,
     onOpen: side => onOpenSwipe(tx.id, side),
     onClose: onCloseSwipe,
   })
-
-  const absAmount = fmt(Math.abs(tx.amount), 2)
-  const amountStr = (tx.amount > 0 ? '+' : '-') + absAmount + ' €'
 
   const leaving = phase === 'leaving'
 
@@ -130,7 +127,7 @@ export function TxRow({ tx, openSide, phase = 'idle', onOpenSwipe, onCloseSwipe,
               tx.amount > 0 ? 'text-[#22c55e]' : 'text-destructive'
             )}
           >
-            {amountStr}
+            <Amount value={tx.amount} decimals={2} signed />
           </span>
         </div>
 

--- a/components/ui/amount.tsx
+++ b/components/ui/amount.tsx
@@ -1,0 +1,38 @@
+import { fmt } from '@/lib/formatting'
+import { cn } from '@/lib/utils'
+
+// Punto único de verdad de la clase de cifras tabulares. Reutilizable en sitios que no
+// pueden renderizar el componente <Amount> (strings, SVG, tooltips de chart).
+export const TABULAR_NUMS = 'tabular-nums [font-variant-numeric:tabular-nums_slashed-zero]'
+
+interface AmountProps {
+  value: number
+  /** Decimales a mostrar (por defecto 0, igual que fmt). */
+  decimals?: number
+  /** Añade el sufijo ' €' (por defecto true). */
+  currency?: boolean
+  /** Fuerza el '+' explícito en valores positivos (fmt ya pone '-' en negativos). */
+  signed?: boolean
+  className?: string
+}
+
+/**
+ * Renderiza un importe monetario con cifras tabulares (alineación en columnas y ancho
+ * estable al actualizarse). Hereda tamaño/peso/color del contenedor padre vía className.
+ */
+export function Amount({
+  value,
+  decimals = 0,
+  currency = true,
+  signed = false,
+  className,
+}: AmountProps) {
+  const plus = signed && value > 0 ? '+' : ''
+  return (
+    <span className={cn(TABULAR_NUMS, className)}>
+      {plus}
+      {fmt(value, decimals)}
+      {currency ? ' €' : ''}
+    </span>
+  )
+}

--- a/lib/categories/seed-sql.ts
+++ b/lib/categories/seed-sql.ts
@@ -43,7 +43,5 @@ ON CONFLICT (id) DO UPDATE
 
 DELETE FROM categories
 WHERE id NOT IN (${ids});
-
-REFRESH MATERIALIZED VIEW transactions_monthly_summary;
 `
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,13 @@ import type { NextConfig } from "next";
 import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import withSerwistInit from "@serwist/next";
+import pkg from "./package.json" with { type: "json" };
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["*.ngrok-free.app", "*.ngrok-free.dev"],
+  // Versión fijada en build-time desde package.json (fuente única). Disponible en
+  // cliente como NEXT_PUBLIC_APP_VERSION; al hacer bump basta el siguiente build.
+  env: { NEXT_PUBLIC_APP_VERSION: pkg.version },
 };
 
 // El service worker (Serwist) solo se genera en el build de producción. En `next dev`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-app",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/scripts/scrapers/sabadell-visa/scrape.mjs
+++ b/scripts/scrapers/sabadell-visa/scrape.mjs
@@ -57,12 +57,44 @@ function writeMarker() {
     }
   }
 }
-function notifySessionExpired() {
+// Best-effort: POST al webhook para que el servidor firme un push al iPhone (#213).
+// Las claves VAPID nunca salen de Vercel; aquí sólo hacemos POST con el secreto
+// compartido. Nunca debe romper el exit del script (calco de notify2faPending de
+// Edenred). La dedup ("un aviso por día") la garantiza el marker notifyPath().
+async function notifyError() {
+  try {
+    const appUrl = process.env.APP_URL?.replace(/\/$/, '')
+    const secret = process.env.SABADELL_VISA_WEBHOOK_SECRET
+    if (!appUrl || !secret) {
+      console.error('[sabadell-scrape] falta APP_URL/SABADELL_VISA_WEBHOOK_SECRET — sin push.')
+      return
+    }
+    const res = await fetch(`${appUrl}/api/sabadell-visa/notify-error`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${secret}` },
+    })
+    if (!res.ok) {
+      console.error(`[sabadell-scrape] push respondió ${res.status}`)
+    } else {
+      console.log('[sabadell-scrape] push de sesión caducada enviado.')
+    }
+  } catch (err) {
+    console.error(`[sabadell-scrape] push falló (${err.message}).`)
+  }
+}
+
+// Aviso de sesión caducada (exit 2): notificación nativa de macOS + push al iPhone.
+// Sólo se dispara bajo cron (CRON_MODE) desde login(); throttle 1/día vía el marker
+// notifyPath(), que cubre ambos canales. Todo en try/catch: nunca debe romper el exit.
+async function notifyExpired() {
   try {
     if (existsSync(notifyPath())) return
-    execFileSync('osascript', ['-e',
-      `display notification ${JSON.stringify('Ejecuta pnpm scrape:sabadell-visa:login para re-enrolar el dispositivo.')} with title ${JSON.stringify('Sabadell VISA: sesión caducada')}`,
-    ])
+    try {
+      execFileSync('osascript', ['-e',
+        `display notification ${JSON.stringify('Ejecuta pnpm scrape:sabadell-visa:login para re-enrolar el dispositivo.')} with title ${JSON.stringify('Sabadell VISA: sesión caducada')}`,
+      ])
+    } catch {}
+    await notifyError()
     mkdirSync(LOG_DIR, { recursive: true })
     closeSync(openSync(notifyPath(), 'a'))
   } catch {}
@@ -87,7 +119,6 @@ async function dump(page, tag) {
 }
 function die(code, msg) {
   console.error(`[sabadell-scrape] ${msg}`)
-  if (code === 2 && CRON_MODE) notifySessionExpired()
   process.exit(code)
 }
 function requireEnv(name) {
@@ -126,10 +157,12 @@ async function login(page) {
 
   if (await page.locator(LOGIN_SELECTORS.otp).first().isVisible().catch(() => false)) {
     await dump(page, 'login-otp')
+    if (CRON_MODE) await notifyExpired()
     die(2, 'Sabadell pide OTP: el dispositivo no está enrolado. Ejecuta pnpm scrape:sabadell:login')
   }
   if (await page.locator(LOGIN_SELECTORS.pass).first().isVisible().catch(() => false)) {
     await dump(page, 'login-failed')
+    if (CRON_MODE) await notifyExpired()
     die(2, 'Login no completado (¿credenciales incorrectas?)')
   }
   if (DEBUG) await dump(page, 'after-login')

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/frontend-design/SKILL.md",
+      "computedHash": "4eabc66183767153e404b39d1b839b1c37f2d82d86f0a0d7e880a579d8d62336"
+    },
     "github-issues": {
       "source": "github/awesome-copilot",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "github-issues": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "skillPath": "skills/github-issues/SKILL.md",
+      "computedHash": "efa9746a60c4507ad5a7ad60e1e9a704b4eea06c1229befe3c86b3bbcaea67c9"
+    },
     "next-best-practices": {
       "source": "vercel-labs/next-skills",
       "sourceType": "github",

--- a/supabase/migrations/20260620000000_drop_transactions_monthly_summary.sql
+++ b/supabase/migrations/20260620000000_drop_transactions_monthly_summary.sql
@@ -1,0 +1,14 @@
+-- Issue #231 (seguridad + cómputo muerto): la MV transactions_monthly_summary no
+-- aplica RLS y vive en public (expuesta por PostgREST → fuga entre hogares). Además
+-- nadie la lee: la analítica usa get_period_data en vivo (app/api/analytics) y el
+-- Dashboard consulta transactions/accounts directamente. Solo se refrescaba en cada
+-- sync, pagando un REFRESH MATERIALIZED VIEW CONCURRENTLY completo sin lectores.
+--
+-- Se elimina la MV junto con su función de refresh. Los índices de la MV
+-- (idx_monthly_unique / idx_monthly_user_month y variantes household) caen
+-- automáticamente con el DROP MATERIALIZED VIEW.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+DROP MATERIALIZED VIEW IF EXISTS transactions_monthly_summary;
+DROP FUNCTION IF EXISTS refresh_monthly_summary();

--- a/supabase/migrations/20260620000001_categories_enable_rls.sql
+++ b/supabase/migrations/20260620000001_categories_enable_rls.sql
@@ -1,0 +1,21 @@
+-- Issue #232 (seguridad): la tabla categories se creó sin RLS (datos de referencia
+-- compartidos). Al estar en public queda expuesta por la Data API y el Security Advisor
+-- la marca como rls_disabled_in_public. Es destino de FK de transactions.category /
+-- category_manual: sin RLS, un authenticated con grant de escritura podría alterar el
+-- catálogo compartido de todos los hogares.
+--
+-- El cliente nunca escribe en categories: el catálogo se siembra server-side
+-- (pnpm seed:categories -> supabase/seed/categories.sql) con un rol que bypassa RLS.
+-- Habilitamos RLS con policy de solo lectura para authenticated; la siembra no se ve
+-- afectada. Revocamos además escrituras a anon/authenticated como defensa en profundidad.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+ALTER TABLE categories ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone authenticated can read categories" ON categories;
+CREATE POLICY "Anyone authenticated can read categories" ON categories
+  FOR SELECT TO authenticated USING (true);
+
+-- Defensa en profundidad: ningún rol de la Data API debe escribir el catálogo.
+REVOKE INSERT, UPDATE, DELETE ON categories FROM anon, authenticated;

--- a/supabase/migrations/20260620000002_drop_obsolete_user_id_indexes.sql
+++ b/supabase/migrations/20260620000002_drop_obsolete_user_id_indexes.sql
@@ -1,0 +1,17 @@
+-- Issue #239: tras #131 la visibilidad y las queries pasaron de user_id a household_id.
+-- Estos índices del modelo anterior no los usa ninguna query: en transactions (tabla más
+-- escrita por el sync) son amplificación de escritura y almacenamiento muertos. Se retiran
+-- solo los índices; la columna user_id se conserva como creador/auditoría (ver #131).
+--
+-- Cubiertos hoy por idx_transactions_household_date / idx_accounts_household /
+-- idx_categorization_rules_household. NO se tocan idx_household_members_user ni
+-- idx_push_subscriptions_user_id (siguen sirviendo filtros vivos por user_id).
+--
+-- Precondición: confirmar idx_scan = 0 en pg_stat_user_indexes y revisar el Performance
+-- Advisor antes de ejecutar.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+DROP INDEX IF EXISTS idx_transactions_user_date;
+DROP INDEX IF EXISTS idx_accounts_user_id;
+DROP INDEX IF EXISTS idx_categorization_rules_user;

--- a/supabase/seed/categories.sql
+++ b/supabase/seed/categories.sql
@@ -60,5 +60,3 @@ ON CONFLICT (id) DO UPDATE
 
 DELETE FROM categories
 WHERE id NOT IN ('groceries', 'restaurant', 'transport', 'fuel', 'parking', 'vehicle', 'mortgage', 'community_fees', 'electricity', 'gas', 'water', 'internet', 'home', 'clothing', 'shopping', 'electronics', 'health', 'pharmacy', 'leisure', 'sports', 'subscriptions', 'travel', 'education', 'insurance_health', 'insurance_home', 'insurance_auto', 'domestic_help', 'beauty', 'gifts', 'charity', 'memberships', 'taxes', 'loans', 'cash', 'fees', 'other', 'payroll', 'returns', 'reimbursement', 'other_income', 'investment', 'savings', 'transfer', 'loan_payment', 'card_payment');
-
-REFRESH MATERIALIZED VIEW transactions_monthly_summary;


### PR DESCRIPTION
Promoción de `develop` → `main` para el release **v0.4.0** (deploy de producción).

Salto menor desde `v0.3.0`. Destacados:
- feat(ui): cifras tabulares para todos los importes monetarios (#243)
- feat(scrapers): push al iPhone cuando falla el scraper de Sabadell VISA (#213)
- feat(auth): mostrar versión de la release y login solo con Google (#226)
- fix(security): RLS en categories (#232), eliminar MV transactions_monthly_summary (#231)
- refactor(db): retira índices user_id obsoletos tras #131 (#239)

Se mergea con **merge commit** (no squash) para preservar el historial. Tras el merge se etiquetará `v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)