### PR TITLE
fix(edenred): blur antes del click para habilitar el botón de login

### DIFF
--- a/scripts/scrapers/edenred/auth.mjs
+++ b/scripts/scrapers/edenred/auth.mjs
@@ -41,6 +41,12 @@ export async function tryAutofill(page, user, pass) {
   try {
     await username.fill(user)
     await password.fill(pass)
+    // El form de Edenred deshabilita el botón "Iniciar sesión" hasta que un campo
+    // pierde el foco (validación on-blur). fill() solo emite 'input', no 'blur',
+    // así que sin esto el botón sigue disabled y submit.click() agota el timeout
+    // de actionability → exit 2 ("Auto-relogin no completado"). Basta con perder
+    // el foco; no hace falta teclear. Arregla el auto-relogin y el login manual.
+    await password.blur()
     await submit.click()
     console.log('[edenred-auth] credenciales auto-rellenadas.')
     return true


### PR DESCRIPTION
Closes #252

## Problema

El auto-relogin desatendido del scraper de Edenred fallaba de forma sistemática con **exit 2** ("Auto-relogin no completado"), diagnosticado en un inicio como 2FA. **No era 2FA**: el flujo nunca llegaba a esa rama.

El formulario de Edenred (validación on-blur) mantiene el botón `getByTestId('login')` **deshabilitado hasta que un campo pierde el foco**. En `tryAutofill`, `locator.fill()` solo emite el evento `input` —no `blur` ni `change`—, así que el botón seguía `disabled` y `submit.click()` agotaba el timeout de actionability (`element is not enabled → retrying click action`) → `die(2)`.

Afectaba también al flujo manual `pnpm scrape:edenred:login`, que obligaba a pulsar **TAB** a mano para habilitar el botón.

## Cambio

Una línea en `scripts/scrapers/edenred/auth.mjs`: `await password.blur()` antes del `submit.click()`. Confirmado que basta con perder el foco (sin teclear). Arregla **ambos** flujos: auto-relogin headless del cron y login manual.

## Validación

- `pnpm test` → 353 ✓
- `pnpm lint` → ✓
- `pnpm build` → ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)