### PR TITLE
fix(scrapers): resuelve owner del hogar de forma determinista en webhooks

### DIFF
--- a/app/api/edenred/route.test.ts
+++ b/app/api/edenred/route.test.ts
@@ -13,7 +13,7 @@ const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000a1'
 const ACCOUNT_ID = '00000000-0000-0000-0000-000000000aaa'
 
 type MockOpts = {
-  userConfig?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
+  householdOwner?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
   accountSelect?: { data: { id: string } | null; error?: unknown }
   accountInsert?: { data: { id: string } | null; error?: unknown }
   accountUpdate?: { error?: unknown }
@@ -25,12 +25,16 @@ function buildMockDb(opts: MockOpts = {}) {
   const updateSpy = vi.fn()
   const upsertSpy = vi.fn()
 
-  const userConfigBuilder: Record<string, unknown> = {}
-  Object.assign(userConfigBuilder, {
-    select: vi.fn(() => userConfigBuilder),
-    limit: vi.fn(() => userConfigBuilder),
+  // Resuelve el owner del hogar (getDefaultHouseholdOwner): cadena
+  // select → eq → order → limit → maybeSingle sobre household_members.
+  const householdMembersBuilder: Record<string, unknown> = {}
+  Object.assign(householdMembersBuilder, {
+    select: vi.fn(() => householdMembersBuilder),
+    eq: vi.fn(() => householdMembersBuilder),
+    order: vi.fn(() => householdMembersBuilder),
+    limit: vi.fn(() => householdMembersBuilder),
     maybeSingle: vi.fn(() =>
-      Promise.resolve(opts.userConfig ?? { data: null, error: null })
+      Promise.resolve(opts.householdOwner ?? { data: null, error: null })
     ),
   })
 
@@ -82,7 +86,7 @@ function buildMockDb(opts: MockOpts = {}) {
 
   const db = {
     from: vi.fn((table: string) => {
-      if (table === 'user_config') return userConfigBuilder
+      if (table === 'household_members') return householdMembersBuilder
       if (table === 'accounts') return accountsBuilder
       if (table === 'transactions') return txBuilder
       throw new Error(`Unmocked table: ${table}`)
@@ -221,9 +225,9 @@ describe('POST /api/edenred — validación de body', () => {
   })
 })
 
-describe('POST /api/edenred — user_config', () => {
-  it('devuelve 500 "No user configured" si user_config está vacío', async () => {
-    const { db } = buildMockDb({ userConfig: { data: null, error: null } })
+describe('POST /api/edenred — household owner', () => {
+  it('devuelve 500 "No user configured" si no hay owner de hogar', async () => {
+    const { db } = buildMockDb({ householdOwner: { data: null, error: null } })
     vi.mocked(createServiceClient).mockReturnValue(
       db as unknown as ReturnType<typeof createServiceClient>
     )
@@ -237,7 +241,7 @@ describe('POST /api/edenred — user_config', () => {
 describe('POST /api/edenred — primer POST (crea cuenta)', () => {
   it('inserta la cuenta Edenred con los campos esperados y upsertea las txns', async () => {
     const { db, insertSpy, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: null, error: null },
       accountInsert: { data: { id: ACCOUNT_ID }, error: null },
     })
@@ -278,7 +282,7 @@ describe('POST /api/edenred — primer POST (crea cuenta)', () => {
 describe('POST /api/edenred — POST siguiente (actualiza cuenta)', () => {
   it('actualiza solo balance y last_synced de la cuenta existente', async () => {
     const { db, insertSpy, updateSpy, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -306,7 +310,7 @@ describe('POST /api/edenred — POST siguiente (actualiza cuenta)', () => {
 describe('POST /api/edenred — idempotencia', () => {
   it('llama a upsert con onConflict="household_id,external_id" e ignoreDuplicates=false', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -327,7 +331,7 @@ describe('POST /api/edenred — idempotencia', () => {
 describe('POST /api/edenred — mapeo de category', () => {
   it('aplica "restaurant" cuando la txn no trae category', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(
@@ -352,7 +356,7 @@ describe('POST /api/edenred — mapeo de category', () => {
 
   it('respeta la category provista por el scraper (p. ej. "payroll" en una recarga)', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelect: { data: { id: ACCOUNT_ID }, error: null },
     })
     vi.mocked(createServiceClient).mockReturnValue(

--- a/app/api/edenred/route.ts
+++ b/app/api/edenred/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getDefaultHouseholdOwner } from '@/lib/household'
 import { safeBearerMatch } from '@/lib/http/bearer'
 
 type EdenredTx = {
@@ -58,19 +59,14 @@ export async function POST(req: Request) {
   const db = createServiceClient()
 
   // El webhook no tiene sesión: se resuelve el hogar (y un user_id de
-  // creador/auditoría) leyendo el único registro de user_config. App personal
-  // con un único hogar (decisión documentada en el plan de #53, adaptada a #131).
-  const { data: userRow, error: userErr } = await db
-    .from('user_config')
-    .select('user_id, household_id')
-    .limit(1)
-    .maybeSingle()
-  if (userErr || !userRow || !userRow.household_id) {
-    console.error('[edenred] no user_config/household:', userErr)
+  // creador/auditoría) de forma determinista a partir del owner del hogar
+  // (household_members.role = 'owner', el más antiguo). Issue #196.
+  const owner = await getDefaultHouseholdOwner(db)
+  if (!owner) {
+    console.error('[edenred] no household owner')
     return NextResponse.json({ error: 'No user configured' }, { status: 500 })
   }
-  const userId = userRow.user_id as string
-  const householdId = userRow.household_id as string
+  const { householdId, userId } = owner
 
   const { data: existingAccount, error: accSelErr } = await db
     .from('accounts')

--- a/app/api/sabadell-visa/route.test.ts
+++ b/app/api/sabadell-visa/route.test.ts
@@ -16,7 +16,7 @@ const ACCOUNT_B = '00000000-0000-0000-0000-000000000bbb'
 type AccountResult = { data: { id: string } | null; error?: unknown }
 
 type MockOpts = {
-  userConfig?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
+  householdOwner?: { data: { user_id: string; household_id?: string } | null; error?: unknown }
   // Una entrada por tarjeta (el handler itera): select previo e insert posterior.
   accountSelects?: AccountResult[]
   accountInserts?: AccountResult[]
@@ -29,11 +29,15 @@ function buildMockDb(opts: MockOpts = {}) {
   const updateSpy = vi.fn()
   const upsertSpy = vi.fn()
 
-  const userConfigBuilder: Record<string, unknown> = {}
-  Object.assign(userConfigBuilder, {
-    select: vi.fn(() => userConfigBuilder),
-    limit: vi.fn(() => userConfigBuilder),
-    maybeSingle: vi.fn(() => Promise.resolve(opts.userConfig ?? { data: null, error: null })),
+  // Resuelve el owner del hogar (getDefaultHouseholdOwner): cadena
+  // select → eq → order → limit → maybeSingle sobre household_members.
+  const householdMembersBuilder: Record<string, unknown> = {}
+  Object.assign(householdMembersBuilder, {
+    select: vi.fn(() => householdMembersBuilder),
+    eq: vi.fn(() => householdMembersBuilder),
+    order: vi.fn(() => householdMembersBuilder),
+    limit: vi.fn(() => householdMembersBuilder),
+    maybeSingle: vi.fn(() => Promise.resolve(opts.householdOwner ?? { data: null, error: null })),
   })
 
   const rulesBuilder: Record<string, unknown> = {}
@@ -91,7 +95,7 @@ function buildMockDb(opts: MockOpts = {}) {
   let currentAccounts: ReturnType<typeof makeAccountsBuilder> | null = null
   const db = {
     from: vi.fn((table: string) => {
-      if (table === 'user_config') return userConfigBuilder
+      if (table === 'household_members') return householdMembersBuilder
       if (table === 'categorization_rules') return rulesBuilder
       if (table === 'accounts') {
         if (!currentAccounts || currentAccounts._afterInsert || currentAccounts._afterUpdate) {
@@ -212,9 +216,9 @@ describe('POST /api/sabadell-visa — validación de body', () => {
   })
 })
 
-describe('POST /api/sabadell-visa — user_config', () => {
-  it('devuelve 500 si user_config está vacío', async () => {
-    const { db } = buildMockDb({ userConfig: { data: null, error: null } })
+describe('POST /api/sabadell-visa — household owner', () => {
+  it('devuelve 500 si no hay owner de hogar', async () => {
+    const { db } = buildMockDb({ householdOwner: { data: null, error: null } })
     vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
     const res = await callRoute(validPayload)
     expect(res.status).toBe(500)
@@ -225,7 +229,7 @@ describe('POST /api/sabadell-visa — user_config', () => {
 describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
   it('inserta una cuenta de tarjeta por cada card y upsertea sus txns', async () => {
     const { db, insertSpy, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: null }, { data: null }],
       accountInserts: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
     })
@@ -264,7 +268,7 @@ describe('POST /api/sabadell-visa — primer POST (crea cuentas)', () => {
 describe('POST /api/sabadell-visa — POST siguiente (actualiza cuentas)', () => {
   it('actualiza balance/last_synced/name de cada cuenta existente sin insertar', async () => {
     const { db, insertSpy, updateSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
     })
     vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)
@@ -292,7 +296,7 @@ describe('POST /api/sabadell-visa — POST siguiente (actualiza cuentas)', () =>
 describe('POST /api/sabadell-visa — nombre de tarjeta desconocida', () => {
   it('conserva el nombre del webhook si el card_id no está mapeado', async () => {
     const { db, insertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: null }],
       accountInserts: [{ data: { id: ACCOUNT_A } }],
     })
@@ -321,7 +325,7 @@ describe('POST /api/sabadell-visa — nombre de tarjeta desconocida', () => {
 describe('POST /api/sabadell-visa — idempotencia', () => {
   it('upsert con onConflict="household_id,external_id" e ignoreDuplicates=false', async () => {
     const { db, upsertSpy } = buildMockDb({
-      userConfig: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
+      householdOwner: { data: { user_id: USER_ID, household_id: HOUSEHOLD_ID }, error: null },
       accountSelects: [{ data: { id: ACCOUNT_A } }, { data: { id: ACCOUNT_B } }],
     })
     vi.mocked(createServiceClient).mockReturnValue(db as unknown as ReturnType<typeof createServiceClient>)

--- a/app/api/sabadell-visa/route.ts
+++ b/app/api/sabadell-visa/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getDefaultHouseholdOwner } from '@/lib/household'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 import { safeBearerMatch } from '@/lib/http/bearer'
 
@@ -91,19 +92,15 @@ export async function POST(req: Request) {
   const db = createServiceClient()
 
   // El webhook no tiene sesión: se resuelve el hogar (y un user_id de
-  // creador/auditoría) leyendo el único registro de user_config. App personal
-  // con un único hogar (mismo patrón que /api/edenred).
-  const { data: userRow, error: userErr } = await db
-    .from('user_config')
-    .select('user_id, household_id')
-    .limit(1)
-    .maybeSingle()
-  if (userErr || !userRow || !userRow.household_id) {
-    console.error('[sabadell-visa] no user_config/household:', userErr)
+  // creador/auditoría) de forma determinista a partir del owner del hogar
+  // (household_members.role = 'owner', el más antiguo). Mismo patrón que
+  // /api/edenred. Issue #196.
+  const owner = await getDefaultHouseholdOwner(db)
+  if (!owner) {
+    console.error('[sabadell-visa] no household owner')
     return NextResponse.json({ error: 'No user configured' }, { status: 500 })
   }
-  const userId = userRow.user_id as string
-  const householdId = userRow.household_id as string
+  const { householdId, userId } = owner
 
   // Reglas de categorización del hogar (mismo criterio que la sync de Enable
   // Banking): las tarjetas de crédito son compras en comercios variados, así que

--- a/lib/household.ts
+++ b/lib/household.ts
@@ -25,3 +25,24 @@ export async function getHouseholdId(
   if (error || !data) return null
   return data.household_id as string
 }
+
+/**
+ * Resuelve el hogar y el usuario creador para procesos sin sesión (webhooks
+ * de scrapers). Determinista: el owner más antiguo (`role = 'owner'`) frente a
+ * la fila arbitraria que devolvía `user_config.limit(1)` (issue #196).
+ * Requiere un cliente service-role (sin RLS). Devuelve `null` si no hay owner.
+ */
+export async function getDefaultHouseholdOwner(
+  supabase: SupabaseClient
+): Promise<{ householdId: string; userId: string } | null> {
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id, user_id')
+    .eq('role', 'owner')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return { householdId: data.household_id as string, userId: data.user_id as string }
+}


### PR DESCRIPTION
## Contexto

Los webhooks sin sesión de los scrapers (`/api/edenred` y `/api/sabadell-visa`) resolvían el `household_id` (dónde escribir) y el `user_id` creador/auditoría leyendo el único registro de `user_config` con `.limit(1)` sin `ORDER BY`. Tras el modelo de hogar de #131, un hogar con dos miembros tiene **dos filas** en `user_config` (ambas apuntan al mismo hogar, así que los datos siguen yendo al sitio correcto), pero el `user_id` registrado como creador pasaba a ser **no determinista**. Además, los campos de agregación de `user_config` quedaron vestigiales tras #131.

## Cambios

- **`lib/household.ts`**: nuevo helper `getDefaultHouseholdOwner(supabase)` que resuelve hogar + creador de forma determinista a partir del owner más antiguo (`household_members.role = 'owner'`), con cliente service-role.
- **`app/api/edenred/route.ts`** y **`app/api/sabadell-visa/route.ts`**: sustituyen el bloque `user_config` por una llamada al helper. Contrato del endpoint sin cambios (500 `"No user configured"` si no hay owner).
- **Tests**: migrados a mockear `household_members` (cadena `select → eq → order → limit → maybeSingle`) en lugar de `user_config`.

## Notas

- No urgente / sin cambio de datos: hoy ambas filas de `user_config` apuntan al mismo hogar, así que esto solo corrige la trazabilidad del `user_id` creador.
- El backfill de #131 garantiza ≥1 miembro con `role = 'owner'` por hogar.

## Validación

- `pnpm test` ✅ (358 tests)
- `pnpm lint` ✅
- `pnpm build` ✅

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)