### PR TITLE
fix(error-log): endurece el endpoint público contra abuso (#233)

### DIFF
--- a/app/api/error-log/route.test.ts
+++ b/app/api/error-log/route.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createClient } from '@/lib/supabase/server'
+import { logError } from '@/lib/error-log'
+import { __resetRateLimit } from '@/lib/http/rate-limit'
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }))
+vi.mock('@/lib/household', () => ({ getHouseholdId: vi.fn() }))
+vi.mock('@/lib/error-log', () => ({ logError: vi.fn() }))
+
+const { POST } = await import('./route')
+
+type CallOpts = { headers?: Record<string, string>; rawBody?: string }
+
+function callRoute(body: unknown, opts: CallOpts = {}) {
+  return POST(
+    new Request('http://test/api/error-log', {
+      method: 'POST',
+      headers: opts.headers ?? {},
+      body: opts.rawBody ?? JSON.stringify(body),
+      // @ts-expect-error NextRequest extiende Request; el handler sólo usa
+      // headers/text, así que un Request plano es suficiente.
+    })
+  )
+}
+
+beforeEach(() => {
+  __resetRateLimit()
+  vi.mocked(createClient).mockResolvedValue({
+    auth: { getUser: async () => ({ data: { user: null } }) },
+  } as unknown as Awaited<ReturnType<typeof createClient>>)
+  vi.mocked(logError).mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/error-log — rate-limit', () => {
+  it('devuelve 429 con Retry-After al superar el límite por IP', async () => {
+    const headers = { 'x-real-ip': '203.0.113.7' }
+    // El límite por defecto es 20/min: las 20 primeras pasan, la 21ª se bloquea.
+    for (let i = 0; i < 20; i++) {
+      const res = await callRoute({ message: 'boom' }, { headers })
+      expect(res.status).toBe(200)
+    }
+    const blocked = await callRoute({ message: 'boom' }, { headers })
+    expect(blocked.status).toBe(429)
+    expect(blocked.headers.get('Retry-After')).toBeTruthy()
+    expect(await blocked.json()).toEqual({ error: 'Too many requests' })
+  })
+})
+
+describe('POST /api/error-log — límite de body', () => {
+  it('devuelve 413 si content-length supera el máximo', async () => {
+    const res = await callRoute(
+      { message: 'boom' },
+      { headers: { 'content-length': '999999' } }
+    )
+    expect(res.status).toBe(413)
+    expect(await res.json()).toEqual({ error: 'Payload too large' })
+  })
+
+  it('devuelve 413 si el body real supera el máximo (content-length mentido)', async () => {
+    const huge = JSON.stringify({ message: 'x'.repeat(40_000) })
+    const res = await callRoute(null, {
+      rawBody: huge,
+      headers: { 'content-length': '10' },
+    })
+    expect(res.status).toBe(413)
+    expect(await res.json()).toEqual({ error: 'Payload too large' })
+  })
+})
+
+describe('POST /api/error-log — validación', () => {
+  it('devuelve 400 con JSON inválido', async () => {
+    const res = await callRoute(null, { rawBody: 'not-json{' })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid JSON' })
+  })
+
+  it('devuelve 400 si falta message', async () => {
+    const res = await callRoute({ stack: 'at foo' })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing message' })
+  })
+})
+
+describe('POST /api/error-log — happy path', () => {
+  it('registra el error y devuelve 200 sin sesión', async () => {
+    const res = await callRoute({
+      message: 'boom',
+      stack: 'at foo',
+      route: '/x',
+      context: { digest: 'abc' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(logError).toHaveBeenCalledTimes(1)
+    expect(logError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'client',
+        message: 'boom',
+        stack: 'at foo',
+        route: '/x',
+        context: { digest: 'abc' },
+        userId: null,
+        householdId: null,
+      })
+    )
+  })
+})

--- a/app/api/error-log/route.ts
+++ b/app/api/error-log/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
 import { logError } from '@/lib/error-log'
+import { rateLimit, clientIp } from '@/lib/http/rate-limit'
 
 /**
  * Endpoint de ingesta de errores de cliente (issue #200). Lo invocan los error
@@ -10,11 +11,39 @@ import { logError } from '@/lib/error-log'
  * Es deliberadamente tolerante a la ausencia de sesión: un error puede ocurrir en
  * una pantalla sin usuario autenticado y aun así queremos registrarlo. Si hay
  * sesión, se adjuntan `user_id` y `household_id` como contexto.
+ *
+ * Al ser una escritura PÚBLICA con service role (se salta RLS, `proxy.ts` lo deja
+ * pasar sin sesión), está endurecido contra abuso (issue #233): rate-limit por IP,
+ * límite de tamaño de body y cap de `context` (este último en `lib/error-log.ts`).
  */
+
+// Cubre message (2K) + stack (8K) + context (8K) + overhead; rechaza payloads
+// claramente abusivos antes de parsearlos.
+const MAX_BODY_BYTES = 32_000
+
 export async function POST(request: NextRequest) {
+  const { ok, retryAfter } = rateLimit(`error-log:${clientIp(request)}`)
+  if (!ok) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(retryAfter) } }
+    )
+  }
+
+  // El header puede faltar o falsearse, así que se valida también el tamaño real.
+  const contentLength = Number(request.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+  }
+
+  const raw = await request.text()
+  if (Buffer.byteLength(raw, 'utf8') > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+  }
+
   let body: unknown
   try {
-    body = await request.json()
+    body = JSON.parse(raw)
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
   }

--- a/lib/error-log.test.ts
+++ b/lib/error-log.test.ts
@@ -67,6 +67,35 @@ describe('logError', () => {
     expect(arg.stack.length).toBe(8_000)
   })
 
+  it('deja pasar un context pequeño intacto', async () => {
+    const context = { op: 'insert', digest: 'abc123' }
+    await logError({ source: 'client', message: 'boom', context })
+
+    expect(insert.mock.calls[0][0].context).toEqual(context)
+  })
+
+  it('sustituye un context demasiado grande por un marcador con el tamaño', async () => {
+    const context = { blob: 'x'.repeat(20_000) }
+    await logError({ source: 'client', message: 'boom', context })
+
+    const arg = insert.mock.calls[0][0]
+    expect(arg.context._truncated).toBe(true)
+    expect(typeof arg.context._bytes).toBe('number')
+    expect(arg.context._bytes).toBeGreaterThan(8_000)
+    expect(arg.context.blob).toBeUndefined()
+  })
+
+  it('marca como _unserializable un context con referencias circulares sin lanzar', async () => {
+    const context: Record<string, unknown> = {}
+    context.self = context
+
+    await expect(
+      logError({ source: 'client', message: 'boom', context })
+    ).resolves.toBeUndefined()
+
+    expect(insert.mock.calls[0][0].context).toEqual({ _unserializable: true })
+  })
+
   it('nunca lanza aunque el insert rechace', async () => {
     insert.mockRejectedValue(new Error('db down'))
     await expect(

--- a/lib/error-log.ts
+++ b/lib/error-log.ts
@@ -25,9 +25,30 @@ export type LogErrorParams = {
 // Límites defensivos: evitar que un stack o un context enormes inflen la tabla.
 const MAX_STACK = 8_000
 const MAX_MESSAGE = 2_000
+// `context` es JSONB arbitrario (puede venir de un endpoint público, issue #233):
+// se serializa y, si pasa del cap, se sustituye por un marcador en vez de
+// truncarlo (truncar JSON deja un objeto inválido).
+const MAX_CONTEXT_BYTES = 8_000
 
 function truncate(value: string, max: number): string {
   return value.length > max ? value.slice(0, max) : value
+}
+
+function capContext(
+  context: Record<string, unknown> | null | undefined
+): Record<string, unknown> | null {
+  if (!context) return null
+  try {
+    const json = JSON.stringify(context)
+    const bytes = Buffer.byteLength(json, 'utf8')
+    if (bytes > MAX_CONTEXT_BYTES) {
+      return { _truncated: true, _bytes: bytes }
+    }
+    return context
+  } catch {
+    // p. ej. referencias circulares: no perdemos la señal de que había context.
+    return { _unserializable: true }
+  }
 }
 
 export async function logError(params: LogErrorParams): Promise<void> {
@@ -38,7 +59,7 @@ export async function logError(params: LogErrorParams): Promise<void> {
       message: truncate(params.message, MAX_MESSAGE),
       stack: params.stack ? truncate(params.stack, MAX_STACK) : null,
       route: params.route ?? null,
-      context: params.context ?? null,
+      context: capContext(params.context),
       user_id: params.userId ?? null,
       household_id: params.householdId ?? null,
     })

--- a/lib/http/rate-limit.test.ts
+++ b/lib/http/rate-limit.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { rateLimit, clientIp, __resetRateLimit } from './rate-limit'
+
+beforeEach(() => {
+  __resetRateLimit()
+})
+
+describe('rateLimit', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('permite hasta el límite y bloquea la siguiente petición', () => {
+    for (let i = 0; i < 3; i++) {
+      expect(rateLimit('k', { limit: 3, windowMs: 1_000 }).ok).toBe(true)
+    }
+    const blocked = rateLimit('k', { limit: 3, windowMs: 1_000 })
+    expect(blocked.ok).toBe(false)
+    expect(blocked.retryAfter).toBeGreaterThan(0)
+  })
+
+  it('cuenta por clave de forma independiente', () => {
+    expect(rateLimit('a', { limit: 1, windowMs: 1_000 }).ok).toBe(true)
+    expect(rateLimit('a', { limit: 1, windowMs: 1_000 }).ok).toBe(false)
+    // Otra clave arranca con su propio cubo.
+    expect(rateLimit('b', { limit: 1, windowMs: 1_000 }).ok).toBe(true)
+  })
+
+  it('vuelve a permitir cuando pasa la ventana', () => {
+    vi.useFakeTimers()
+    expect(rateLimit('k', { limit: 1, windowMs: 1_000 }).ok).toBe(true)
+    expect(rateLimit('k', { limit: 1, windowMs: 1_000 }).ok).toBe(false)
+
+    vi.advanceTimersByTime(1_001)
+    expect(rateLimit('k', { limit: 1, windowMs: 1_000 }).ok).toBe(true)
+  })
+})
+
+describe('clientIp', () => {
+  const req = (headers: Record<string, string>) =>
+    new Request('http://test/', { headers })
+
+  it('usa x-real-ip cuando está presente', () => {
+    expect(clientIp(req({ 'x-real-ip': '1.2.3.4' }))).toBe('1.2.3.4')
+  })
+
+  it('cae al primer valor de x-forwarded-for', () => {
+    expect(
+      clientIp(req({ 'x-forwarded-for': '5.6.7.8, 9.9.9.9' }))
+    ).toBe('5.6.7.8')
+  })
+
+  it('devuelve "unknown" sin cabeceras de IP', () => {
+    expect(clientIp(req({}))).toBe('unknown')
+  })
+})

--- a/lib/http/rate-limit.ts
+++ b/lib/http/rate-limit.ts
@@ -1,0 +1,88 @@
+/**
+ * Rate-limit en memoria por ventana fija. Usado por rutas públicas que escriben
+ * con service role y no tienen sesión que las proteja (p. ej. `/api/error-log`,
+ * issue #233).
+ *
+ * Es defensa best-effort consciente: en Vercel serverless el estado vive en cada
+ * instancia y se resetea en cold start, así que NO es un límite distribuido —
+ * basta para mitigar ráfagas de spam en una app personal sin añadir Redis/Upstash.
+ */
+
+type Bucket = { count: number; resetAt: number }
+
+const DEFAULT_LIMIT = 20
+const DEFAULT_WINDOW_MS = 60_000
+
+// Cota dura del número de claves vivas para que el Map no crezca sin límite ante
+// un atacante que rote IPs. Al alcanzarla se purga lo expirado y, si aún así está
+// lleno, se descarta la entrada más antigua.
+const MAX_KEYS = 10_000
+
+const buckets = new Map<string, Bucket>()
+
+export type RateLimitResult = { ok: boolean; retryAfter: number }
+
+export function rateLimit(
+  key: string,
+  opts: { limit?: number; windowMs?: number } = {}
+): RateLimitResult {
+  const limit = opts.limit ?? DEFAULT_LIMIT
+  const windowMs = opts.windowMs ?? DEFAULT_WINDOW_MS
+  const now = Date.now()
+
+  pruneExpired(now)
+
+  let bucket = buckets.get(key)
+  if (!bucket || bucket.resetAt <= now) {
+    if (!buckets.has(key) && buckets.size >= MAX_KEYS) evictOldest()
+    bucket = { count: 0, resetAt: now + windowMs }
+    buckets.set(key, bucket)
+  }
+
+  bucket.count++
+  if (bucket.count > limit) {
+    return { ok: false, retryAfter: Math.ceil((bucket.resetAt - now) / 1000) }
+  }
+  return { ok: true, retryAfter: 0 }
+}
+
+function pruneExpired(now: number): void {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key)
+  }
+}
+
+function evictOldest(): void {
+  let oldestKey: string | null = null
+  let oldestReset = Infinity
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt < oldestReset) {
+      oldestReset = bucket.resetAt
+      oldestKey = key
+    }
+  }
+  if (oldestKey !== null) buckets.delete(oldestKey)
+}
+
+/** Sólo para tests: vacía el estado entre casos. */
+export function __resetRateLimit(): void {
+  buckets.clear()
+}
+
+/**
+ * Resuelve la IP del cliente desde las cabeceras de proxy. Vercel setea
+ * `x-real-ip`; como fallback se toma el primer valor de `x-forwarded-for`.
+ * Devuelve `'unknown'` si no hay ninguna (las peticiones sin IP comparten cubo).
+ */
+export function clientIp(request: Request): string {
+  const realIp = request.headers.get('x-real-ip')
+  if (realIp) return realIp.trim()
+
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim()
+    if (first) return first
+  }
+
+  return 'unknown'
+}


### PR DESCRIPTION
Cierra #233.

`POST /api/error-log` (#200) es **deliberadamente público** (`proxy.ts` lo deja pasar sin sesión) y escribe en `error_log` con **service role**, que se salta RLS. Era, por tanto, una escritura pública sin protección de abuso: `context` (JSONB) sin límite, sin cap de body y sin rate-limit.

## Cambios

- **Cap de `context`** (`lib/error-log.ts`): se serializa y, si supera **8 KB**, se sustituye por un marcador `{ _truncated: true, _bytes }` en vez de truncar JSON (que lo dejaría inválido). Referencias circulares → `{ _unserializable: true }`. `logError` sigue sin lanzar nunca.
- **Límite de body** (`app/api/error-log/route.ts`): **32 KB** máximo (cubre message 2K + stack 8K + context 8K + overhead). Se valida `content-length` y, como puede faltar/falsearse, también el tamaño real del cuerpo → **413**.
- **Rate-limit in-memory por IP** (`lib/http/rate-limit.ts`, nuevo): ventana fija **20/min**, helper `clientIp` (`x-real-ip` → `x-forwarded-for`). Excederlo → **429** con `Retry-After`. Best-effort consciente: en Vercel serverless el estado es por instancia (no distribuido); decisión tomada para no introducir Redis/Upstash en una app personal.

Orden en el handler: rate-limit → 413 → parse → validación → log.

## Criterios de aceptación

- [x] `context` no puede superar un tamaño máximo definido (8 KB).
- [x] El endpoint rechaza bodies excesivamente grandes (413).
- [x] Existe rate-limiting por IP para mitigar el spam (429).

## Fuera de alcance

- No se añade auth al endpoint (debe seguir siendo público por diseño, #200).
- No se introduce rate-limit distribuido (Redis/Upstash).

## Verificación

- `pnpm test` → 373 ✓ (nueva cobertura: `lib/error-log.test.ts`, `lib/http/rate-limit.test.ts`, `app/api/error-log/route.test.ts`).
- `pnpm lint` y `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)