### PR TITLE
fix(rls): restringe escrituras de household_members al owner (#234)

### DIFF
--- a/supabase/migrations/20260630000000_household_members_owner_rls.sql
+++ b/supabase/migrations/20260630000000_household_members_owner_rls.sql
@@ -1,0 +1,53 @@
+-- Issue #234 (seguridad): endurecer la RLS de household_members con control de rol.
+--
+-- La policy original era FOR ALL con USING/WITH CHECK (household_id IN
+-- current_household_ids()), sin distinguir `role`. Cualquier miembro del hogar
+-- podía insertar membresías arbitrarias (añadir terceros), expulsar a otros
+-- miembros (incluido el owner) o auto-promoverse. Inofensivo en Fase 1 (un único
+-- usuario, que ya es owner por el backfill de 20260603000001), pero es una vía de
+-- escalada que debe cerrarse antes de habilitar multiusuario (#131/#132).
+--
+-- Separamos las policies por operación: lectura para cualquier miembro del hogar
+-- (comportamiento actual); escritura (INSERT/UPDATE/DELETE) restringida al owner.
+-- El modelo de invitaciones / asignación de owner a nuevos hogares es parte de
+-- #131/#132.
+--
+-- Ejecutar en Supabase SQL Editor como un único bloque.
+
+-- ============================================================
+-- HELPER: current_owner_household_ids()
+-- ============================================================
+-- Hogares en los que el usuario autenticado es owner. Análogo a
+-- current_household_ids(): SECURITY DEFINER para que las policies de escritura de
+-- household_members puedan comprobar el rol sin disparar la RLS de la propia tabla
+-- (evita recursión). search_path fijado por seguridad.
+CREATE OR REPLACE FUNCTION current_owner_household_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT household_id FROM household_members
+  WHERE user_id = auth.uid() AND role = 'owner';
+$$;
+
+-- ============================================================
+-- POLICIES de household_members por operación
+-- ============================================================
+DROP POLICY IF EXISTS "Members access household membership" ON household_members;
+
+-- Lectura: cualquier miembro ve las membresías de sus hogares (comportamiento actual).
+CREATE POLICY "Members read household membership" ON household_members
+  FOR SELECT USING (household_id IN (SELECT current_household_ids()));
+
+-- Escritura: solo el owner del hogar gestiona las membresías.
+CREATE POLICY "Owners insert household membership" ON household_members
+  FOR INSERT WITH CHECK (household_id IN (SELECT current_owner_household_ids()));
+
+CREATE POLICY "Owners update household membership" ON household_members
+  FOR UPDATE USING     (household_id IN (SELECT current_owner_household_ids()))
+             WITH CHECK (household_id IN (SELECT current_owner_household_ids()));
+
+CREATE POLICY "Owners delete household membership" ON household_members
+  FOR DELETE USING (household_id IN (SELECT current_owner_household_ids()));


### PR DESCRIPTION
## Qué

Cierra #234. Endurece la RLS de `household_members` introduciendo control de rol.

La policy original era `FOR ALL` con `USING/WITH CHECK (household_id IN current_household_ids())`, sin distinguir `role`. Cualquier miembro del hogar podía:
- insertar membresías arbitrarias (añadir terceros),
- borrar a otros miembros (incluido el `owner`),
- auto-promoverse a `owner`.

Inofensivo en Fase 1 (un único usuario, ya `owner` por el backfill de `20260603000001`), pero una vía de escalada que debe cerrarse **antes** de habilitar multiusuario (#131/#132).

## Cómo

Nueva migración `supabase/migrations/20260630000000_household_members_owner_rls.sql`:

- **Helper `current_owner_household_ids()`** — análogo a `current_household_ids()`, `SECURITY DEFINER` + `STABLE` + `search_path` fijo, para comprobar el rol sin disparar la RLS de la propia tabla (evita recursión).
- **Policies por operación** que sustituyen a la `FOR ALL`:
  - `SELECT` para cualquier miembro del hogar (comportamiento actual).
  - `INSERT`/`UPDATE`/`DELETE` restringidos al `owner` del hogar.

Un no-owner queda con solo `SELECT`: no puede añadir terceros, expulsar ni auto-promoverse. El owner conserva la gestión completa.

Sin cambios de código de aplicación: ningún cliente *authenticated* escribe en `household_members` (solo lecturas en `lib/household.ts`; los scrapers usan service-role que bypassa RLS), así que el tightening no rompe ningún flujo de Fase 1.

## Fuera de alcance (notas para #131/#132)

- Modelo de invitaciones y asignación de `owner` a nuevos hogares.
- La policy `FOR ALL` de la tabla `households` tiene el mismo patrón; se endurecerá junto al diseño multiusuario.

## Verificación

- `pnpm test` (373 ✓), `pnpm lint` y `pnpm build`: OK.
- Tras aplicar la migración en el SQL Editor:
  - `SELECT polname, cmd FROM pg_policies WHERE tablename = 'household_members';` → 4 policies.
  - Smoke test: owner puede `INSERT`/`UPDATE`/`DELETE`; un member no-owner queda bloqueado en escritura y conserva `SELECT`.

Criterios de aceptación de #234 cubiertos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)