### PR TITLE
feat(analytics): resuelve el período inicial en servidor (#235)

### DIFF
--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,5 +1,19 @@
+import { redirect } from 'next/navigation'
 import AnalyticsClient from '@/components/analytics/AnalyticsClient'
+import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
+import { buildAnalyticsResponse, DEFAULT_GRANULARITY } from '@/lib/analytics'
 
-export default function AnalyticsPage() {
-  return <AnalyticsClient />
+export default async function AnalyticsPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const householdId = await getHouseholdId(supabase, user.id)
+  if (!householdId) redirect('/login')
+
+  // Resuelve el período inicial en servidor (sin waterfall cliente, #235)
+  const initialData = await buildAnalyticsResponse(supabase, householdId, DEFAULT_GRANULARITY, 0)
+
+  return <AnalyticsClient initialData={initialData} />
 }

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getHouseholdId } from '@/lib/household'
 import { logError } from '@/lib/error-log'
-import { getWindowPeriods, getYoYRange, toISODate } from '@/lib/analytics'
-import type { Granularity, PeriodData, AnalyticsResponse } from '@/types'
+import { buildAnalyticsResponse } from '@/lib/analytics'
+import type { Granularity } from '@/types'
 
 const VALID_GRANULARITY: Granularity[] = ['week', 'month', 'quarter', 'year']
 
@@ -28,44 +28,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const window = getWindowPeriods(granularity, offset)
-
-    const periods: PeriodData[] = await Promise.all(
-      window.map(async (range) => {
-        const yoy = getYoYRange(range)
-        const [cur, prev] = await Promise.all([
-          supabase.rpc('get_period_data', {
-            p_household_id: householdId,
-            p_start_date: toISODate(range.start),
-            p_end_date:   toISODate(range.end),
-          }),
-          supabase.rpc('get_period_data', {
-            p_household_id: householdId,
-            p_start_date: toISODate(yoy.start),
-            p_end_date:   toISODate(yoy.end),
-          }),
-        ])
-
-        const curRow  = cur.data?.[0]
-        const prevRow = prev.data?.[0]
-        // §5.7: null cuando no hay transacciones del período del año anterior
-        const hasYoy  = prevRow && (Number(prevRow.income) > 0 || Number(prevRow.expense) > 0)
-
-        return {
-          label:       range.label,
-          start:       toISODate(range.start),
-          end:         toISODate(range.end),
-          income:    Number(curRow?.income   ?? 0),
-          expense:      Number(curRow?.expense     ?? 0),
-          savings:      Number(curRow?.savings     ?? 0),
-          byCategory:  curRow?.by_category ?? [],
-          yoyIncome: hasYoy ? Number(prevRow.income) : null,
-          yoyExpense:   hasYoy ? Number(prevRow.expense)   : null,
-        }
-      })
-    )
-
-    return NextResponse.json({ granularity, periods } satisfies AnalyticsResponse)
+    const data = await buildAnalyticsResponse(supabase, householdId, granularity, offset)
+    return NextResponse.json(data)
   } catch (e) {
     console.error('[GET /api/analytics]', e)
     await logError({

--- a/components/analytics/AnalyticsClient.tsx
+++ b/components/analytics/AnalyticsClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { AnalyticsResponse, Granularity } from '@/types'
 import { useAnalytics } from '@/contexts/AnalyticsContext'
 import { PERIOD_LABELS } from '@/lib/analytics'
@@ -50,10 +50,10 @@ interface PageState {
   showYoY: boolean
 }
 
-export default function AnalyticsClient() {
+export default function AnalyticsClient({ initialData }: { initialData: AnalyticsResponse }) {
   const { granularity, setShowPicker } = useAnalytics()
   const [{ data, selectedBarIdx, showYoY }, setPageState] = useState<PageState>({
-    data: null, selectedBarIdx: null, showYoY: false,
+    data: initialData, selectedBarIdx: null, showYoY: false,
   })
 
   // Derived: loading when data hasn't arrived yet or belongs to a different granularity
@@ -64,7 +64,15 @@ export default function AnalyticsClient() {
   const toggleShowYoY = () =>
     setPageState(s => ({ ...s, showYoY: !s.showYoY }))
 
+  // El período inicial ya viene resuelto del servidor: solo se hace fetch en las
+  // transiciones posteriores de granularidad, no en el montaje (#235).
+  const isFirst = useRef(true)
   useEffect(() => {
+    if (isFirst.current && granularity === initialData.granularity) {
+      isFirst.current = false
+      return
+    }
+    isFirst.current = false
     let cancelled = false
     fetch(`/api/analytics?granularity=${granularity}&offset=0`)
       .then(r => r.json())
@@ -72,7 +80,7 @@ export default function AnalyticsClient() {
         if (!cancelled) setPageState({ data: d, selectedBarIdx: null, showYoY: false })
       })
     return () => { cancelled = true }
-  }, [granularity])
+  }, [granularity, initialData.granularity])
 
   // Derived active bar
   const activeIdx = selectedBarIdx ?? (data?.periods.length ?? 1) - 1

--- a/contexts/AnalyticsContext.tsx
+++ b/contexts/AnalyticsContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState } from 'react'
 import type { Granularity } from '@/types'
+import { DEFAULT_GRANULARITY } from '@/lib/analytics'
 
 interface AnalyticsContextValue {
   granularity: Granularity
@@ -13,7 +14,7 @@ interface AnalyticsContextValue {
 const AnalyticsContext = createContext<AnalyticsContextValue | null>(null)
 
 export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
-  const [granularity, setGranularity] = useState<Granularity>('month')
+  const [granularity, setGranularity] = useState<Granularity>(DEFAULT_GRANULARITY)
   const [showPicker, setShowPicker] = useState(false)
 
   return (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,10 +1,15 @@
-import type { Granularity } from '@/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Granularity, PeriodData, AnalyticsResponse } from '@/types'
 
 export interface PeriodRange {
   start: Date
   end: Date
   label: string
 }
+
+// Granularidad inicial por defecto: fuente única compartida por el servidor
+// (período inicial de Analítica) y el cliente (AnalyticsContext) para evitar drift.
+export const DEFAULT_GRANULARITY: Granularity = 'month'
 
 const WINDOW_SIZE: Record<Granularity, number> = {
   week: 9,
@@ -107,4 +112,54 @@ export const PERIOD_LABELS: Record<Granularity, string> = {
   month:   'Mes',
   quarter: 'Trimestre',
   year:    'Año',
+}
+
+// Agrega la ventana de períodos de Analítica vía la RPC `get_period_data`
+// (período actual + YoY). Recibe el cliente Supabase por parámetro para que el
+// servidor (período inicial) y el endpoint `/api/analytics` (transiciones)
+// compartan la misma lógica sin duplicarla y sin importar módulos server-only.
+export async function buildAnalyticsResponse(
+  supabase: SupabaseClient,
+  householdId: string,
+  granularity: Granularity,
+  offset: number,
+): Promise<AnalyticsResponse> {
+  const window = getWindowPeriods(granularity, offset)
+
+  const periods: PeriodData[] = await Promise.all(
+    window.map(async (range) => {
+      const yoy = getYoYRange(range)
+      const [cur, prev] = await Promise.all([
+        supabase.rpc('get_period_data', {
+          p_household_id: householdId,
+          p_start_date: toISODate(range.start),
+          p_end_date:   toISODate(range.end),
+        }),
+        supabase.rpc('get_period_data', {
+          p_household_id: householdId,
+          p_start_date: toISODate(yoy.start),
+          p_end_date:   toISODate(yoy.end),
+        }),
+      ])
+
+      const curRow  = cur.data?.[0]
+      const prevRow = prev.data?.[0]
+      // §5.7: null cuando no hay transacciones del período del año anterior
+      const hasYoy  = prevRow && (Number(prevRow.income) > 0 || Number(prevRow.expense) > 0)
+
+      return {
+        label:       range.label,
+        start:       toISODate(range.start),
+        end:         toISODate(range.end),
+        income:    Number(curRow?.income   ?? 0),
+        expense:      Number(curRow?.expense     ?? 0),
+        savings:      Number(curRow?.savings     ?? 0),
+        byCategory:  curRow?.by_category ?? [],
+        yoyIncome: hasYoy ? Number(prevRow.income) : null,
+        yoyExpense:   hasYoy ? Number(prevRow.expense)   : null,
+      }
+    })
+  )
+
+  return { granularity, periods }
 }


### PR DESCRIPTION
Cierra #235.

## Qué

La pantalla de Analítica era la única que cargaba sus datos en **cascada desde el cliente** (`useEffect` → `fetch('/api/analytics')` al montar). Ahora el **período inicial** (granularidad por defecto `month`, offset 0) se resuelve en el Server Component, igual que Dashboard y Transacciones.

## Cambios

- **`lib/analytics.ts`**: nuevo helper `buildAnalyticsResponse(supabase, householdId, granularity, offset)` que extrae la agregación inline del endpoint (RPC `get_period_data` ×2 por período, regla §5.7 de YoY incluida). Recibe el cliente Supabase por parámetro → compartido entre servidor y endpoint sin duplicar lógica ni contaminar el bundle cliente. Nueva constante `DEFAULT_GRANULARITY` como fuente única del defecto.
- **`app/api/analytics/route.ts`**: usa el helper; se mantiene para las transiciones (cambios de granularidad/offset).
- **`app/(app)/analytics/page.tsx`**: pasa a Server Component `async`, resuelve `initialData` y lo pasa como prop. El `loading.tsx` existente es el único estado de carga.
- **`components/analytics/AnalyticsClient.tsx`**: inicializa su estado con `initialData`; un `useRef` evita el fetch redundante en el montaje. Las transiciones siguen por `/api/analytics`.
- **`contexts/AnalyticsContext.tsx`**: usa `DEFAULT_GRANULARITY` para que el defecto del cliente coincida con el del servidor.

## Criterios de aceptación

- [x] El primer render de Analítica incluye datos (sin fetch en `useEffect` para el período inicial).
- [x] Solo se muestra un estado de carga (el de servidor).
- [x] Los cambios de granularidad/offset siguen funcionando vía `/api/analytics`.

## Validación

`pnpm test` (373 ✓), `pnpm lint` y `pnpm build` pasan. `/analytics` pasa a ruta `ƒ` (server-rendered on demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)