### PR TITLE
perf(auth): deduplica getUser()/household_id por request con cache() (#236)

### DIFF
--- a/app/(app)/accounts/page.tsx
+++ b/app/(app)/accounts/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
 import { Check, Landmark } from 'lucide-react'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 import { AccountCard } from '@/components/accounts/AccountCard'
 import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
 import { RenewedSyncTrigger } from '@/components/accounts/RenewedSyncTrigger'
@@ -27,9 +27,9 @@ async function AccountsContent({
 }: {
   searchParams: Promise<AccountsSearchParams>
 }) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) redirect('/login')
+  const supabase = await getRequestClient()
 
   const { data: accounts } = await supabase
     .from('accounts')

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,16 +1,16 @@
 import { redirect } from 'next/navigation'
 import AnalyticsClient from '@/components/analytics/AnalyticsClient'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { buildAnalyticsResponse, DEFAULT_GRANULARITY } from '@/lib/analytics'
 
 export default async function AnalyticsPage() {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) redirect('/login')
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) redirect('/login')
+
+  const supabase = await getRequestClient()
 
   // Resuelve el período inicial en servidor (sin waterfall cliente, #235)
   const initialData = await buildAnalyticsResponse(supabase, householdId, DEFAULT_GRANULARITY, 0)

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 import { AppHeader } from '@/components/app-header'
 import { BottomNav } from '@/components/bottom-nav'
 import { SyncStatusProvider } from '@/components/sync/SyncStatusProvider'
@@ -8,9 +8,9 @@ import { NotificationsProvider } from '@/components/notifications/NotificationsP
 import { getConsentBannerData } from '@/lib/accounts'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) redirect('/login')
+  const supabase = await getRequestClient()
 
   // Datos de perfil del proveedor OAuth (Google rellena estos campos en
   // user_metadata). Con login email/contraseña vienen vacíos.

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { TransactionsClient } from '@/components/transactions/TransactionsClient'
 import { TransactionsSkeleton } from '@/components/transactions/TransactionsSkeleton'
 import { buildNextCursor } from '@/lib/pagination'
@@ -27,12 +26,13 @@ async function TransactionsContent({
   searchParams: Promise<{ account?: string }>
 }) {
   const { account } = await searchParams
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) redirect('/login')
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) redirect('/login')
+
+  const supabase = await getRequestClient()
 
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - 90)

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,18 +1,18 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { data: accounts, error } = await supabase
     .from('accounts')

--- a/app/api/analytics/category/route.ts
+++ b/app/api/analytics/category/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 import { getWindowPeriods, toISODate } from '@/lib/analytics'
 import type { Granularity, CategoryId, CategoryAnalyticsResponse } from '@/types'
@@ -18,16 +17,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid params' }, { status: 400 })
   }
 
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   try {
     const allPeriods = getWindowPeriods(granularity, 0)

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 import { buildAnalyticsResponse } from '@/lib/analytics'
 import type { Granularity } from '@/types'
@@ -16,16 +15,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid params' }, { status: 400 })
   }
 
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   try {
     const data = await buildAnalyticsResponse(supabase, householdId, granularity, offset)

--- a/app/api/banking/callback/route.ts
+++ b/app/api/banking/callback/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { createSessionFromCode, decodeBankingState } from '@/lib/enablebanking'
 
 /** Normaliza un IBAN para comparar (sin espacios, mayúsculas). */
@@ -19,16 +18,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${appUrl}/accounts?error=bank_auth_cancelled`)
   }
 
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const user = await getCurrentUser()
   if (!user) {
     return NextResponse.redirect(`${appUrl}/login`)
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.redirect(`${appUrl}/login`)
   }
+
+  const supabase = await getRequestClient()
 
   let session
   try {

--- a/app/api/banking/connect/route.ts
+++ b/app/api/banking/connect/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser } from '@/lib/auth/session'
 import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
 
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/app/api/banking/renew/route.ts
+++ b/app/api/banking/renew/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
 
 /**
@@ -10,16 +9,17 @@ import { initiateAuth, encodeBankingState } from '@/lib/enablebanking'
  * detecta `accountId` en el `state` y actualiza la fila en vez de duplicarla.
  */
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { accountId } = await request.json()
   if (!accountId) {

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser } from '@/lib/auth/session'
 import { getDashboardData } from '@/lib/dashboard'
 import { logError } from '@/lib/error-log'
 
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/app/api/error-log/route.ts
+++ b/app/api/error-log/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 import { rateLimit, clientIp } from '@/lib/http/rate-limit'
 
@@ -62,11 +61,10 @@ export async function POST(request: NextRequest) {
   let userId: string | null = null
   let householdId: string | null = null
   try {
-    const supabase = await createClient()
-    const { data: { user } } = await supabase.auth.getUser()
+    const user = await getCurrentUser()
     if (user) {
       userId = user.id
-      householdId = await getHouseholdId(supabase, user.id)
+      householdId = await getCurrentHouseholdId()
     }
   } catch {
     // sin sesión / cookies no disponibles: registramos igualmente

--- a/app/api/notifications/mark-read/route.ts
+++ b/app/api/notifications/mark-read/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 
 // Marca como leídas todas las notificaciones no leídas del usuario (#177). Lo
@@ -7,11 +7,11 @@ import { logError } from '@/lib/error-log'
 // las filas propias; añadimos el filtro explícito read_at IS NULL para no reescribir
 // las ya leídas.
 export async function POST() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const supabase = await getRequestClient()
 
   const { error } = await supabase
     .from('notifications')

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 
 // Lista de notificaciones in-app del usuario para la campana del header (#177).
@@ -9,11 +9,11 @@ import { logError } from '@/lib/error-log'
 const LIST_LIMIT = 30
 
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const supabase = await getRequestClient()
 
   const { data, error } = await supabase
     .from('notifications')

--- a/app/api/notifications/unread-count/route.ts
+++ b/app/api/notifications/unread-count/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 
 // Conteo de notificaciones no leídas para el badge de la campana (#177). Calco de
@@ -8,11 +8,11 @@ import { logError } from '@/lib/error-log'
 // endpoint. RLS limita la consulta a las filas propias; `head: true` evita traer
 // filas (solo el conteo, apoyado en el índice parcial de read_at IS NULL).
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const supabase = await getRequestClient()
 
   const { count, error } = await supabase
     .from('notifications')

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 
 /**
  * Guarda la PushSubscription del navegador para el usuario autenticado
@@ -8,16 +7,17 @@ import { getHouseholdId } from '@/lib/household'
  * actualiza las claves en vez de duplicar la fila.
  */
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { endpoint, keys } = await request.json().catch(() => ({}))
   if (!endpoint || !keys?.p256dh || !keys?.auth) {

--- a/app/api/push/unsubscribe/route.ts
+++ b/app/api/push/unsubscribe/route.ts
@@ -1,16 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
 
 /**
  * Elimina la PushSubscription del usuario autenticado por `endpoint`
  * (issue #115). La RLS ya garantiza que solo borra filas propias.
  */
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  const supabase = await getRequestClient()
 
   const { endpoint } = await request.json().catch(() => ({}))
   if (!endpoint) {

--- a/app/api/sync/enablebanking/route.ts
+++ b/app/api/sync/enablebanking/route.ts
@@ -1,20 +1,18 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { getCurrentUser, getCurrentHouseholdId } from '@/lib/auth/session'
 import { createServiceClient } from '@/lib/supabase/service'
-import { getHouseholdId } from '@/lib/household'
 import { getAccountTransactions } from '@/lib/enablebanking'
 import { categorizeWithRules, type DbCategorizationRule } from '@/lib/categories'
 import { SYNC_COOLDOWN_MS } from '@/lib/sync'
 
 export async function POST(request: Request) {
-  // Auth: verify user via cookie client
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  // Auth: verify user via cookie client (memoizado por request, #236)
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 import type { CategoryId } from '@/types'
 import { VALID_CATEGORIES } from '@/lib/categories'
@@ -9,16 +8,17 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { id } = await params
   const body = await request.json()
@@ -74,16 +74,17 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { id } = await params
 

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,19 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 
 export async function POST(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const body = await request.json()
   const { amount, description, date, category_manual, account_id } = body
@@ -58,16 +58,17 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { searchParams } = request.nextUrl
   const accountsParam = searchParams.get('accounts')

--- a/app/api/transactions/unread-count/route.ts
+++ b/app/api/transactions/unread-count/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { logError } from '@/lib/error-log'
 
 // Conteo de movimientos no leídos para refrescar el badge de la tabBar sin
@@ -11,16 +10,17 @@ import { logError } from '@/lib/error-log'
 // (visibilitychange). RLS limita la consulta al hogar del usuario; `head: true`
 // evita traer filas (solo el conteo, apoyado en el índice parcial de #149).
 export async function GET() {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) {
+  const user = await getCurrentUser()
+  if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = await getRequestClient()
 
   const { count, error } = await supabase
     .from('transactions')

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,35 @@
+import { cache } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/server'
+import { getHouseholdId } from '@/lib/household'
+
+/**
+ * Resolvers de sesión memoizados por request con `cache()` de React (issue #236).
+ *
+ * `getUser()` es una llamada de red al servidor Auth de Supabase (valida el JWT) y
+ * la resolución de `household_id` consulta `household_members`. Sin memoización,
+ * ambos se repetían en cada render de servidor (layout `(app)` + page) y en helpers
+ * de datos invocados dentro del mismo request. `cache()` deduplica dentro de un
+ * único render/request y no persiste entre requests, así que es seguro para datos
+ * de sesión.
+ *
+ * El proxy (middleware) es una request aparte y no se deduplica con esto.
+ */
+
+/** Cliente Supabase de servidor, memoizado por request. */
+export const getRequestClient = cache(createClient)
+
+/** Usuario autenticado, resuelto una sola vez por request. */
+export const getCurrentUser = cache(async (): Promise<User | null> => {
+  const supabase = await getRequestClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  return user
+})
+
+/** `household_id` del usuario actual, memoizado por request. `null` si no hay sesión u hogar. */
+export const getCurrentHouseholdId = cache(async (): Promise<string | null> => {
+  const user = await getCurrentUser()
+  if (!user) return null
+  const supabase = await getRequestClient()
+  return getHouseholdId(supabase, user.id)
+})

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
-import { getHouseholdId } from '@/lib/household'
+import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import type { Account } from '@/types'
 
 export interface DashboardData {
@@ -21,12 +20,13 @@ export function calculateNetWorth(
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
-  const supabase = await createClient()
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Unauthorized')
+  const user = await getCurrentUser()
+  if (!user) throw new Error('Unauthorized')
 
-  const householdId = await getHouseholdId(supabase, user.id)
+  const householdId = await getCurrentHouseholdId()
   if (!householdId) throw new Error('Unauthorized')
+
+  const supabase = await getRequestClient()
 
   const { data: accounts, error: accError } = await supabase
     .from('accounts')


### PR DESCRIPTION
## Contexto

Cierra #236. No existía ningún `cache()` de React en el proyecto. En cada render de servidor de las páginas de `(app)`, `supabase.auth.getUser()` —una llamada de red al servidor Auth de Supabase que valida el JWT— se ejecutaba varias veces por request (layout `(app)` + page), y `getHouseholdId()` (consulta a `household_members`) tras cada uno. Además `lib/dashboard.ts` repetía `getUser()` dentro del mismo request que ya lo había hecho `/api/dashboard`.

## Cambios

- **Nuevo `lib/auth/session.ts`** con resolvers memoizados por request usando `cache()` de React:
  - `getRequestClient` — cliente Supabase de servidor compartido por request.
  - `getCurrentUser` — usuario autenticado, una sola resolución por request.
  - `getCurrentHouseholdId` — `household_id` del usuario actual, memoizado.
- **Migración a los resolvers** del layout `(app)`, las pages RSC (`transactions`, `accounts`, `analytics`), `lib/dashboard.ts` y **todas las rutas API autenticadas**. Se mantiene exactamente el flujo de auth/redirección/401 de cada fichero.
- `cache()` es por request y no persiste entre requests → seguro para datos de sesión.

## Fuera de alcance (intencionado)

- **`proxy.ts`** (middleware): es otra request, `cache()` no la cubre.
- **`app/layout.tsx`** raíz: síncrono, no llama a `getUser()`.
- **Webhooks/cron sin sesión** (`/api/edenred`, `/api/sabadell-visa`, `/api/sync/enablebanking/cron`): usan service-role / `getDefaultHouseholdOwner`.

## Verificación

- `pnpm test` → 373 tests OK
- `pnpm lint` → sin errores
- `pnpm build` → compila

## Criterios de aceptación

- [x] `getUser()` se resuelve una sola vez por render de servidor (layout + page comparten resultado).
- [x] Sin cambios de comportamiento en auth/redirecciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)