### PR TITLE
fix(supabase): protege setAll con try/catch en el cliente de servidor (#237)

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -9,10 +9,16 @@ export async function createClient() {
     {
       cookies: {
         getAll: () => cookieStore.getAll(),
-        setAll: (cookiesToSet) =>
-          cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options)
-          ),
+        setAll: (cookiesToSet) => {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // Llamado desde el render de un Server Component: el refresh de
+            // sesión lo gestiona el proxy (proxy.ts). Ignorar de forma segura.
+          }
+        },
       },
     }
   )


### PR DESCRIPTION
## Qué

Envuelve el callback `setAll` de [lib/supabase/server.ts](lib/supabase/server.ts) en un `try/catch` silencioso, siguiendo el patrón canónico de Supabase SSR.

## Por qué

`setAll` llamaba a `cookieStore.set(...)` sin protección. Si `getUser()` dispara un refresh de token **durante el render de un Server Component**, Next.js lanza *"Cookies can only be modified in a Server Action or Route Handler"*.

Hoy el proxy ([proxy.ts](proxy.ts)) refresca la sesión antes de renderizar, así que en la práctica el `setAll` en render suele ser un no-op. El `try/catch` es la red de seguridad para el caso límite (refresh en el borde del render).

## Criterios de aceptación

- [x] `setAll` no puede lanzar durante el render de un Server Component.
- [x] El refresh de sesión sigue funcionando vía proxy (sin cambios en `proxy.ts`).

## Validación

- `pnpm test` → 373 tests OK
- `pnpm lint` → limpio
- `pnpm build` → OK

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)