### PR TITLE
feat(metadata): título de pestaña por sección (#238)

### DIFF
--- a/app/(app)/accounts/page.tsx
+++ b/app/(app)/accounts/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { Check, Landmark } from 'lucide-react'
 import { getCurrentUser, getRequestClient } from '@/lib/auth/session'
@@ -7,6 +8,8 @@ import { ConnectBankButton } from '@/components/accounts/ConnectBankButton'
 import { RenewedSyncTrigger } from '@/components/accounts/RenewedSyncTrigger'
 import { AccountsSkeleton } from '@/components/accounts/AccountsSkeleton'
 import type { Account } from '@/types'
+
+export const metadata: Metadata = { title: 'Cuentas' }
 
 type AccountsSearchParams = { connected?: string; error?: string; renewed?: string }
 

--- a/app/(app)/analytics/category/[id]/page.tsx
+++ b/app/(app)/analytics/category/[id]/page.tsx
@@ -1,7 +1,18 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { CATEGORY_META } from '@/lib/theme'
 import type { CategoryId } from '@/types'
 import CategoryDetailClient from '@/components/analytics/CategoryDetailClient'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  if (!(id in CATEGORY_META)) return {} // hereda el default; la página hará notFound()
+  return { title: CATEGORY_META[id as CategoryId].label }
+}
 
 export default async function CategoryDetailPage({
   params,

--- a/app/(app)/analytics/page.tsx
+++ b/app/(app)/analytics/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import AnalyticsClient from '@/components/analytics/AnalyticsClient'
 import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { buildAnalyticsResponse, DEFAULT_GRANULARITY } from '@/lib/analytics'
+
+export const metadata: Metadata = { title: 'Análisis' }
 
 export default async function AnalyticsPage() {
   const user = await getCurrentUser()

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -1,10 +1,13 @@
 import { Suspense } from 'react'
+import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getCurrentUser, getCurrentHouseholdId, getRequestClient } from '@/lib/auth/session'
 import { TransactionsClient } from '@/components/transactions/TransactionsClient'
 import { TransactionsSkeleton } from '@/components/transactions/TransactionsSkeleton'
 import { buildNextCursor } from '@/lib/pagination'
 import type { TransactionWithAccount } from '@/types'
+
+export const metadata: Metadata = { title: 'Movimientos' }
 
 const INITIAL_PAGE_SIZE = 200
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,10 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
-  title: 'Finanzas',
+  title: {
+    default: 'Finanzas',
+    template: '%s · Finanzas',
+  },
   description: 'App de gestión financiera personal',
   icons: {
     apple: '/icons/apple-touch-icon.png',


### PR DESCRIPTION
## Contexto

Cierra #238. Solo el root layout exportaba `metadata` (`title: 'Finanzas'`), así que todas las secciones mostraban el mismo título en la pestaña del navegador, el historial y la cuota de la PWA.

## Cambios

- **Root layout** ([app/layout.tsx](../blob/feature/per-page-metadata/app/layout.tsx)): `title` pasa a `{ default: 'Finanzas', template: '%s · Finanzas' }`. `appleWebApp.title` se mantiene en `'Finanzas'`.
- **Metadata por sección** (todas Server Components):
  - Cuentas → `'Cuentas'`
  - Movimientos → `'Movimientos'`
  - Análisis → `'Análisis'` (coincide con la etiqueta visible en la bottom-nav)
- **Ficha de categoría** (`analytics/category/[id]`): `generateMetadata` reutiliza `CATEGORY_META` para el nombre de la categoría (p. ej. "Supermercado · Finanzas"); id inválido devuelve `{}` y la página sigue haciendo `notFound()`.
- La **home** no define título → hereda el `default` "Finanzas".

## Resultado en pestaña

| Ruta | Título |
|---|---|
| `/` | Finanzas |
| `/accounts` | Cuentas · Finanzas |
| `/transactions` | Movimientos · Finanzas |
| `/analytics` | Análisis · Finanzas |
| `/analytics/category/groceries` | Supermercado · Finanzas |

## Validación

- `pnpm test` → 373 passed
- `pnpm lint` → limpio
- `pnpm build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)